### PR TITLE
Fix branch component order.

### DIFF
--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -847,14 +847,22 @@ HorizontalBranchGroupItem::HorizontalBranchGroupItem( model::Splitter & splitter
         branchComponents = loop.demandComponents(node1,node2);
       }
 
-      std::vector<model::ModelObject> rBranchComponents;
-      for( std::vector<model::ModelObject>::reverse_iterator rit = branchComponents.rbegin();
-           rit < branchComponents.rend(); rit++ )
+      if( isSupplySide )
       {
-        rBranchComponents.push_back( *rit );
+        m_branchItems.push_back(new HorizontalBranchItem(branchComponents,this));
+        it2++;
       }
-      m_branchItems.push_back(new HorizontalBranchItem(rBranchComponents,this));
-      it2++;
+      else
+      {
+        std::vector<model::ModelObject> rBranchComponents;
+        for( std::vector<model::ModelObject>::reverse_iterator rit = branchComponents.rbegin();
+             rit < branchComponents.rend(); rit++ )
+        {
+          rBranchComponents.push_back( *rit );
+        }
+        m_branchItems.push_back(new HorizontalBranchItem(rBranchComponents,this));
+        it2++;
+      }
     }
   }
 


### PR DESCRIPTION
#21

@asparke2 

Supply side branches displayed their components in reverse order in the
OpenStudio application.  Demand side components were unaffected.
