### PR TITLE
Fixes #24 at least for the 0718_SmallSurfaceIntersectTest - Copy_e7.osm ...

### DIFF
--- a/openstudiocore/ruby/openstudio/sketchup_plugin/lib/dialogs/SurfaceMatchingDialog.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/lib/dialogs/SurfaceMatchingDialog.rb
@@ -233,6 +233,8 @@ This operation cannot be undone. Do you want to continue?", MB_OKCANCEL)
       # get all base surfaces
       surfaces = model_interface.surfaces.to_a
       
+      inspector_dialog_enabled = Plugin.dialog_manager.inspector_dialog.disable
+      
       begin
 
         # create a progress dialog
@@ -467,6 +469,8 @@ This operation cannot be undone. Do you want to continue?", MB_OKCANCEL)
       # switch render mode back to original
       proc = Proc.new { model_interface.materials_interface.rendering_mode = starting_rendermode }
       Plugin.add_event( proc )
+      
+      Plugin.dialog_manager.inspector_dialog.enable if inspector_dialog_enabled
       
       # resume event processing
       Plugin.start_event_processing if event_processing_stopped

--- a/openstudiocore/ruby/openstudio/sketchup_plugin/lib/interfaces/DrawingInterface.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/lib/interfaces/DrawingInterface.rb
@@ -348,8 +348,10 @@ module OpenStudio
           Plugin.log(OpenStudio::Info,"delete_model_object of type #{@model_object.class} with handle #{old_handle} and #{handles_to_remove.size - 1} non-visible children")    
 
           @model_interface.deleted_model_object_hash[old_handle] = idf_objects_to_restore
-          @model_interface.openstudio_model.removeObjects(handles_to_remove)
           
+          model_watcher_enabled = @model_interface.model_watcher.disable
+          @model_interface.openstudio_model.removeObjects(handles_to_remove)
+          @model_interface.model_watcher.enable if model_watcher_enabled
         end
       end
     end

--- a/openstudiocore/ruby/openstudio/sketchup_plugin/lib/observers/FaceObserver.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/lib/observers/FaceObserver.rb
@@ -118,24 +118,35 @@ module OpenStudio
           swapped_face = nil
 
           # Check for swapping of face entities if the erased face was a Surface.
-          # (Swapping never happens when @drawing_interface is a SubSurface.)
+          # (Swapping never seems to happen when @drawing_interface is a SubSurface.)
           if (@drawing_interface.class == Surface)
             
             #Plugin.log(OpenStudio::Trace, "#{current_method_name}, @drawing_interface = #{@drawing_interface.class} check for swapping")
             
+            # get the vertices of the surface from the model object and transformed into SketchUp coordinates
             drawing_interface_points = @drawing_interface.surface_polygon.points
 
+            # search all entities in containing_entity for surface that matches these vertices
+            # containing_entity.entities will not return entity because it has been deleted
             containing_entity.entities.each { |this_entity|
               if ((this_entity.class == Sketchup::Face))
                 face_points = this_entity.outer_polygon.reduce.points
 
                 # Check to see if all drawing_object points are a subset of the face points.
                 if (drawing_interface_points.is_subset_of?(face_points))
-                  #puts "Found swapped face = " + this_entity.to_s
-                  swapped_face = this_entity
-                  
-                  #Plugin.log(OpenStudio::Trace, "#{current_method_name}, swap detected with swapped_face = #{swapped_face}")
-                  break
+                
+                  # @drawing_interface's model object is really associated with this_entity
+                
+                  if @drawing_interface == this_entity.drawing_interface
+                    # maybe this happens when one entity is copied to another entity?  should we really be cloning drawing interface here?
+                    #Plugin.log(OpenStudio::Trace, "#{entity} and #{this_entity} both refer to #{@drawing_interface}, how did this happen?")
+                  else
+                    #puts "Found swapped face = " + this_entity.to_s
+                    swapped_face = this_entity
+                    
+                    #Plugin.log(OpenStudio::Trace, "#{current_method_name}, swap detected with swapped_face = #{swapped_face}")
+                    break
+                  end
                 end
               end
             }
@@ -147,7 +158,7 @@ module OpenStudio
             
             # 'swapped_face' is the entity that is left.  'entity' is already erased.
             
-            #Plugin.log(OpenStudio::Trace, "#{current_method_name}, remove current swapped_face.drawing_interface.entity = #{swapped_face.drawing_interface.entity}")
+            #Plugin.log(OpenStudio::Trace, "#{current_method_name}, remove current swapped_face.drawing_interface.entity = #{swapped_face.drawing_interface.entity}, swapped_face = #{swapped_face}")
 
             # Detach the drawing interface from the swapped surface.
             removed_interface = swapped_face.drawing_interface


### PR DESCRIPTION
...file

[#53721649]

Issue was when face swapping occurred sometimes the swapped face shared the same drawing interface as the deleted entity.  Larger models might be having other issues.  David can you check this fix out and especially look for wonky behavior after doing the surface matching?
