### PR TITLE
Fix OSX clang 5.0 build error

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -186,7 +186,7 @@ ENDIF( BUILD_TESTING )
 IF(UNIX)
   # all warnings
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -fno-strict-aliasing -Winvalid-pch")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -ftemplate-depth=256")
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -fno-strict-aliasing --std=c99")
   # effective c++
   #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")


### PR DESCRIPTION
I am getting a build error with XCode 5.0 with Command Line Tools installed (clang 5.0) in develop branch. This is on a clean build of develop. The error is ... http://pastebin.com/eYEmxudc or "recursive template instantiation exceeded maximum depth of 128".

Mac OSX 10.8.5
Apple LLVM version 5.0 (clang-500.2.75) (based on LLVM 3.3svn)
Homebrew Boost 1.47.0 (built with clang 5.0, Boost not built through OpenStudio build process)

After some research, it seems to be an issue related to clang 5.0. I have found a solution for the issue online and tested it on my machine. Develop now compiles properly and has no build errors. This solution seems to work on my machine, but I have not tested it on Linux and on OSX with versions of clang <5.0. The solution should not affect Windows build process at all.

@kbenne @axelstudios
