### PR TITLE
Fix DocumentFixture.Serialization failing test on OSX

### DIFF
--- a/openstudiocore/src/utilities/document/Document.cpp
+++ b/openstudiocore/src/utilities/document/Document.cpp
@@ -35,7 +35,6 @@
 #include <boost/foreach.hpp>
 #include <boost/archive/archive_exception.hpp>
 
-#ifndef __APPLE__
 BOOST_CLASS_EXPORT(openstudio::SectionHeading);
 BOOST_CLASS_EXPORT(openstudio::Section);
 BOOST_CLASS_EXPORT(openstudio::Text);
@@ -44,7 +43,6 @@ BOOST_CLASS_EXPORT(openstudio::detail::SectionHeading_Impl);
 BOOST_CLASS_EXPORT(openstudio::detail::Section_Impl);
 BOOST_CLASS_EXPORT(openstudio::detail::Text_Impl);
 BOOST_CLASS_EXPORT(openstudio::detail::Table_Impl);
-#endif
 
 namespace openstudio {
 


### PR DESCRIPTION
DocumentFixture.Serialization test in openstudio_utilities_tests fails
on OSX and results in the following message ...

[ RUN      ] DocumentFixture.Serialization
[openstudio.Document] <1> Boost archive exception while writing Document
out to boost serialization text format (.osd). Code 2. Message:
unregistered class - derived class not registered or exported
Segmentation fault: 11

This message means that the class needs to be exported aka BOOST_CLASS_EXPORT().

From the code this seems to be limited to OSX only.

@macumber
I don't know from a historical perspective why the #ifndef **APPLE** but it doesn't seem necessary now.

@axelstudios @kbenne - check and make sure this builds on your Macs and the test passes with this change.
