### PR TITLE
Fix Matrix python swig

### DIFF
--- a/openstudiocore/src/utilities/data/Matrix.i
+++ b/openstudiocore/src/utilities/data/Matrix.i
@@ -8,30 +8,28 @@
 // create an instantiation of the vector class
 %template(MatrixVector) std::vector< openstudio::Matrix >;
 
-#ifdef SWIGPYTHON
-
-%typemap(in) (unsigned i, unsigned j) {
-  long a, b;
-
-  if (PyTuple_Check($input)) {
-    if (!PyArg_ParseTuple($input,"ll", &a, &b)) {
-      PyErr_SetString(PyExc_TypeError,"tuple must have 2 elements");
-      return NULL;
-    }
-    $1 = a;
-    $2 = b;
-  } else {
-    PyErr_SetString(PyExc_TypeError,"expected a tuple.");
-    return NULL;
-  }
-}
-
-#endif
-
 namespace openstudio{
 
 class Matrix{
 public:
+
+  #ifdef SWIGPYTHON
+    %typemap(in) (unsigned i, unsigned j) {
+      long a, b;
+
+      if (PyTuple_Check($input)) {
+        if (!PyArg_ParseTuple($input,"ll", &a, &b)) {
+          PyErr_SetString(PyExc_TypeError,"tuple must have 2 elements");
+          return NULL;
+        }
+        $1 = a;
+        $2 = b;
+      } else {
+        PyErr_SetString(PyExc_TypeError,"expected a tuple.");
+        return NULL;
+      }
+    }
+  #endif
 
   // constructors
   Matrix();


### PR DESCRIPTION
This fixes an issue with "**setitem**" and "**getitem**" in python swig of Matrix. This
fixes…

for "**setitem**"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "openstudioutilitiesdata.py", line 4094, in **setitem**
    return _openstudioutilitiesdata.Matrix___setitem__(self, *args)
TypeError: Matrix___setitem__() takes exactly 4 arguments (3 given)

and for "**getitem**"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "openstudioutilitiesdata.py", line 3608, in **getitem**
    return _openstudioutilitiesdata.Matrix___getitem__(self, *args)
TypeError: Matrix___getitem__() takes exactly 3 arguments (2 given)

in the following python code (start python interpreter, copy and paste following code, and it should reproduce errors)

=====CODE======
import sys
import os

path_to_build = 'path/to/your/build/directory'
path_to_python_files = 'OpenStudioCore-prefix/src/OpenStudioCore-build/Products/python'
append_path = os.path.join(path_to_build, path_to_python_files)
sys.path.append(append_path)

from openstudioutilitiesdata import *

m = Matrix(4,4,0)
print m[0,0]  # should be 0
m[0,0] = 1
print m[0,0]  # should be 1

=====CODE======

this is due to the fact that in m[0,0] = 1 the [0,0] is a tuple (0,0) and gets passed to swig as a tuple argument. The C++ code expects (unsigned int, unsigned int, double) so this converts the tuple to the appropriate C++ input.

This code should only affect python swig and shouldn't have unexpected python behavior, at least none has shown up in my testing.

@axelstudios @lefticus @kbenne @macumber 
