### PR TITLE
Fix error in "convectioncoefficient" ScheduleTypeLimit::units()

### DIFF
--- a/openstudiocore/src/model/ScheduleTypeLimits.cpp
+++ b/openstudiocore/src/model/ScheduleTypeLimits.cpp
@@ -334,10 +334,10 @@ boost::optional<Unit> ScheduleTypeLimits::units(std::string unitType, bool retur
       }
       else if (unitType == "convectioncoefficient") {
         if (returnIP) {
-          result = createSIThermalConductance();
+          result = BTUUnit(BTUExpnt(1,-2,-1,-1));
         }
         else {
-          result = BTUUnit(BTUExpnt(1,-2,-1,-1));
+          result = createSIThermalConductance();
         }
       }
       break;


### PR DESCRIPTION
This fixes an error in ScheduleTypeLimits::units() for "convectioncoefficient". The IP and SI units appear to be switched based solely on the names of the method calls. I haven't looked too deep into this to make sure, but it definitely appears to be a bug. 

"convectioncoefficient" doesn't appear to be used (yet) in ScheduleTypeRegistrySingleton::ScheduleTypeRegistrySingleton() in ScheduleTypeRegistry.cpp so this might be why it has not be seen or fixed yet.

@macumber 
