### PR TITLE
[#58926460] Correct caching of job data during updateJob

### DIFF
--- a/openstudiocore/src/analysis/DataPoint.cpp
+++ b/openstudiocore/src/analysis/DataPoint.cpp
@@ -531,8 +531,6 @@ namespace detail {
       runManager->updateJob(*m_topLevelJob, directory());
     }
 
-    // make sure we have the right reference to the job, since runmanager copies it in.
-    m_topLevelJob = runManager->getJob(m_topLevelJob->uuid());
 
     // get file references for
     //   m_osmInputData

--- a/openstudiocore/src/runmanager/lib/Job_Impl.cpp
+++ b/openstudiocore/src/runmanager/lib/Job_Impl.cpp
@@ -1853,6 +1853,10 @@ namespace detail {
     m_tools = newtools;
     m_params = newparams;
     m_id = newUUID;
+    m_outdir = boost::none;
+    m_allTools = boost::none;
+    m_allParams = boost::none;
+    m_allInputFiles = boost::none;
     l.unlock();
 
     sendSignals(oldState, newState, oldUUID, newUUID);


### PR DESCRIPTION
Cached data, which than became primary data during serialization was the problem. I'm clearing the cache when updateJob is called.

@macumber 

Not as exciting as the last go with this. 
