### PR TITLE
Show status starting for 39 second delay after I click the "run" button ...

### DIFF
--- a/openstudiocore/src/analysisdriver/AnalysisDriver.cpp
+++ b/openstudiocore/src/analysisdriver/AnalysisDriver.cpp
@@ -124,6 +124,10 @@ namespace detail {
     
     if (m_status == AnalysisStatus::Idle){
       setStatus(AnalysisStatus::Starting);
+
+      // DLM: this allows GUIs to update before rest of function completes
+      // this could cause problems if one of these events was a stop button request...
+      Application::instance().processEvents();
     }
 
     cleanOutIncompleteJobs(analysis);

--- a/openstudiocore/src/pat_app/RunTabController.cpp
+++ b/openstudiocore/src/pat_app/RunTabController.cpp
@@ -261,12 +261,12 @@ void RunTabController::onPlayButtonClicked()
         analysisdriver::AnalysisRunOptions runOptions = standardRunOptions(*project);
         analysisdriver::CurrentAnalysis currentAnalysis = analysisDriver.run(analysis, runOptions);
 
-        // start the run
-        analysisDriver.unpauseQueue();
-
         // connect currentAnalysis to update progress on this
         bool isConnected = currentAnalysis.connect(SIGNAL(iterationProgress(int,int)), this, SLOT(onIterationProgress()), Qt::QueuedConnection);
         OS_ASSERT(isConnected);
+
+        // start the run
+        analysisDriver.unpauseQueue();
       }
 
       // update progress


### PR DESCRIPTION
...for a local run on 75 datapoint project.

[#58711150]
