### PR TITLE
Altered interface to LogSink to hide implementation of boost:regex (now using std:string)

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.cpp
@@ -56,6 +56,8 @@
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/plot/ProgressBar.hpp>
 
+#include <string>
+
 #include <QThread>
 
 using namespace openstudio::model;
@@ -69,7 +71,7 @@ namespace energyplus {
 ForwardTranslator::ForwardTranslator()
 {
   m_logSink.setLogLevel(Warn);
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.energyplus\\.ForwardTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.energyplus\\.ForwardTranslator"));
   m_logSink.setThreadId(QThread::currentThread());
 
   // temp code 

--- a/openstudiocore/src/energyplus/ReverseTranslator.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator.cpp
@@ -31,6 +31,8 @@
 #include <utilities/core/Assert.hpp>
 #include <utilities/plot/ProgressBar.hpp>
 
+#include <string>
+
 #include <QThread>
 
 using namespace openstudio::model;
@@ -44,7 +46,7 @@ namespace energyplus {
 ReverseTranslator::ReverseTranslator()
 {
   m_logSink.setLogLevel(Warn);
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.energyplus\\.ReverseTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.energyplus\\.ReverseTranslator"));
   m_logSink.setThreadId(QThread::currentThread());
 }
 
@@ -64,12 +66,12 @@ boost::optional<model::Model> ReverseTranslator::loadModel(const openstudio::pat
 
   m_logSink.setThreadId(QThread::currentThread());
 
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.IdfFile"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.IdfFile"));
 
   //load idf and convert to a workspace
   boost::optional<openstudio::IdfFile> idfFile = IdfFile::load(path, IddFileType::EnergyPlus, progressBar);
 
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.energyplus\\.ReverseTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.energyplus\\.ReverseTranslator"));
 
   // energyplus idfs may not be draft level strictness, eventually need a fixer
   if (!idfFile){
@@ -139,7 +141,7 @@ Model ReverseTranslator::translateWorkspace(const Workspace & workspace, Progres
   }
 
   // first thing to do is convert geometry system
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.energyplus\\.GeometryTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.energyplus\\.GeometryTranslator"));
 
   m_progressBar = progressBar;
   if (m_progressBar){
@@ -151,7 +153,7 @@ Model ReverseTranslator::translateWorkspace(const Workspace & workspace, Progres
   GeometryTranslator geometryTranslator(m_workspace);
   geometryTranslator.convert(CoordinateSystem::Relative, CoordinateSystem::Relative);
 
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.energyplus\\.ReverseTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.energyplus\\.ReverseTranslator"));
 
   // look for site object in workspace and translate if found
   LOG(Trace,"Translating Site:Location object.");

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateScheduleTypeLimits.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateScheduleTypeLimits.cpp
@@ -28,6 +28,8 @@
 
 #include <utilities/core/Assert.hpp>
 
+#include <boost/regex.hpp>
+
 using namespace openstudio::model;
 
 namespace openstudio {

--- a/openstudiocore/src/gbxml/ForwardTranslator.cpp
+++ b/openstudiocore/src/gbxml/ForwardTranslator.cpp
@@ -50,6 +50,8 @@
 
 #include <boost/math/constants/constants.hpp>
 
+#include <string>
+
 #include <QFile>
 #include <QDomDocument>
 #include <QDomElement>
@@ -61,7 +63,7 @@ namespace gbxml {
   ForwardTranslator::ForwardTranslator()
   {
     m_logSink.setLogLevel(Warn);
-    m_logSink.setChannelRegex(boost::regex("openstudio\\.gbxml\\.ForwardTranslator"));
+    m_logSink.setChannelRegex(std::string("openstudio\\.gbxml\\.ForwardTranslator"));
     m_logSink.setThreadId(QThread::currentThread());
   }
 

--- a/openstudiocore/src/gbxml/ReverseTranslator.cpp
+++ b/openstudiocore/src/gbxml/ReverseTranslator.cpp
@@ -65,7 +65,7 @@ namespace gbxml {
     : m_lengthMultiplier(1.0)
   {
     m_logSink.setLogLevel(Warn);
-    m_logSink.setChannelRegex(boost::regex("openstudio\\.gbxml\\.ReverseTranslator"));
+    m_logSink.setChannelRegex(std::string("openstudio\\.gbxml\\.ReverseTranslator"));
     m_logSink.setThreadId(QThread::currentThread());
   }
 

--- a/openstudiocore/src/model/Meter.hpp
+++ b/openstudiocore/src/model/Meter.hpp
@@ -23,6 +23,8 @@
 #include <model/ModelAPI.hpp>
 #include <model/ModelObject.hpp>
 
+#include <boost/regex.hpp>
+
 namespace openstudio {
 
 class EndUseType;

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -51,6 +51,8 @@
 
 #include <OpenStudio.hxx>
 
+#include <string>
+
 #include <QThread>
 
 #include <boost/foreach.hpp>
@@ -66,7 +68,7 @@ VersionTranslator::VersionTranslator()
   : m_originalVersion("0.0.0")
 {
   m_logSink.setLogLevel(Warn);
-  m_logSink.setChannelRegex(boost::regex("openstudio\\.osversion\\.VersionTranslator"));
+  m_logSink.setChannelRegex(std::string("openstudio\\.osversion\\.VersionTranslator"));
   m_logSink.setThreadId(QThread::currentThread());
 
   // Register required update methods, indexed on the file version returned by the method (the

--- a/openstudiocore/src/radiance/ForwardTranslator.cpp
+++ b/openstudiocore/src/radiance/ForwardTranslator.cpp
@@ -61,6 +61,7 @@
 #include <cstring>
 #include <cmath>
 #include <sstream>
+#include <string>
 #include <iterator>
 #include <algorithm>
 #include <fstream>
@@ -125,7 +126,7 @@ namespace radiance {
   ForwardTranslator::ForwardTranslator()
   {
     m_logSink.setLogLevel(Warn);
-    m_logSink.setChannelRegex(boost::regex("openstudio\\.radiance\\.ForwardTranslator"));
+	m_logSink.setChannelRegex(std::string("openstudio\\.radiance\\.ForwardTranslator"));
     m_logSink.setThreadId(QThread::currentThread());
   }
 

--- a/openstudiocore/src/sdd/ForwardTranslator.cpp
+++ b/openstudiocore/src/sdd/ForwardTranslator.cpp
@@ -43,6 +43,8 @@
 #include <utilities/plot/ProgressBar.hpp>
 #include <utilities/core/Assert.hpp>
 
+#include <string>
+
 #include <QFile>
 #include <QDomDocument>
 #include <QDomElement>
@@ -54,7 +56,7 @@ namespace sdd {
   ForwardTranslator::ForwardTranslator()
   {
     m_logSink.setLogLevel(Warn);
-    m_logSink.setChannelRegex(boost::regex("openstudio\\.sdd\\.ForwardTranslator"));
+	m_logSink.setChannelRegex(std::string("openstudio\\.sdd\\.ForwardTranslator"));
     m_logSink.setThreadId(QThread::currentThread());
   }
 

--- a/openstudiocore/src/sdd/ReverseTranslator.cpp
+++ b/openstudiocore/src/sdd/ReverseTranslator.cpp
@@ -72,6 +72,8 @@
 #include <utilities/units/UnitFactory.hpp>
 #include <utilities/units/Unit.hpp>
 
+#include <string>
+
 #include <QFile>
 #include <QDomDocument>
 #include <QDomElement>
@@ -95,7 +97,7 @@ namespace sdd {
       m_masterAutosize(masterAutosize)
   {
     m_logSink.setLogLevel(Warn);
-    m_logSink.setChannelRegex(boost::regex("openstudio\\.sdd\\.ReverseTranslator"));
+	m_logSink.setChannelRegex(std::string("openstudio\\.sdd\\.ReverseTranslator"));
     m_logSink.setThreadId(QThread::currentThread());
   }
 

--- a/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
@@ -25,6 +25,8 @@
 #include <utilities/core/Containers.hpp>
 #include <utilities/data/Attribute.hpp>
 
+#include <boost/regex.hpp>
+
 #include <iomanip>
 
 using openstudio::model::ModelObject;

--- a/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
@@ -25,6 +25,8 @@
 #include <utilities/core/Containers.hpp>
 #include <utilities/data/Attribute.hpp>
 
+#include <boost/regex.hpp> 
+
 #include <iomanip>
 
 using openstudio::model::ModelObject;

--- a/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
@@ -25,6 +25,8 @@
 #include <utilities/core/Containers.hpp>
 #include <utilities/data/Attribute.hpp>
 
+#include <boost/regex.hpp>
+
 #include <iomanip>
 
 using openstudio::model::ModelObject;

--- a/openstudiocore/src/utilities/core/LogSink.cpp
+++ b/openstudiocore/src/utilities/core/LogSink.cpp
@@ -30,6 +30,7 @@
 #include <boost/log/utility/init/to_file.hpp>
 #include <boost/log/utility/init/to_console.hpp>
 #include <boost/log/utility/init/common_attributes.hpp>
+#include <boost/regex.hpp>
 
 #include <QReadWriteLock>
 #include <QWriteLocker>
@@ -95,18 +96,18 @@ namespace openstudio{
       this->updateFilter(l);
     }
 
-    boost::optional<boost::regex> LogSink_Impl::channelRegex() const
+	boost::optional<std::string> LogSink_Impl::channelRegex() const
     {
       QReadLocker l(m_mutex);
 
-      return m_channelRegex;
+      return m_channelRegex->str();
     }
    
-    void LogSink_Impl::setChannelRegex(const boost::regex& channelRegex)
+    void LogSink_Impl::setChannelRegex(const std::string& channelRegex)
     {
       QWriteLocker l(m_mutex);
 
-      m_channelRegex = channelRegex;
+      m_channelRegex = boost::regex(channelRegex);
 
       this->updateFilter(l);
     }
@@ -260,12 +261,12 @@ namespace openstudio{
     m_impl->resetLogLevel();
   }
 
-  boost::optional<boost::regex> LogSink::channelRegex() const
+  boost::optional<std::string> LogSink::channelRegex() const
   {
     return m_impl->channelRegex();
   }
  
-  void LogSink::setChannelRegex(const boost::regex& channelRegex)
+  void LogSink::setChannelRegex(const std::string& channelRegex)
   {
     m_impl->setChannelRegex(channelRegex);
   }

--- a/openstudiocore/src/utilities/core/LogSink.hpp
+++ b/openstudiocore/src/utilities/core/LogSink.hpp
@@ -24,9 +24,9 @@
 
 #include <utilities/core/LogMessage.hpp>
 
-#include <boost/regex.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <string>
 #include <ostream>
 
 class QThread;
@@ -61,10 +61,10 @@ namespace openstudio{
     void resetLogLevel();
 
     /// get the regular expression to match log channels
-    boost::optional<boost::regex> channelRegex() const;
+	boost::optional<std::string> channelRegex() const;
 
     /// set the regular expression to match log channels
-    void setChannelRegex(const boost::regex& filter);
+    void setChannelRegex(const std::string& filter);
 
     /// reset the regular expression to match log channels
     void resetChannelRegex();

--- a/openstudiocore/src/utilities/core/LogSink_Impl.hpp
+++ b/openstudiocore/src/utilities/core/LogSink_Impl.hpp
@@ -25,6 +25,8 @@
 #include <utilities/core/LogMessage.hpp>
 #include <utilities/core/LogSink.hpp>
 
+#include <boost/regex.hpp>
+
 class QReadWriteLock;
 class QWriteLocker;
 class QThread;
@@ -60,11 +62,11 @@ namespace openstudio{
       /// reset the core logging level
       void resetLogLevel();
 
-      /// get the regular expression to match log channels
-      boost::optional<boost::regex> channelRegex() const;
+	  /// get the regular expression to match log channels.
+	  boost::optional<std::string> channelRegex() const;
 
       /// set the regular expression to match log channels
-      void setChannelRegex(const boost::regex& filter);
+      void setChannelRegex(const std::string& filter);
 
       /// reset the regular expression to match log channels
       void resetChannelRegex();

--- a/openstudiocore/src/utilities/idd/IddField.cpp
+++ b/openstudiocore/src/utilities/idd/IddField.cpp
@@ -40,6 +40,7 @@
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
 
 #include <algorithm>
 
@@ -178,13 +179,14 @@ namespace detail {
     m_name = name;
   }
 
-  void IddField_Impl::incrementFieldId(const boost::regex& fieldType) {
+  void IddField_Impl::incrementFieldId(const std::string& fieldType) {
     boost::regex fieldIdRegex("([AN])([0-9]+)");
     boost::smatch m;
     bool ok = boost::regex_match(m_fieldId,m,fieldIdRegex);
     OS_ASSERT(ok);
     std::string letterStr(m[1].first,m[1].second);
-    if (boost::regex_match(letterStr,fieldType)) {
+	boost::regex fieldTypeRegex = boost::regex(fieldType);
+    if (boost::regex_match(letterStr,fieldTypeRegex)) {
       std::string numberStr(m[2].first,m[2].second);
       int n = boost::lexical_cast<int>(numberStr);
       ++n;
@@ -683,7 +685,7 @@ void IddField::setName(const std::string& name)
   m_impl->setName(name);
 }
 
-void IddField::incrementFieldId(const boost::regex& fieldType) {
+void IddField::incrementFieldId(const std::string& fieldType) {
   m_impl->incrementFieldId(fieldType);
 }
 

--- a/openstudiocore/src/utilities/idd/IddField.hpp
+++ b/openstudiocore/src/utilities/idd/IddField.hpp
@@ -94,7 +94,7 @@ class UTILITIES_API IddField {
 
   /** Increments the field id number, that is, A1 becomes A2, etc. Added to support
    *  IddObject::insertHandleField(). Not for general use. */
-  void incrementFieldId(const boost::regex& fieldType = boost::regex("A"));
+  void incrementFieldId(const std::string& fieldType = std::string("A"));
 
   //@}
   /** @name Queries */

--- a/openstudiocore/src/utilities/idd/IddField_Impl.hpp
+++ b/openstudiocore/src/utilities/idd/IddField_Impl.hpp
@@ -87,7 +87,7 @@ namespace detail {
 
     /** Increments the field id number, that is, A1 becomes A2, etc. Added to support
      *  IddObject::insertHandleField(). Not for general use. */
-    void incrementFieldId(const boost::regex& fieldType = boost::regex("A"));
+	void incrementFieldId(const std::string& fieldType = std::string("A"));
 
     //@}
     /** @name Queries */

--- a/openstudiocore/src/utilities/idd/IddFile.cpp
+++ b/openstudiocore/src/utilities/idd/IddFile.cpp
@@ -32,6 +32,7 @@
 #include <boost/foreach.hpp> 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
 
 #include <sstream>
 

--- a/openstudiocore/src/utilities/idd/IddFile.hpp
+++ b/openstudiocore/src/utilities/idd/IddFile.hpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include <boost/shared_ptr.hpp>
+#include <boost/regex.hpp>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/idd/IddFileAndFactoryWrapper.hpp
+++ b/openstudiocore/src/utilities/idd/IddFileAndFactoryWrapper.hpp
@@ -24,6 +24,8 @@
 #include <utilities/idd/IddFile.hpp>
 #include <utilities/idd/IddEnums.hxx>
 
+#include <boost/regex.hpp>
+
 namespace openstudio {
 
 /** Wraps the functionality of IddFile and \link IddFactorySingleton IddFactory \endlink 


### PR DESCRIPTION
Altered interface to LogSink to hide implementation details of boost:regex. The regular expression text is now passed as a std:string and returned as a std:string.

This was a potential portability issue and was causing VS2008 intellisense to stop working.

Testing - code compiles without error on Win 7, 64 bit using VS 2008.
