### PR TITLE
Add new AirLoopHVAC::addBranchForZone overload

### DIFF
--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -721,6 +721,13 @@ namespace detail {
     return addBranchForZone(thermalZone,comp);
   }
 
+  bool AirLoopHVAC_Impl::addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal)
+  {
+    boost::optional<StraightComponent> comp = airTerminal;
+
+    return addBranchForZone(thermalZone, comp);
+  }
+
   bool AirLoopHVAC_Impl::addBranchForHVACComponent(HVACComponent airTerminal)
   {
     Model _model = this->model();
@@ -1131,6 +1138,11 @@ IddObjectType AirLoopHVAC::iddObjectType() {
 bool AirLoopHVAC::addBranchForZone(openstudio::model::ThermalZone & thermalZone)
 {
   return getImpl<detail::AirLoopHVAC_Impl>()->addBranchForZone(thermalZone);
+}
+
+bool AirLoopHVAC::addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal)
+{
+  return getImpl<detail::AirLoopHVAC_Impl>()->addBranchForZone(thermalZone, airTerminal);
 }
 
 bool AirLoopHVAC::addBranchForHVACComponent(HVACComponent airTerminal)

--- a/openstudiocore/src/model/AirLoopHVAC.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC.hpp
@@ -209,6 +209,9 @@ class MODEL_API AirLoopHVAC : public Loop
   /** Overloaded version of addBranchForZone() **/
   bool addBranchForZone(openstudio::model::ThermalZone & thermalZone);
 
+  /** Overloaded version of addBranchForZone() **/
+  bool addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal);
+
   /** Adds a new branch on the demand side of the air loop with the specified airTerminal.
    *  Returns true if the airTerminal was accepted, otherwise false.  The demand side
    *  of the air loop must be empty for this operation to succeed.

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -128,6 +128,8 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   bool addBranchForZone(openstudio::model::ThermalZone & thermalZone);
 
+  bool addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal);
+
   bool addBranchForHVACComponent(HVACComponent airTerminal);
 
   SizingSystem sizingSystem() const;


### PR DESCRIPTION
Add new AirLoopHVAC::addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal) overload.

This fixes an issue with the Ruby and Python bindings where you can not pass an Air Terminal to addBranchForZone() without first casting it to optional<StraightComponent>.

@kbenne @asparke2
All model unit tests pass and ruby test code passes.

The following code will reproduce the error before this fix.

===Ruby===
m = OpenStudio::Model::Model.new()
s = m.alwaysOnDiscreteSchedule()
coil = OpenStudio::Model::CoilHeatingWater.new(m, s)
terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(m,s,coil)
coil2 = OpenStudio::Model::CoilHeatingWater.new(m, s)
terminal2 = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(m,s,coil2)
air_loop = OpenStudio::Model::AirLoopHVAC.new(m)
thermal_zone = OpenStudio::Model::ThermalZone.new(m)
thermal_zone2 = OpenStudio::Model::ThermalZone.new(m)
# fails before fix, works with new overload

air_loop.addBranchForZone(thermal_zone, terminal)

terminal_straight_component = terminal2.to_StraightComponent()
# works before and after fix

air_loop.addBranchForZone(thermal_zone2, terminal_straight_component)

===ERROR MESSAGE===
ArgumentError: Wrong arguments for overloaded method 'AirLoopHVAC.addBranchForZone'.
Possible C/C++ prototypes are:
    bool AirLoopHVAC.addBranchForZone(openstudio::model::ThermalZone &thermalZone, boost::optional< openstudio::model::StraightComponent > optAirTerminal)
    bool AirLoopHVAC.addBranchForZone(openstudio::model::ThermalZone &thermalZone)
