### PR TITLE
Fixes build error in RefrigerationSystem

### DIFF
--- a/openstudiocore/src/model/RefrigerationSystem.hpp
+++ b/openstudiocore/src/model/RefrigerationSystem.hpp
@@ -61,7 +61,7 @@ class MODEL_API RefrigerationSystem : public ModelObject {
 
   static std::vector<std::string> suctionTemperatureControlTypeValues();
 
-  static std::vector<std::string> numberofCompressorStagesValues();
+  // static std::vector<std::string> numberofCompressorStagesValues();
 
   static std::vector<std::string> intercoolerTypeValues();
 


### PR DESCRIPTION
This seems to only manifest when built with python bindings. The other
build process must not hit this code? It should be commented out since
numberofCompressorStages is no longer in OS IDD.

@kbenne 
