### PR TITLE
Update various ZoneHVAC components

### DIFF
--- a/openstudiocore/src/model/ZoneHVACBaseboardConvectiveElectric.cpp
+++ b/openstudiocore/src/model/ZoneHVACBaseboardConvectiveElectric.cpp
@@ -228,19 +228,21 @@ namespace detail {
   
   boost::optional<ThermalZone> ZoneHVACBaseboardConvectiveElectric_Impl::thermalZone()
   {
-    boost::optional<ThermalZone> result;
     Model m = this->model();
+    ModelObject thisObject = this->getObject<ModelObject>();
     std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    BOOST_FOREACH(ThermalZone& thermalZone, thermalZones){
-      std::vector<ModelObject> equipments = thermalZone.equipment(); 
-      BOOST_FOREACH(ModelObject& equipment, equipments){
-        if (equipment.handle() == this->handle()){
-          result = thermalZone;
-        }
+    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
+         it != thermalZones.end();
+         it++ )
+    {
+      std::vector<ModelObject> equipment = it->equipment();
+
+      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
+      {
+        return *it;
       }
     }
-
-    return result;
+    return boost::none;
   }
   
   bool ZoneHVACBaseboardConvectiveElectric_Impl::addToThermalZone(ThermalZone & thermalZone)
@@ -263,22 +265,8 @@ namespace detail {
   
   void ZoneHVACBaseboardConvectiveElectric_Impl::removeFromThermalZone()
   {
-    boost::optional<ThermalZone> thermalZone = this->thermalZone();
-    Model m = this->model();
-    ModelObject thisObject = this->getObject<ModelObject>();
-    std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
-         it != thermalZones.end();
-         it++ )
-    {
-      std::vector<ModelObject> equipment = it->equipment();
-
-      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
-      {
-        it->removeEquipment(thisObject);
-
-        break;
-      }
+    if ( boost::optional<ThermalZone> thermalZone = this->thermalZone() ) {
+      thermalZone->removeEquipment(this->getObject<ZoneHVACComponent>());
     }
   }
 

--- a/openstudiocore/src/model/ZoneHVACBaseboardConvectiveWater.cpp
+++ b/openstudiocore/src/model/ZoneHVACBaseboardConvectiveWater.cpp
@@ -202,19 +202,21 @@ std::vector<IdfObject> ZoneHVACBaseboardConvectiveWater_Impl::remove()
 
   boost::optional<ThermalZone> ZoneHVACBaseboardConvectiveWater_Impl::thermalZone()
   {
-    boost::optional<ThermalZone> result;
     Model m = this->model();
+    ModelObject thisObject = this->getObject<ModelObject>();
     std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    BOOST_FOREACH(ThermalZone& thermalZone, thermalZones){
-      std::vector<ModelObject> equipments = thermalZone.equipment(); 
-      BOOST_FOREACH(ModelObject& equipment, equipments){
-        if (equipment.handle() == this->handle()){
-          result = thermalZone;
-        }
+    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
+         it != thermalZones.end();
+         it++ )
+    {
+      std::vector<ModelObject> equipment = it->equipment();
+
+      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
+      {
+        return *it;
       }
     }
-
-    return result;
+    return boost::none;
   }
 
   //reimplemented to override the base-class method in ZoneHVACComponent
@@ -242,22 +244,8 @@ std::vector<IdfObject> ZoneHVACBaseboardConvectiveWater_Impl::remove()
   //and therefore doesn't need to be removed from them when removed from the zone
   void ZoneHVACBaseboardConvectiveWater_Impl::removeFromThermalZone()
   {
-    boost::optional<ThermalZone> thermalZone = this->thermalZone();
-    Model m = this->model();
-    ModelObject thisObject = this->getObject<ModelObject>();
-    std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
-         it != thermalZones.end();
-         it++ )
-    {
-      std::vector<ModelObject> equipment = it->equipment();
-
-      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
-      {
-        it->removeEquipment(thisObject);
-
-        break;
-      }
+    if ( boost::optional<ThermalZone> thermalZone = this->thermalZone() ) {
+      thermalZone->removeEquipment(this->getObject<ZoneHVACComponent>());
     }
   }
 } // detail

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
@@ -495,19 +495,21 @@ namespace detail {
 
   boost::optional<ThermalZone> ZoneHVACLowTempRadiantConstFlow_Impl::thermalZone() const
   {
-    boost::optional<ThermalZone> result;
     Model m = this->model();
+    ModelObject thisObject = this->getObject<ModelObject>();
     std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    BOOST_FOREACH(ThermalZone& thermalZone, thermalZones){
-      std::vector<ModelObject> equipments = thermalZone.equipment(); 
-      BOOST_FOREACH(ModelObject& equipment, equipments){
-        if (equipment.handle() == this->handle()){
-          result = thermalZone;
-        }
+    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
+         it != thermalZones.end();
+         it++ )
+    {
+      std::vector<ModelObject> equipment = it->equipment();
+
+      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
+      {
+        return *it;
       }
     }
-
-    return result;
+    return boost::none;
   }
 
   //reimplemented to override the base-class method in ZoneHVACComponent
@@ -535,22 +537,8 @@ namespace detail {
   //and therefore doesn't need to be removed from them when removed from the zone
   void ZoneHVACLowTempRadiantConstFlow_Impl::removeFromThermalZone()
   {
-    boost::optional<ThermalZone> thermalZone = this->thermalZone();
-    Model m = this->model();
-    ModelObject thisObject = this->getObject<ModelObject>();
-    std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
-         it != thermalZones.end();
-         it++ )
-    {
-      std::vector<ModelObject> equipment = it->equipment();
-
-      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
-      {
-        it->removeEquipment(thisObject);
-
-        break;
-      }
+    if ( boost::optional<ThermalZone> thermalZone = this->thermalZone() ) {
+      thermalZone->removeEquipment(this->getObject<ZoneHVACComponent>());
     }
   }
 } // detail

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantVarFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantVarFlow.cpp
@@ -421,21 +421,21 @@ namespace detail {
 
   boost::optional<ThermalZone> ZoneHVACLowTempRadiantVarFlow_Impl::thermalZone() const
   {
-    boost::optional<ThermalZone> result;
     Model m = this->model();
+    ModelObject thisObject = this->getObject<ModelObject>();
     std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    BOOST_FOREACH(ThermalZone& thermalZone, thermalZones)
+    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
+         it != thermalZones.end();
+         it++ )
     {
-      std::vector<ModelObject> equipments = thermalZone.equipment(); 
-      BOOST_FOREACH(ModelObject& equipment, equipments)
+      std::vector<ModelObject> equipment = it->equipment();
+
+      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
       {
-        if (equipment.handle() == this->handle()){
-          result = thermalZone;
-        }
+        return *it;
       }
     }
-
-    return result;
+    return boost::none;
   }
 
   //reimplemented to override the base-class method in ZoneHVACComponent
@@ -463,22 +463,8 @@ namespace detail {
   //and therefore doesn't need to be removed from them when removed from the zone
   void ZoneHVACLowTempRadiantVarFlow_Impl::removeFromThermalZone()
   {
-    boost::optional<ThermalZone> thermalZone = this->thermalZone();
-    Model m = this->model();
-    ModelObject thisObject = this->getObject<ModelObject>();
-    std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
-         it != thermalZones.end();
-         it++ )
-    {
-      std::vector<ModelObject> equipment = it->equipment();
-
-      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
-      {
-        it->removeEquipment(thisObject);
-
-        break;
-      }
+    if ( boost::optional<ThermalZone> thermalZone = this->thermalZone() ) {
+      thermalZone->removeEquipment(this->getObject<ZoneHVACComponent>());
     }
   }
 

--- a/openstudiocore/src/model/ZoneHVACLowTemperatureRadiantElectric.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTemperatureRadiantElectric.cpp
@@ -360,19 +360,21 @@ namespace detail {
   
   boost::optional<ThermalZone> ZoneHVACLowTemperatureRadiantElectric_Impl::thermalZone() const
   {
-    boost::optional<ThermalZone> result;
     Model m = this->model();
+    ModelObject thisObject = this->getObject<ModelObject>();
     std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    BOOST_FOREACH(ThermalZone& thermalZone, thermalZones){
-      std::vector<ModelObject> equipments = thermalZone.equipment(); 
-      BOOST_FOREACH(ModelObject& equipment, equipments){
-        if (equipment.handle() == this->handle()){
-          result = thermalZone;
-        }
+    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
+         it != thermalZones.end();
+         it++ )
+    {
+      std::vector<ModelObject> equipment = it->equipment();
+
+      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
+      {
+        return *it;
       }
     }
-
-    return result;
+    return boost::none;
   }
 
   //reimplemented to override the base-class method in ZoneHVACComponent
@@ -400,22 +402,8 @@ namespace detail {
   //and therefore doesn't need to be removed from them when removed from the zone
   void ZoneHVACLowTemperatureRadiantElectric_Impl::removeFromThermalZone()
   {
-    boost::optional<ThermalZone> thermalZone = this->thermalZone();
-    Model m = this->model();
-    ModelObject thisObject = this->getObject<ModelObject>();
-    std::vector<ThermalZone> thermalZones = m.getModelObjects<ThermalZone>();
-    for( std::vector<ThermalZone>::iterator it = thermalZones.begin();
-         it != thermalZones.end();
-         it++ )
-    {
-      std::vector<ModelObject> equipment = it->equipment();
-
-      if( std::find(equipment.begin(),equipment.end(),thisObject) != equipment.end() )
-      {
-        it->removeEquipment(thisObject);
-
-        break;
-      }
+    if ( boost::optional<ThermalZone> thermalZone = this->thermalZone() ) {
+      thermalZone->removeEquipment(this->getObject<ZoneHVACComponent>());
     }
   }
 


### PR DESCRIPTION
This updates the implementation of thermalZone() and addToThermalZone()
for non-air-based ZoneHVACComponents.

The old implementation of thermalZone() kept looping through equipment
and thermalZones even after finding the correct thermalZone. Now it
returns after finding the correct thermalZone.

The old implementation of addToThermalZone() found the ThermalZone but
didn’t use it and proceeds to loop through all ThermalZones and
Equipment again. The new version grabs the ThermalZone and removes the
equipment.

@kbenne Check against the integrate tests.
@asparke2 
