### PR TITLE
Preventing circular reference caused by opening OSP file associated with...

### DIFF
--- a/openstudiocore/src/analysisdriver/SimpleProject.cpp
+++ b/openstudiocore/src/analysisdriver/SimpleProject.cpp
@@ -561,6 +561,16 @@ namespace detail {
       return result;
     }
 
+    // is not osm that made this osp
+    openstudio::path osmForThisOsp = projectDir().parent_path() / toPath(projectDir().stem());
+    osmForThisOsp = setFileExtension(osmForThisOsp,"osm");
+    if (currentSeedLocation.path() == osmForThisOsp) {
+      LOG(Warn,"Cannot set seed to " << toString(currentSeedLocation.path()) <<
+          ", because this OSP file was created by that OSM. Saving this project elsewhere "
+          << "before setting the baseline to that file will break the circular reference.");
+      return result;
+    } 
+
     // compatible with analysis?
     bool ok = analysis().setSeed(currentSeedLocation);
     if (!ok) {

--- a/openstudiocore/src/pat_app/PatApp.cpp
+++ b/openstudiocore/src/pat_app/PatApp.cpp
@@ -66,6 +66,7 @@
 #include <utilities/core/Application.hpp>
 #include <utilities/core/ApplicationPathHelpers.hpp>
 #include <utilities/core/Assert.hpp>
+#include <utilities/core/PathHelpers.hpp>
 #include <utilities/core/System.hpp>
 #include <utilities/core/ZipFile.hpp>
 
@@ -1207,6 +1208,15 @@ bool PatApp::openFile(const QString& fileName)
         QTimer::singleShot(0, this, SLOT(markAsModified()));
       } else {
         QTimer::singleShot(0, this, SLOT(markAsUnmodified()));
+      }
+      openstudio::path osmForThisOsp = project->projectDir().parent_path() / toPath(project->projectDir().stem());
+      osmForThisOsp = setFileExtension(osmForThisOsp,"osm");
+      if (boost::filesystem::exists(osmForThisOsp)) {
+        QMessageBox::warning(mainWindow,
+                             "PAT Project Associated with an OSM",
+                             QString("This project appears to be associated with the OpenStudio Application file '") + 
+                             toQString(osmForThisOsp) + 
+                             QString("'. For best results, 'Save as ...' this project elsewhere before continuing your work."));
       }
       return true;
     } else {


### PR DESCRIPTION
... OSM and then setting that OSP's baseline to the OSM file that created it. Give user warning on opening the OSP, and then do not allow the setSeed operation to proceed.
