### PR TITLE
Update ZoneHVACWaterToAirHeatPump constructor

### DIFF
--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.cpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.cpp
@@ -494,7 +494,7 @@ namespace detail {
     OS_ASSERT(result);
   }
 
-  void ZoneHVACWaterToAirHeatPump_Impl::setSupplyAirFan(HVACComponent& fansOnOff) {
+  bool ZoneHVACWaterToAirHeatPump_Impl::setSupplyAirFan(HVACComponent& fansOnOff) {
     bool isAllowedType = false;
     if( fansOnOff.iddObjectType() == IddObjectType::OS_Fan_OnOff)
     {
@@ -503,11 +503,12 @@ namespace detail {
 
     if( isAllowedType )
     {
-      setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanName,fansOnOff.handle());
+      return setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanName,fansOnOff.handle());
     }
+    return false;
   }
 
-  void ZoneHVACWaterToAirHeatPump_Impl::setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP) 
+  bool ZoneHVACWaterToAirHeatPump_Impl::setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP) 
   {
     bool isAllowedType = false;
 
@@ -518,11 +519,12 @@ namespace detail {
 
     if( isAllowedType )
     {
-      setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatingCoilName,heatingCoilsWaterToAirHP.handle());
+      return setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatingCoilName,heatingCoilsWaterToAirHP.handle());
     }
+    return false;
   }
 
-  void ZoneHVACWaterToAirHeatPump_Impl::setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP) {
+  bool ZoneHVACWaterToAirHeatPump_Impl::setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP) {
     bool isAllowedType = false;
 
     if( coolingCoilsWaterToAirHP.iddObjectType() == IddObjectType::OS_Coil_Cooling_WaterToAirHeatPump_EquationFit )
@@ -532,8 +534,9 @@ namespace detail {
 
     if( isAllowedType )
     {
-      setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::CoolingCoilName,coolingCoilsWaterToAirHP.handle());
+      return setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::CoolingCoilName,coolingCoilsWaterToAirHP.handle());
     }
+    return false;
   }
 
   bool ZoneHVACWaterToAirHeatPump_Impl::setMaximumCyclingRate(boost::optional<double> maximumCyclingRate) {
@@ -779,10 +782,14 @@ ZoneHVACWaterToAirHeatPump::ZoneHVACWaterToAirHeatPump(const Model& model,
                   << availabilitySchedule.briefDescription() << ".");
   }
 
-  setSupplyAirFan(supplyAirFan);
-  setHeatingCoil(heatingCoil);
-  setCoolingCoil(coolingCoil);
-  setSupplementalHeatingCoil(supplementalHeatingCoil);
+  ok = setSupplyAirFan(supplyAirFan);
+  OS_ASSERT(ok);
+  ok = setHeatingCoil(heatingCoil);
+  OS_ASSERT(ok);
+  ok = setCoolingCoil(coolingCoil);
+  OS_ASSERT(ok);
+  ok = setSupplementalHeatingCoil(supplementalHeatingCoil);
+  OS_ASSERT(ok);
 
   autosizeSupplyAirFlowRateDuringCoolingOperation();
   autosizeSupplyAirFlowRateDuringHeatingOperation();
@@ -1008,16 +1015,16 @@ void ZoneHVACWaterToAirHeatPump::autosizeOutdoorAirFlowRateWhenNoCoolingorHeatin
   getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->autosizeOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded();
 }
 
-void ZoneHVACWaterToAirHeatPump::setSupplyAirFan(HVACComponent& fansOnOff) {
-  getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setSupplyAirFan(fansOnOff);
+bool ZoneHVACWaterToAirHeatPump::setSupplyAirFan(HVACComponent& fansOnOff) {
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setSupplyAirFan(fansOnOff);
 }
 
-void ZoneHVACWaterToAirHeatPump::setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP) {
-  getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setHeatingCoil(heatingCoilsWaterToAirHP);
+bool ZoneHVACWaterToAirHeatPump::setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP) {
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setHeatingCoil(heatingCoilsWaterToAirHP);
 }
 
-void ZoneHVACWaterToAirHeatPump::setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP) {
-  getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setCoolingCoil(coolingCoilsWaterToAirHP);
+bool ZoneHVACWaterToAirHeatPump::setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP) {
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setCoolingCoil(coolingCoilsWaterToAirHP);
 }
 
 bool ZoneHVACWaterToAirHeatPump::setMaximumCyclingRate(boost::optional<double> maximumCyclingRate) {

--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.hpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.hpp
@@ -168,11 +168,11 @@ class MODEL_API ZoneHVACWaterToAirHeatPump : public ZoneHVACComponent {
 
   void autosizeOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded();
 
-  void setSupplyAirFan(HVACComponent& fansOnOff);
+  bool setSupplyAirFan(HVACComponent& fansOnOff);
 
-  void setHeatingCoil(HVACComponent& heatingCoils);
+  bool setHeatingCoil(HVACComponent& heatingCoils);
 
-  void setCoolingCoil(HVACComponent& coolingCoils);
+  bool setCoolingCoil(HVACComponent& coolingCoils);
 
   bool setMaximumCyclingRate(boost::optional<double> maximumCyclingRate);
 

--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
@@ -185,11 +185,11 @@ namespace detail {
 
     void autosizeOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded();
 
-    void setSupplyAirFan(HVACComponent& fansOnOff);
+    bool setSupplyAirFan(HVACComponent& fansOnOff);
 
-    void setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP);
+    bool setHeatingCoil(HVACComponent& heatingCoilsWaterToAirHP);
 
-    void setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP);
+    bool setCoolingCoil(HVACComponent& coolingCoilsWaterToAirHP);
 
     bool setMaximumCyclingRate(boost::optional<double> maximumCyclingRate);
 

--- a/openstudiocore/src/model/test/ZoneHVACWaterToAirHeatPump_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACWaterToAirHeatPump_GTest.cpp
@@ -25,6 +25,8 @@
 #include <model/Node_Impl.hpp>
 #include <model/FanOnOff.hpp>
 #include <model/FanOnOff_Impl.hpp>
+#include <model/FanConstantVolume.hpp>
+#include <model/FanConstantVolume_Impl.hpp>
 #include <model/HVACComponent.hpp>
 #include <model/HVACComponent_Impl.hpp>
 #include <model/CurveExponent.hpp>
@@ -45,6 +47,8 @@
 #include <model/CoilHeatingWater_Impl.hpp>
 #include <model/ScheduleConstant.hpp>
 #include <model/ScheduleConstant_Impl.hpp>
+#include <model/Schedule.hpp>
+#include <model/Schedule_Impl.hpp>
 #include <model/ThermalZone.hpp>
 #include <model/ThermalZone_Impl.hpp>
 //#include <utilities/units/Quantity.hpp>
@@ -53,7 +57,63 @@
 using namespace openstudio;
 using namespace openstudio::model;
 
-TEST(ZoneHVACWaterToAirHeatPump,ZoneHVACWaterToAirHeatPump_SetGetFields) {
+TEST_F(ModelFixture, ZoneHVACWaterToAirHeatPump_FanOnOff)
+{
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  ASSERT_EXIT ( 
+  {  
+    Model model;
+    Schedule availabilitySched = model.alwaysOnDiscreteSchedule();
+    CurveExponent fanPowerFtSpeedCurve(model);
+    CurveCubic fanEfficiencyFtSpeedCurve(model);
+
+    fanPowerFtSpeedCurve.setCoefficient1Constant(0.0);
+    fanPowerFtSpeedCurve.setCoefficient2Constant(1.0);
+    fanPowerFtSpeedCurve.setCoefficient3Constant(3.0);
+    fanPowerFtSpeedCurve.setMinimumValueofx(0.0);
+    fanPowerFtSpeedCurve.setMaximumValueofx(1.5);
+    fanPowerFtSpeedCurve.setMinimumCurveOutput(0.01);
+    fanPowerFtSpeedCurve.setMaximumCurveOutput(1.5);
+
+    fanEfficiencyFtSpeedCurve.setCoefficient1Constant(0.33856828);
+    fanEfficiencyFtSpeedCurve.setCoefficient2x(1.72644131);
+    fanEfficiencyFtSpeedCurve.setCoefficient3xPOW2(-1.49280132);
+    fanEfficiencyFtSpeedCurve.setCoefficient4xPOW3(0.42776208);
+    fanEfficiencyFtSpeedCurve.setMinimumValueofx(0.5);
+    fanEfficiencyFtSpeedCurve.setMaximumValueofx(1.5);
+    fanEfficiencyFtSpeedCurve.setMinimumCurveOutput(0.3);
+    fanEfficiencyFtSpeedCurve.setMaximumCurveOutput(1.0);
+
+    FanOnOff supplyFan(model,availabilitySched,fanPowerFtSpeedCurve,fanEfficiencyFtSpeedCurve);
+    CoilHeatingWaterToAirHeatPumpEquationFit coilHeatingWaterToAirHP(model);
+    CoilCoolingWaterToAirHeatPumpEquationFit coilCoolingWaterToAirHP(model);
+    CoilHeatingElectric supplementalHC(model,availabilitySched);
+    ZoneHVACWaterToAirHeatPump testHP(model,availabilitySched,supplyFan,coilHeatingWaterToAirHP,coilCoolingWaterToAirHP,supplementalHC);
+
+    exit(0); 
+  } ,
+    ::testing::ExitedWithCode(0), "" );
+}
+
+TEST_F(ModelFixture, ZoneHVACWaterToAirHeatPump_FanConstantVolume)
+{
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  ASSERT_DEATH (
+  {
+    Model model;
+    Schedule availabilitySched = model.alwaysOnDiscreteSchedule();
+    FanConstantVolume supplyFan(model,availabilitySched);
+    CoilHeatingWaterToAirHeatPumpEquationFit coilHeatingWaterToAirHP(model);
+    CoilCoolingWaterToAirHeatPumpEquationFit coilCoolingWaterToAirHP(model);
+    CoilHeatingElectric supplementalHC(model,availabilitySched);
+
+    ZoneHVACWaterToAirHeatPump testHP(model,availabilitySched,supplyFan,coilHeatingWaterToAirHP,coilCoolingWaterToAirHP,supplementalHC);
+  }, ".*" );
+}
+
+TEST_F(ModelFixture, ZoneHVACWaterToAirHeatPump_SetGetFields) {
   Model model;
 
   CurveExponent fanPowerFtSpeedCurve(model);


### PR DESCRIPTION
This updates the constructor to fail if any of the sub components fail to be set properly.

The setters for the sub components change from void to bool returns.

Includes two new unit tests for this functionality.

This addresses issue #708

@asparke2 @kbenne 
