### PR TITLE
Change TimeSeries +/- to use seconds, add GTest

### DIFF
--- a/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
+++ b/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
@@ -372,6 +372,68 @@ TEST_F(DataFixture,TimeSeries_DetailedConstructor_WrapAroundDates)
 
 }
 
+TEST_F(DataFixture,TimeSeries_AddSubtract8760)
+{
+  // Test out various addition and subtraction combinations - some of the tests look a little
+  // strange but were the best way to get at some strange rounding issues that came up.
+  std::string units = "C";
+
+  // interval
+  Time interval = Time(0,1);
+  Vector values = linspace(1, 8760, 8760);
+
+  Date startDate(Date(MonthOfYear(MonthOfYear::Jan),1));
+  DateTime startDateTime(startDate, Time(0,1,0,0));
+  Date endDate(Date(MonthOfYear(MonthOfYear::Dec),31));
+  DateTime endDateTime(endDate, Time(0,24,0,0));
+  Time delta(0,1,0,0);
+  std::vector<DateTime> dateTimes;
+  for(openstudio::DateTime current=startDateTime; current <= endDateTime; current += delta)
+  {
+    dateTimes.push_back(current);
+  }
+
+  TimeSeries intervalTimeSeries(startDateTime, interval, values, units);
+  TimeSeries detailedTimeSeries(dateTimes, values, units);
+
+  // Addition
+  TimeSeries intervalPlusDetailed = intervalTimeSeries + detailedTimeSeries;
+  EXPECT_EQ(8760,intervalPlusDetailed.values().size());
+
+  TimeSeries detailedPlusDetailed = detailedTimeSeries + detailedTimeSeries;
+  EXPECT_EQ(8760,detailedPlusDetailed.values().size());
+
+  TimeSeries intervalSelfPlusDetailed = intervalTimeSeries;
+  intervalSelfPlusDetailed = intervalSelfPlusDetailed + detailedTimeSeries;
+  EXPECT_EQ(8760,intervalSelfPlusDetailed.values().size());
+
+  TimeSeries detailedSelfPlusDetailed = detailedTimeSeries;
+  detailedSelfPlusDetailed = detailedSelfPlusDetailed + detailedTimeSeries;
+  EXPECT_EQ(8760,detailedSelfPlusDetailed.values().size());
+
+  TimeSeries dpdSelfPlusDetailed = detailedTimeSeries + detailedTimeSeries;
+  dpdSelfPlusDetailed = dpdSelfPlusDetailed + detailedTimeSeries;
+  EXPECT_EQ(8760,dpdSelfPlusDetailed.values().size());
+
+  // Subtraction
+  TimeSeries intervalMinusDetailed = intervalTimeSeries - detailedTimeSeries;
+  EXPECT_EQ(8760,intervalMinusDetailed.values().size());
+
+  TimeSeries detailedMinusDetailed = detailedTimeSeries - detailedTimeSeries;
+  EXPECT_EQ(8760,detailedMinusDetailed.values().size());
+
+  TimeSeries intervalSelfMinusDetailed = intervalTimeSeries;
+  intervalSelfMinusDetailed = intervalSelfMinusDetailed - detailedTimeSeries;
+  EXPECT_EQ(8760,intervalSelfPlusDetailed.values().size());
+
+  TimeSeries detailedSelfMinusDetailed = detailedTimeSeries;
+  detailedSelfMinusDetailed = detailedSelfMinusDetailed - detailedTimeSeries;
+  EXPECT_EQ(8760,detailedSelfMinusDetailed.values().size());
+
+  TimeSeries dmdSelfMinusDetailed = detailedTimeSeries - detailedTimeSeries;
+  dmdSelfMinusDetailed = dmdSelfMinusDetailed - detailedTimeSeries;
+  EXPECT_EQ(8760,dmdSelfMinusDetailed.values().size());
+}
 
 TEST_F(DataFixture,TimeSeries_AddSubtractSameTimePeriod)
 {

--- a/openstudiocore/src/utilities/data/TimeSeries.cpp
+++ b/openstudiocore/src/utilities/data/TimeSeries.cpp
@@ -553,17 +553,8 @@ namespace openstudio{
 
         // make unique, ordered set of all date times
         std::set<DateTime> dateTimesSet;
-        DateTimeVector dateTimes1(m_values.size());
-        Vector m_daysFromFirstReport = daysFromFirstReport();  // Another stand-in for using seconds
-        for(unsigned i=0; i<m_values.size();i++)
-        {
-          dateTimes1[i] = m_firstReportDateTime + Time(m_daysFromFirstReport[i]);
-        }
-        DateTimeVector dateTimes2(other.values().size());
-        for(unsigned i=0; i<other.values().size();i++)
-        {
-          dateTimes2[i] = other.firstReportDateTime() + Time(other.daysFromFirstReport(i));
-        }
+        DateTimeVector dateTimes1 = dateTimes();
+        DateTimeVector dateTimes2 = other.dateTimes();
         dateTimesSet.insert(dateTimes1.begin(), dateTimes1.end());
         dateTimesSet.insert(dateTimes2.begin(), dateTimes2.end());
 
@@ -602,17 +593,8 @@ namespace openstudio{
 
         // make unique, ordered set of all date times
         std::set<DateTime> dateTimesSet;
-        DateTimeVector dateTimes1(m_values.size());
-        Vector m_daysFromFirstReport = daysFromFirstReport();  // Another stand-in for using seconds
-        for(unsigned i=0; i<m_values.size();i++)
-        {
-          dateTimes1[i] = m_firstReportDateTime + Time(m_daysFromFirstReport[i]);
-        }
-        DateTimeVector dateTimes2(other.values().size());
-        for(unsigned i=0; i<other.values().size();i++)
-        {
-          dateTimes2[i] = other.firstReportDateTime() + Time(other.daysFromFirstReport(i));
-        }
+        DateTimeVector dateTimes1 = dateTimes();
+        DateTimeVector dateTimes2 = other.dateTimes();
         dateTimesSet.insert(dateTimes1.begin(), dateTimes1.end());
         dateTimesSet.insert(dateTimes2.begin(), dateTimes2.end());
 


### PR DESCRIPTION
@macumber The addition and subtraction of TimeSeries wasn't working that well - I was getting a lot of this sort of thing when adding together series:

2009-Jan-17 07:59:57 0.030163
2009-Jan-17 07:59:58 0.030163
2009-Jan-17 07:59:59 0.030163
2009-Jan-17 08:00:00 0.030163

I changed the addition and subtraction functions to use the dateTimes method and that seems to have straightened things out.
