### PR TITLE
Adjust thermostat translation

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.cpp
@@ -1829,7 +1829,6 @@ std::vector<IddObjectType> ForwardTranslator::iddObjectsToTranslateInitializer()
   result.push_back(IddObjectType::OS_Node);
   result.push_back(IddObjectType::OS_PlantLoop);
   result.push_back(IddObjectType::OS_Splitter);
-  result.push_back(IddObjectType::OS_ThermostatSetpoint_DualSetpoint);
   result.push_back(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Water);
   result.push_back(IddObjectType::OS_ZoneHVAC_IdealLoadsAirSystem);
   result.push_back(IddObjectType::OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlow);


### PR DESCRIPTION
@macumber @DavidGoldwasser 

Removed thermostats from the idd object types to translate because thermostats
will be explicitly translated within translateThermalZone.
This removes any possibilty of orphan thermostats ending up in
the idf file.

[#63470904]
