### PR TITLE
Addresses bug #830, missing EPW

### DIFF
--- a/openstudiocore/src/runmanager/lib/Job_Impl.hpp
+++ b/openstudiocore/src/runmanager/lib/Job_Impl.hpp
@@ -464,6 +464,15 @@ namespace detail {
     private:
       REGISTER_LOGGER("openstudio.runmanager.Job_Impl");
 
+      enum CleanType {
+        none,
+        standard,
+        maximum
+      };
+
+      CleanType m_cleanTypeToRun;
+      void doCleanUp();
+
       boost::optional<QDateTime> lastRunInternal() const;
 
       mutable QReadWriteLock m_mutex;


### PR DESCRIPTION
I was bothered by the demonstration of this bug by @DavidGoldwasser
as it did not appear to be anything I had seen before, so I decided to
investigate.

It seems there is a race condition involving complex workflows which
generate new OSMs. The weather files which are picked up by the generated
OSMs may or may not be removed by the job cleanup process before the down
stream jobs have picked them up for processing. It seems to be the ModelToIdf
which notices the missing epw. It files the one used in a previous job step
then goes to use it for itself, at which time it's been deleted out
from underneath the ModelToIdf Job.

The solution implemented here is to only run the cleanup process after (and
only if) the entire job tree completes successfully.

JobCleanup unit tests still pass with this code in place, and in the case
that something goes wrong halfway through a job tree execution, we now have
more data to use for debugging the problem.

This doesn't appear to be a bug that I've ever seen before, but it might solve
other lingering, unknown issues.
