### PR TITLE
Update system() implementation in Case and Walkin

### DIFF
--- a/openstudiocore/src/model/RefrigerationCase.cpp
+++ b/openstudiocore/src/model/RefrigerationCase.cpp
@@ -422,10 +422,7 @@ namespace detail {
     RefrigerationCase refrigerationCase = this->getObject<RefrigerationCase>();
     BOOST_FOREACH(RefrigerationSystem refrigerationSystem, refrigerationSystems) {
       RefrigerationCaseVector refrigerationCases = refrigerationSystem.cases();
-      if ( refrigerationCases.empty() ) {
-        continue;
-      }
-      if ( std::find(refrigerationCases.begin(), refrigerationCases.end(), refrigerationCase) != refrigerationCases.end() ) {
+      if ( !refrigerationCases.empty() && std::find(refrigerationCases.begin(), refrigerationCases.end(), refrigerationCase) != refrigerationCases.end() ) {
         return refrigerationSystem;
       }
     }

--- a/openstudiocore/src/model/RefrigerationWalkIn.cpp
+++ b/openstudiocore/src/model/RefrigerationWalkIn.cpp
@@ -327,10 +327,7 @@ namespace detail {
     RefrigerationWalkIn refrigerationWalkIn = this->getObject<RefrigerationWalkIn>();
     BOOST_FOREACH(RefrigerationSystem refrigerationSystem, refrigerationSystems) {
       RefrigerationWalkInVector refrigerationWalkIns = refrigerationSystem.walkins();
-      if ( refrigerationWalkIns.empty() ) {
-        continue;
-      }
-      if ( std::find(refrigerationWalkIns.begin(), refrigerationWalkIns.end(), refrigerationWalkIn) != refrigerationWalkIns.end() ) {
+      if ( !refrigerationWalkIns.empty() && std::find(refrigerationWalkIns.begin(), refrigerationWalkIns.end(), refrigerationWalkIn) != refrigerationWalkIns.end() ) {
         return refrigerationSystem;
       }
     }


### PR DESCRIPTION
This implementation uses std::find() to look for the case and returns
the refrigerationSystem. The old implementation didn’t break all for
loops when the system was found. It also checks for empty vector of
cases/walkins first.

@evanweaver I didn't compile this on my machine (didn't want to do a full build of this branch) but I can't see any reason why this wouldn't compile.
