### PR TITLE
Avoid creatName for Connection objects

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -11103,6 +11103,7 @@ OS:Connection,
   A2, \field Name
        \type alpha
        \reference ConnectionNames
+       \default Connection
   A3, \field Source Object
        \type object-list
        \required-field

--- a/openstudiocore/src/model/Connection.cpp
+++ b/openstudiocore/src/model/Connection.cpp
@@ -138,6 +138,7 @@ namespace detail {
 Connection::Connection(const Model& model)
   : ModelObject(Connection::iddObjectType(),model)
 {
+  setName(handle().toString().toStdString());
   OS_ASSERT(getImpl<detail::Connection_Impl>());
 }
 


### PR DESCRIPTION
The Connection ModelObject works behind the scenes to join HVAC
components together.  A typical model has a very large number of them
and they are all getting a pretty human readable name for no purpose.
This eats up time.  Consider setting name to the handle string and avoid
work of the createName method.

Note that Connection has overloaded createName for some time but it is
not working.  It seems virtual functions are not called in constructors.

The method used here is to give the name field a default and then set
name to the handle string in the Connection constructor.  The default
implementation of createName seems to avoid the expensive operation if
there is a default.

[#66666852]
