### PR TITLE
Change default terminal priority

### DIFF
--- a/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeCooledBeam.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeCooledBeam.cpp
@@ -183,7 +183,6 @@ AirTerminalSingleDuctConstantVolumeCooledBeam_Impl::outputVariableNames() const
                 AirTerminalSingleDuctConstantVolumeCooledBeam mo = this->getObject<AirTerminalSingleDuctConstantVolumeCooledBeam>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true;

--- a/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeReheat.cpp
@@ -172,8 +172,6 @@ namespace detail {
                 AirTerminalSingleDuctConstantVolumeReheat mo = this->getObject<AirTerminalSingleDuctConstantVolumeReheat>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setHeatingPriority(mo,1);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true; 

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
@@ -458,8 +458,6 @@ namespace detail {
                 ModelObject mo = this->getObject<ModelObject>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setHeatingPriority(mo,1);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true; 

--- a/openstudiocore/src/model/AirTerminalSingleDuctUncontrolled.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctUncontrolled.cpp
@@ -164,8 +164,6 @@ namespace detail{
                 AirTerminalSingleDuctUncontrolled mo = this->getObject<AirTerminalSingleDuctUncontrolled>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setHeatingPriority(mo,1);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true;

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
@@ -372,8 +372,6 @@ bool AirTerminalSingleDuctVAVNoReheat_Impl::addToNode(Node & node)
                 AirTerminalSingleDuctVAVNoReheat mo = this->getObject<AirTerminalSingleDuctVAVNoReheat>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setHeatingPriority(mo,1);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true; 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -176,8 +176,6 @@ namespace detail{
                 AirTerminalSingleDuctVAVReheat mo = this->getObject<AirTerminalSingleDuctVAVReheat>();
 
                 thermalZone->addEquipment(mo);
-                thermalZone->setHeatingPriority(mo,1);
-                thermalZone->setCoolingPriority(mo,1);
               }
 
               return true; 


### PR DESCRIPTION
@asparke2 @mleachNREL @DavidGoldwasser

This came at the request of PSD.  Since there is no way to set priority in the GUI it was thought better to let default order be determined by the order you add things instead of always set terminals to priority 1.  I'm not sure if we want to accept this behavioral change or not, as it might impact some measures.  Discussion please.

Instead of setting terminal heating/cooling priority to 1 when added to
zone, assign as the last priority.  Default priorty is thus controlled
by the order equipment is added to zone.  The API still allows changing
priority after the fact.
