### PR TITLE
Fix boost 1.55 compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,15 +469,12 @@ ENDIF()
 
 IF(BUILD_BOOST)
   IF(APPLE)
-    STRING(REGEX MATCH "[0-9]+\\.[0-9]+" OSX_SDK_VERSION ${CMAKE_OSX_SYSROOT})
-    # DLM: TODO address comment on Mac
-    # Added cxxflags="-stdlib=libstdc++" linkflags="-stdlib=libstdc++" for Boost 1.47.0 to compile when osx_deployment_target=10.9
-    # These flags can be removed if Boost is updated to newer version (~1.55.0), may need --c++11 flag?
     ExternalProject_Add( Boost
       URL http://developer.nrel.gov/downloads/buildings/openstudio/src/boost_1_55_0.tar.gz
       URL_MD5 93780777cfbf999a600f62883bd54b17
       CONFIGURE_COMMAND cd ${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost && ./bootstrap.sh
-      BUILD_COMMAND cd ${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost && ./b2 cxxflags="-stdlib=libstdc++" linkflags="-stdlib=libstdc++" variant=debug,release address-model=32_64 macosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} macosx-version=${OSX_SDK_VERSION} architecture=x86 define=BOOST_CHRONO_HEADER_ONLY --layout=tagged --with-filesystem --with-regex --with-program_options --with-system --with-thread --with-date_time --with-serialization --with-log --prefix=${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost-install -j${CPUCOUNT} install
+      PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/dependencies/Boost/xcode_51a.diff < ${CMAKE_SOURCE_DIR}/dependencies/Boost/xcode_51b.diff
+      BUILD_COMMAND cd ${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost && ./b2 cxxflags="-stdlib=libstdc++" linkflags="-stdlib=libstdc++" variant=debug,release address-model=32_64 architecture=x86 define=BOOST_CHRONO_HEADER_ONLY --layout=tagged --with-filesystem --with-regex --with-program_options --with-system --with-thread --with-date_time --with-serialization --with-log --prefix=${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost-install -j${CPUCOUNT} install
       INSTALL_COMMAND ""
       )
     SET(BOOST_ROOT ${CMAKE_BINARY_DIR}/Boost-prefix/src/Boost-install)

--- a/dependencies/Boost/xcode_51a.diff
+++ b/dependencies/Boost/xcode_51a.diff
@@ -1,0 +1,35 @@
+diff --git a/boost/atomic/detail/cas128strong.hpp b/boost/atomic/detail/cas128strong.hpp
+index 906c13e..dcb4d7d 100644
+--- a/boost/atomic/detail/cas128strong.hpp
++++ b/boost/atomic/detail/cas128strong.hpp
+@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void
+     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type value_s = 0;
++        storage_type value_s;
++        memset(&value_s, 0, sizeof(value_s));
+         memcpy(&value_s, &value, sizeof(value_type));
+         platform_fence_before_store(order);
+         platform_store128(value_s, &v_);
+@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+ 

--- a/dependencies/Boost/xcode_51b.diff
+++ b/dependencies/Boost/xcode_51b.diff
@@ -1,0 +1,55 @@
+diff --git a/boost/atomic/detail/gcc-atomic.hpp b/boost/atomic/detail/gcc-atomic.hpp
+index a130590..4af99a1 100644
+--- a/boost/atomic/detail/gcc-atomic.hpp
++++ b/boost/atomic/detail/gcc-atomic.hpp
+@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+     }
+@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
+ 
+     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+         value_type res;
+@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
+@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,


### PR DESCRIPTION
This gets boost 1.55 to compile on Mac OSX via superbuild.
This is tested against 10.9 and Clang 5.1

The two patches are required when compiling with clang 5.1.
https://github.com/Homebrew/homebrew/commit/a20650deb61faa38356b370bcbaa
f35c195135b4

In the future the -stdlib=libstdc++ should be removed since libc++ is the default stdlib in 10.9. All Macs back to 10.7 have libc++ on them, however, libstdc++ is the default on those older versions of OSX. If in the future Openstudio wants to use c++11 features, libc++ will have to be used on Mac.

@macumber
