### PR TITLE
Fix openstudio_utilities_tests link issue

### DIFF
--- a/openstudiocore/ProjectMacros.cmake
+++ b/openstudiocore/ProjectMacros.cmake
@@ -51,9 +51,9 @@ macro( CREATE_TEST_TARGETS BASE_NAME SRC DEPENDENCIES )
     ENDIF()
       
     TARGET_LINK_LIBRARIES( ${BASE_NAME}_tests 
-      ${ALL_DEPENDENCIES} 
       gtest 
       gtest_main
+      ${ALL_DEPENDENCIES}
     )
 
     ADD_GOOGLE_TESTS( ${BASE_NAME}_tests ${SRC} )

--- a/openstudiocore/src/utilities/CMakeLists.txt
+++ b/openstudiocore/src/utilities/CMakeLists.txt
@@ -242,7 +242,8 @@ SET( ${target_name}_depends
   litesql-util
   miniziplib
   ${Boost_LIBRARIES}
-  ${CMAKE_THREAD_LIBS}
+  #JWD: On Ubuntu 14.04, the thread lib is included in Boost_LIBRARIES
+  # ${CMAKE_THREAD_LIBS}
   ${QT_LIBS}
 )
 


### PR DESCRIPTION
@macumber The CMake macro CREATE_TEST_TARGETS had the target link libraries ordered with gtest and gtest_main before the thread library, and on Ubuntu 14.04 this was causing the link to fail for openstudio_utilities_tests. Moving ALL_DEPENDENCIES to after gtest and gtest_main fixes that. Also, the thread library was showing up twice in the link command, so I commented out the explicit addition for the utilities test. I've left it in as a comment since I can only build this branch on Ubuntu and it needs to be verified on other platforms.
