### PR TITLE
Fix missing time label in schedule view

### DIFF
--- a/openstudiocore/src/openstudio_lib/SchedulesView.cpp
+++ b/openstudiocore/src/openstudio_lib/SchedulesView.cpp
@@ -1058,6 +1058,7 @@ ScheduleDayView::ScheduleDayView(bool isIP,
                                  const model::ScheduleDay & scheduleDay,
                                  SchedulesView * schedulesView)
   : QWidget(schedulesView),
+    m_focusStartTime(0.0),
     m_zoom(1.0),
     m_snap(3600.0),
     m_scheduleDay(scheduleDay),


### PR DESCRIPTION
Uninitialized double member m_focusStartTime in ScheduleDayView has
appeard to cause the issue.

[#67037740]

https://www.pivotaltracker.com/story/show/67037740

[#766]
