### PR TITLE
Fix FanOnOff unit test

### DIFF
--- a/openstudiocore/src/model/test/FanOnOff_GTest.cpp
+++ b/openstudiocore/src/model/test/FanOnOff_GTest.cpp
@@ -416,7 +416,7 @@ TEST_F(ModelFixture,FanOnOff_Test_Setters_and_Getters)
   EXPECT_TRUE(testObject.setFanEfficiencyRatioFunctionofSpeedRatioCurve(newCurve3));
 
   EXPECT_FALSE(testObject.setFanPowerRatioFunctionofSpeedRatioCurve(newCurve2));
-  EXPECT_FALSE(testObject.setFanPowerRatioFunctionofSpeedRatioCurve(newCurve3));
+  EXPECT_TRUE(testObject.setFanPowerRatioFunctionofSpeedRatioCurve(newCurve3));
   EXPECT_FALSE(testObject.setFanEfficiencyRatioFunctionofSpeedRatioCurve(newCurve1));
 }
 


### PR DESCRIPTION
[#73252230]

@kbenne @macumber 

FanOnOff::fanPowerRatioFunctionofSpeedRatioCurve now allows CurveCubic as an option. This alters the unit test to reflect the change.

https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/resources/model/OpenStudio.idd#L13677
