### PR TITLE
[#73252274] Fix repeated warnings failure

### DIFF
--- a/openstudiocore/src/energyplus/Test/ErrorFile_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ErrorFile_GTest.cpp
@@ -104,14 +104,4 @@ TEST_F(EnergyPlusFixture,ErrorFile_WarningsAndCrash)
   EXPECT_FALSE(errorFile.completedSuccessfully());
 }
 
-TEST_F(EnergyPlusFixture,ErrorFile_RepeatingWarnings)
-{
-  openstudio::path path = resourcesPath() / openstudio::toPath("energyplus/ErrorFiles/RepeatingWarnings.err");
 
-  ErrorFile errorFile(path);
-  EXPECT_EQ(8931u, errorFile.warnings().size());
-  EXPECT_EQ(static_cast<unsigned>(0), errorFile.severeErrors().size());
-  EXPECT_EQ(static_cast<unsigned>(0), errorFile.fatalErrors().size());
-  EXPECT_TRUE(errorFile.completed());
-  EXPECT_TRUE(errorFile.completedSuccessfully());
-}

--- a/openstudiocore/src/runmanager/lib/CMakeLists.txt
+++ b/openstudiocore/src/runmanager/lib/CMakeLists.txt
@@ -273,6 +273,7 @@ SET( runmanager_test_src
   Test/JSON_GTest.cpp
   Test/ExternallyManagedJobs_GTest.cpp
   Test/RunJSONWorkflow_GTest.cpp
+  Test/JobErrors_GTest.cpp
   "${CMAKE_BINARY_DIR}/src/runmanager/Test/ToolBin.hxx"
 )
 

--- a/openstudiocore/src/runmanager/lib/JobErrors.cpp
+++ b/openstudiocore/src/runmanager/lib/JobErrors.cpp
@@ -59,6 +59,10 @@ std::vector<std::pair<int, std::string> > JobErrors::errorsByTypeWithCount(const
       boost::smatch matches;
       if (boost::regex_search(itr->second, matches, occurredTotalTimes)) {
         std::string temp = std::string(matches[1].first, matches[1].second); 
+        // note that we subtract one here because the repeating EnergyPlus warnings that we are
+        // parsing out are listed once when they first occur, then again with a "total times" count.
+        // If we don't subtract 1 then we end up with an off by 1 error for each repeated warning
+        // in the total count.
         repeatCount = atoi(temp.c_str()) - 1;
       }
 

--- a/openstudiocore/src/runmanager/lib/Test/JobErrors_GTest.cpp
+++ b/openstudiocore/src/runmanager/lib/Test/JobErrors_GTest.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include "RunManagerTestFixture.hpp"
+#include <runmanager/Test/ToolBin.hxx>
+#include <resources.hxx>
+
+#include <runmanager/lib/JobFactory.hpp>
+#include <runmanager/lib/ModelToRadJob.hpp>
+#include <runmanager/lib/RunManager.hpp>
+#include <runmanager/lib/Workflow.hpp>
+
+#include <model/Model.hpp>
+
+#include <utilities/idf/IdfFile.hpp>
+#include <utilities/idf/IdfObject.hpp>
+#include <utilities/data/EndUses.hpp>
+#include <utilities/data/Attribute.hpp>
+#include <utilities/sql/SqlFile.hpp>
+
+#include <boost/filesystem/path.hpp>
+
+
+TEST_F(RunManagerTestFixture, JobErrors_RepeatingWarnings)
+{
+  openstudio::runmanager::JobErrors err;
+  err.addError(openstudio::runmanager::ErrorType::Warning, "CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 12\" - Low condenser dry-bulb temperature error continues...\n This error occurred 3 total times;\n during Warmup 0 times;\n during Sizing 0 times.\n Max=-0.966667 [C]  Min=-3.8 [C]");
+
+  err.addError(openstudio::runmanager::ErrorType::Warning, "CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 12\" - Full load outlet temperature indicates a possibility of frost/freeze error continues. Outlet air temperature statistics follow:\n This error occurred 958 total times;\n during Warmup 0 times;\n during Sizing 0 times.\n Max=1.997448  Min=-8.176312");
+
+  err.addError(openstudio::runmanager::ErrorType::Warning, "CalcDoe2DXCoil: Coil:Cooling:DX:SingleSpeed=\"COIL COOLING DX SINGLE SPEED 6\" - Low condenser dry-bulb temperature error continues...\n This error occurred 4 total times;\n during Warmup 0 times;\n during Sizing 0 times.\n Max=-0.966667 [C]  Min=-3.8 [C]");
+
+
+  EXPECT_EQ(3u, err.errorsByType(openstudio::runmanager::ErrorType::Warning).size());
+  EXPECT_EQ(962, err.totalCountByType(openstudio::runmanager::ErrorType::Warning));
+
+  std::vector<std::pair<int, std::string> > errs = err.errorsByTypeWithCount(openstudio::runmanager::ErrorType::Warning);
+
+  ASSERT_EQ(3u, errs.size());
+  EXPECT_EQ(2, errs[0].first);
+  EXPECT_EQ(957, errs[1].first);
+  EXPECT_EQ(3, errs[2].first);
+
+}


### PR DESCRIPTION
The last reworking of how repeated warnings are handled moved the
repeated warning parsing from EnergyPlus lib to
openstudio::runamanger::JobErrors where it is more useful to GUI's and
applications. This commit moves the unit test appropriately.
