### PR TITLE
Fix crash when importing large office

### DIFF
--- a/openstudiocore/src/openstudio_lib/MainMenu.cpp
+++ b/openstudiocore/src/openstudio_lib/MainMenu.cpp
@@ -85,17 +85,17 @@ MainMenu::MainMenu(bool isIP, bool isPlugin, QWidget *parent) :
 
   action = new QAction(tr("IDF"), this);
   importMenu->addAction(action);
-  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importClicked()));
+  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importClicked()), Qt::QueuedConnection);
   OS_ASSERT(isConnected);
 
   action = new QAction(tr("gbXML"), this); 
   importMenu->addAction(action);
-  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importgbXMLClicked()));
+  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importgbXMLClicked()), Qt::QueuedConnection);
   OS_ASSERT(isConnected);
 
   action = new QAction(tr("SDD"), this); 
   importMenu->addAction(action);
-  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importSDDClicked()));
+  isConnected = connect(action, SIGNAL(triggered()), this, SIGNAL(importSDDClicked()), Qt::QueuedConnection);
   OS_ASSERT(isConnected);
 
   QMenu * exportMenu = m_fileMenu->addMenu(tr("Export"));


### PR DESCRIPTION
[#69514896]
#970

Looks like all import options were crashing in recent builds.  This should clear it up.
