### PR TITLE
Enable import of Sizing:Zone object

### DIFF
--- a/openstudiocore/src/energyplus/ReverseTranslator.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator.cpp
@@ -759,7 +759,7 @@ boost::optional<ModelObject> ReverseTranslator::translateAndMapWorkspaceObject(c
     }
   case openstudio::IddObjectType::Sizing_Zone :
     {
-      //modelObject = translateSizingZone(workspaceObject );
+      modelObject = translateSizingZone(workspaceObject );
       break;
     }
   case openstudio::IddObjectType::SteamEquipment :


### PR DESCRIPTION
This has the desired consequence of importing the related design oa object.

[fixes #69514824]
https://www.pivotaltracker.com/story/show/69514824
