### PR TITLE
Fix compiler warning in EpwFile.cpp

### DIFF
--- a/openstudiocore/src/utilities/filetypes/EpwFile.cpp
+++ b/openstudiocore/src/utilities/filetypes/EpwFile.cpp
@@ -214,6 +214,9 @@ std::string EpwDataPoint::units(EpwDataField field)
   case EpwDataField::DewPointTemperature:
     string = "C";
     break;
+  case EpwDataField::RelativeHumidity:
+    //string = "None";
+    break;
   case EpwDataField::AtmosphericStationPressure:
     string = "Pa";
     break;
@@ -253,11 +256,23 @@ std::string EpwDataPoint::units(EpwDataField field)
   case EpwDataField::WindSpeed:
     string = "m/s";
     break;
+  case EpwDataField::TotalSkyCover:
+    //string = "None";
+    break;
+  case EpwDataField::OpaqueSkyCover:
+    //string = "None";
+    break;
   case EpwDataField::Visibility:
     string = "km";
     break;
   case EpwDataField::CeilingHeight:
     string = "m";
+    break;
+  case EpwDataField::PresentWeatherObservation:
+    //string = "None";
+    break;
+  case EpwDataField::PresentWeatherCodes:
+    //string = "None";
     break;
   case EpwDataField::PrecipitableWater:
     string = "mm";
@@ -267,6 +282,12 @@ std::string EpwDataPoint::units(EpwDataField field)
     break;
   case EpwDataField::SnowDepth:
     string = "cm";
+    break;
+  case EpwDataField::DaysSinceLastSnowfall:
+    //string = "None";
+    break;
+  case EpwDataField::Albedo:
+    //string = "None";
     break;
   case EpwDataField::LiquidPrecipitationDepth:
     string = "mm";


### PR DESCRIPTION
@jasondegraw @macumber 

I get the following compiler warning and fixed it by adding a 'default' to the switch statement.

openstudiocore/src/utilities/filetypes/EpwFile.cpp:209:10: warning: 
      6 enumeration values not handled in switch: 'Year', 'Month', 'Day'...
      [-Wswitch]
  switch(field.value())
             ^
1 warning generated.
