### PR TITLE
Update OSM_Diagnostic_Script.rb

### DIFF
--- a/openstudiocore/ruby/openstudio/sketchup_plugin/user_scripts/Reports/OSM_Diagnostic_Script.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/user_scripts/Reports/OSM_Diagnostic_Script.rb
@@ -109,13 +109,13 @@ class DiagnosticScript < OpenStudio::Ruleset::UtilityUserScript
     partition_surfaces = model.getInteriorPartitionSurfaces
     puts "Model has " + partition_surfaces.size.to_s + " interior partition surfaces"
     
-#    puts ""
-#    puts "Outputting Draft Validity Report"
-#    puts workspace.validityReport("Draft".to_StrictnessLevel)
-#
-#    puts ""
-#    puts "Outputting Final Validity Report (note: some errors are expected here)"
-#    puts workspace.validityReport("Final".to_StrictnessLevel)
+    puts ""
+    puts "Outputting Draft Validity Report"
+    puts workspace.validityReport("Draft".to_StrictnessLevel)
+ 
+    puts ""
+    puts "Outputting Final Validity Report (note: some errors are expected here)"
+    puts workspace.validityReport("Final".to_StrictnessLevel)
 
     savediagnostic = false # this will change to true later in script if necessary
 


### PR DESCRIPTION
Per recommendation of David, I have uncommented lines 112 through 118, "...should print a workspace report for draft and final validity and may identify the problem objects that prevent plugin or OS app from opening the model".
