### PR TITLE
Fix translation bug in HeatExchangerFluidToFluid

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeatExchangerFluidToFluid.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeatExchangerFluidToFluid.cpp
@@ -53,10 +53,12 @@ boost::optional<IdfObject> ForwardTranslator::translateHeatExchangerFluidToFluid
   }
 
   // AvailabilityScheduleName
-  boost::optional<Schedule> sched = modelObject.availabilitySchedule();
-  if( (idfo = translateAndMapModelObject(sched.get())) )
+  if( boost::optional<Schedule> sched = modelObject.availabilitySchedule() )
   {
-    idfObject.setString(HeatExchanger_FluidToFluidFields::AvailabilityScheduleName,idfo->name().get());
+    if( (idfo = translateAndMapModelObject(sched.get())) )
+    {
+      idfObject.setString(HeatExchanger_FluidToFluidFields::AvailabilityScheduleName,idfo->name().get());
+    }
   }
 
   // LoopDemandSideInletNode

--- a/openstudiocore/src/model/HeatExchangerFluidToFluid.cpp
+++ b/openstudiocore/src/model/HeatExchangerFluidToFluid.cpp
@@ -416,9 +416,6 @@ HeatExchangerFluidToFluid::HeatExchangerFluidToFluid(const Model& model)
 {
   OS_ASSERT(getImpl<detail::HeatExchangerFluidToFluid_Impl>());
 
-  Schedule s = model.alwaysOnDiscreteSchedule();
-  setAvailabilitySchedule(s);
-
   autosizeLoopDemandSideDesignFlowRate();
   autosizeLoopSupplySideDesignFlowRate();
   setHeatExchangeModelType("Ideal");


### PR DESCRIPTION
The availability schedule of HVAC components is no longer required by
EnergyPlus.  If it is not specified, EnergyPlus will default to always
on.  The OpenStudio code for HeatExchangerFluidToFluid had confusion in
this area.  The model object was initialized with an always on schedule,
while the method returned optional Schedule.  No problem there, except
the E+ translator does not check the optional before tranlsating,
resulting in a crash.

Removed the code to initialize availability schedule in
HeatExchangerFluidToFluid.  Also updated the translator to check if
there is an availability schedule before attempting to translate the
schedule.  This better reflects current E+ convention and new objects
should follow this patter.

[#76734866]
