### PR TITLE
Fix CreateScheduleLibrary Failure

### DIFF
--- a/openstudiocore/ruby/openstudio.rb
+++ b/openstudiocore/ruby/openstudio.rb
@@ -62,6 +62,26 @@ else
   ENV['PATH'] = "#{$OpenStudio_Dir};#{$OpenStudio_Dir}openstudio;#{original_path}"
 end
 
+
+# NOTE: The order of module loading is critically important. The SWIG Ruby module prefers the type
+# information that is loaded *first* instead of the type information that can be considered *best*
+#
+# Example: OpenStudioGBXML references openstudio::model::Container, but does not define it
+# OpenStudioModelCore does define openstudio::model::Container.
+#
+# If OpenStudioGBXML is loaded first, the *incomplete* type information that it contains for Container is loaded.
+# When OpenStudioModelCore is subsequently loaded the *first* version of Container loaded (which is incomplete, from
+# OpenStudioGBXML) is considered the authoritative source of type information.
+#
+# When the code is OpenStudioModelCore, at some point in the future, goes to use the type information for Container
+# an odd, unchecked crash occurs inside of the SWIG generated code.
+#
+# To prevent this problem, make sure the module that defines the type is loaded before the module that uses the type.
+# 
+# True as of Ruby 3.0.1. There probably isn't any better way to handle this issue, so I'd be surprised if it changes
+#
+
+
 # load ruby extensions
 require 'openstudioutilitiescore'
 require 'openstudioutilitieseconomics'
@@ -77,10 +97,6 @@ require 'openstudioutilitiesidd'
 require 'openstudioutilitiesidf'
 require 'openstudioutilitiesfiletypes'
 require 'openstudioutilities'
-require 'openstudioenergyplus'
-require 'openstudioradiance'
-require 'openstudiogbxml'
-require 'openstudiocontam'
 require 'openstudiomodel'
 require 'openstudiomodelcore'
 require 'openstudiomodelsimulation'
@@ -88,6 +104,10 @@ require 'openstudiomodelresources'
 require 'openstudiomodelgeometry'
 require 'openstudiomodelhvac'
 require 'openstudiomodelrefrigeration'
+require 'openstudioenergyplus'
+require 'openstudioradiance'
+require 'openstudiogbxml'
+require 'openstudiocontam'
 require 'openstudioosversion'
 require 'openstudioruleset'
 require 'openstudiorunmanager'

--- a/openstudiocore/ruby/openstudio/examples/CreateScheduleLibrary.rb
+++ b/openstudiocore/ruby/openstudio/examples/CreateScheduleLibrary.rb
@@ -71,10 +71,8 @@ schedules.each { |schedule|
   components.push(newComponent)
 }
 
-# ETH@20121010 - For some reason, the Components are getting deleted out from under the 
-# components vector. The problem does not happen in C++, and the Trace messages I added 
-# to the Component and Component_Impl destructors do not appear in the log.
-  
+
+
 # save components to database
 index = 1
 puts "Saving " + components.size.to_s + " components to " + projectFilepath.to_s + "."

--- a/openstudiocore/ruby/openstudio_dev.rb
+++ b/openstudiocore/ruby/openstudio_dev.rb
@@ -48,6 +48,25 @@ $:.insert(1, $OpenStudio_LibPath)
 $:.insert(2, $OpenStudio_BinaryDir)
 $:.insert(3, $OpenStudio_RubyBinaryDir)
 
+
+# NOTE: The order of module loading is critically important. The SWIG Ruby module prefers the type
+# information that is loaded *first* instead of the type information that can be considered *best*
+#
+# Example: OpenStudioGBXML references openstudio::model::Container, but does not define it
+# OpenStudioModelCore does define openstudio::model::Container.
+#
+# If OpenStudioGBXML is loaded first, the *incomplete* type information that it contains for Container is loaded.
+# When OpenStudioModelCore is subsequently loaded the *first* version of Container loaded (which is incomplete, from
+# OpenStudioGBXML) is considered the authoritative source of type information.
+#
+# When the code is OpenStudioModelCore, at some point in the future, goes to use the type information for Container
+# an odd, unchecked crash occurs inside of the SWIG generated code.
+#
+# To prevent this problem, make sure the module that defines the type is loaded before the module that uses the type.
+# 
+# True as of Ruby 3.0.1. There probably isn't any better way to handle this issue, so I'd be surprised if it changes
+#
+
 # load ruby extensions
 require 'openstudioutilitiescore'
 require 'openstudioutilitieseconomics'
@@ -63,10 +82,6 @@ require 'openstudioutilitiesidd'
 require 'openstudioutilitiesidf'
 require 'openstudioutilitiesfiletypes'
 require 'openstudioutilities'
-require 'openstudioenergyplus'
-require 'openstudioradiance'
-require 'openstudiogbxml'
-require 'openstudiocontam'
 require 'openstudiomodel'
 require 'openstudiomodelcore'
 require 'openstudiomodelsimulation'
@@ -74,6 +89,10 @@ require 'openstudiomodelresources'
 require 'openstudiomodelgeometry'
 require 'openstudiomodelhvac'
 require 'openstudiomodelrefrigeration'
+require 'openstudioenergyplus'
+require 'openstudioradiance'
+require 'openstudiogbxml'
+require 'openstudiocontam'
 require 'openstudioosversion'
 require 'openstudioruleset'
 require 'openstudiorunmanager'


### PR DESCRIPTION
[#78208904] The issue revolves around the load order of ruby modules and
how the SWIG internal type management system handles that. Verbose
comments are port in place in the code to help make sure this kind of
subtle problem is not encountered again.

Please see code comments for more details.
