### PR TITLE
Fix failing HVAC model tests

### DIFF
--- a/openstudiocore/src/model/test/CoilCoolingDXSingleSpeed_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilCoolingDXSingleSpeed_GTest.cpp
@@ -148,9 +148,9 @@ TEST_F(ModelFixture,CoilCoolingDXSingleSpeed_addToNode) {
   CoilCoolingDXSingleSpeed testObject3(m, s, c1_2, c2_2, c3_2, c4_2, c5_2);
 
   if( boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode() ) {
-    EXPECT_FALSE(testObject3.addToNode(*reliefNode));
+    EXPECT_TRUE(testObject3.addToNode(*reliefNode));
     EXPECT_EQ( (unsigned)5, airLoop.supplyComponents().size() );
-    EXPECT_EQ( (unsigned)1, outdoorAirSystem.reliefComponents().size() );
+    EXPECT_EQ( (unsigned)3, outdoorAirSystem.reliefComponents().size() );
   }
 
   // tests and checks to figure out clone bug

--- a/openstudiocore/src/model/test/CoilCoolingDXTwoSpeed_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilCoolingDXTwoSpeed_GTest.cpp
@@ -410,9 +410,9 @@ TEST_F(ModelFixture, CoilCoolingDXTwoSpeed_addToNode)
   CoilCoolingDXTwoSpeed testObject3(m, s, c1_2, c2_2, c3_2, c4_2, c5_2, c6_2, c7_2);
 
   if( boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode() ) {
-    EXPECT_FALSE(testObject3.addToNode(*reliefNode));
+    EXPECT_TRUE(testObject3.addToNode(*reliefNode));
     EXPECT_EQ( (unsigned)5, airLoop.supplyComponents().size() );
-    EXPECT_EQ( (unsigned)1, outdoorAirSystem.reliefComponents().size() );
+    EXPECT_EQ( (unsigned)3, outdoorAirSystem.reliefComponents().size() );
   }
 
   CoilCoolingDXTwoSpeed testObjectClone = testObject.clone(m).cast<CoilCoolingDXTwoSpeed>();

--- a/openstudiocore/src/model/test/CoilHeatingDXSingleSpeed_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilHeatingDXSingleSpeed_GTest.cpp
@@ -124,9 +124,9 @@ TEST_F(ModelFixture,CoilHeatingDXSingleSpeed_addToNode) {
   CoilHeatingDXSingleSpeed testObject3(m, s, c1_2, c2_2, c3_2, c4_2, c5_2);
 
   if( boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode() ) {
-    EXPECT_FALSE(testObject3.addToNode(*reliefNode));
+    EXPECT_TRUE(testObject3.addToNode(*reliefNode));
     EXPECT_EQ( (unsigned)5, airLoop.supplyComponents().size() );
-    EXPECT_EQ( (unsigned)1, outdoorAirSystem.reliefComponents().size() );
+    EXPECT_EQ( (unsigned)3, outdoorAirSystem.reliefComponents().size() );
   }
 
   CoilHeatingDXSingleSpeed testObjectClone = testObject.clone(m).cast<CoilHeatingDXSingleSpeed>();

--- a/openstudiocore/src/model/test/CoilHeatingElectric_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilHeatingElectric_GTest.cpp
@@ -90,9 +90,9 @@ TEST_F(ModelFixture,CoilHeatingElectric_addToNode) {
   }
 
   if( boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode() ) {
-    EXPECT_FALSE(testObject3.addToNode(*reliefNode));
+    EXPECT_TRUE(testObject3.addToNode(*reliefNode));
     EXPECT_EQ( (unsigned)5, airLoop.supplyComponents().size() );
-    EXPECT_EQ( (unsigned)1, outdoorAirSystem.reliefComponents().size() );
+    EXPECT_EQ( (unsigned)3, outdoorAirSystem.reliefComponents().size() );
   }
 
   CoilHeatingElectric testObjectClone = testObject.clone(m).cast<CoilHeatingElectric>();

--- a/openstudiocore/src/model/test/CoilHeatingGas_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilHeatingGas_GTest.cpp
@@ -96,9 +96,9 @@ TEST_F(ModelFixture,CoilHeatingGas_addToNode) {
   }
 
   if( boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode() ) {
-    EXPECT_FALSE(testObject3.addToNode(*reliefNode));
+    EXPECT_TRUE(testObject3.addToNode(*reliefNode));
     EXPECT_EQ( (unsigned)5, airLoop.supplyComponents().size() );
-    EXPECT_EQ( (unsigned)1, outdoorAirSystem.reliefComponents().size() );
+    EXPECT_EQ( (unsigned)3, outdoorAirSystem.reliefComponents().size() );
   }
 
   CoilHeatingGas testObjectClone = testObject.clone(m).cast<CoilHeatingGas>();


### PR DESCRIPTION
These tests have been updated to reflect that components are now allowed
on the relief air stream of the oa system as the result of a recent
enhancement.

[#78202714]
