### PR TITLE
Import design OA spec

### DIFF
--- a/openstudiocore/src/energyplus/ReverseTranslator.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator.cpp
@@ -458,7 +458,9 @@ boost::optional<ModelObject> ReverseTranslator::translateAndMapWorkspaceObject(c
     }
   case openstudio::IddObjectType::DesignSpecification_OutdoorAir :
     {
-      modelObject = translateDesignSpecificationOutdoorAir(workspaceObject);
+      // Call this directly because we don't want to translate all of them
+      // only those that are connected to the SizingZone object
+      //modelObject = translateDesignSpecificationOutdoorAir(workspaceObject);
       break;
     }
   case openstudio::IddObjectType::ElectricEquipment :

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateSizingZone.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateSizingZone.cpp
@@ -140,7 +140,7 @@ OptionalModelObject ReverseTranslator::translateSizingZone( const WorkspaceObjec
 
     target = workspaceObject.getTarget(Sizing_ZoneFields::DesignSpecificationOutdoorAirObjectName);
     if (target){
-      OptionalModelObject mo = translateAndMapWorkspaceObject(*target);
+      OptionalModelObject mo = translateDesignSpecificationOutdoorAir(*target);
       if (mo){
         if (mo->optionalCast<DesignSpecificationOutdoorAir>()){
           std::vector<Space> spaces = thermalZone.spaces();
@@ -249,7 +249,7 @@ OptionalModelObject ReverseTranslator::translateSizingZone( const WorkspaceObjec
     //DesignSpecification_ZoneAirDistribution
 
     boost::optional<WorkspaceObject> _designSpecification 
-        = workspaceObject.getTarget(Sizing_ZoneFields::DesignSpecificationOutdoorAirObjectName);
+        = workspaceObject.getTarget(Sizing_ZoneFields::DesignSpecificationZoneAirDistributionObjectName);
 
     if( _designSpecification )
     {


### PR DESCRIPTION
This change will import design OA spec objects associated with
SizingZone, but not others, such as those associated with
ZoneHVACEquipment, OA Controllers, or others. This means OS created
models will import, but some others may not bring in all instances of
design OA spec, because OS does not support design OA spec directly on
equipment.

Also fix an issue importing DesignSpecification_ZoneAirDistribution
which was trying to incorrectly pull data from the OA spec object
instead of the zone air distribution object.
