### PR TITLE
update regex to find energyplus with dots

### DIFF
--- a/openstudiocore/ruby/openstudio/energyplus/find_energyplus.rb
+++ b/openstudiocore/ruby/openstudio/energyplus/find_energyplus.rb
@@ -70,7 +70,7 @@ module OpenStudio
     def find_energyplus(major_version, minor_version, build_version = '.*')
 
       # version matches either internal or official releases
-      version = "#{major_version}-#{minor_version}-0[-]?#{build_version}"
+      version = "#{major_version}[-\.]#{minor_version}[-\.]0[-\.]?#{build_version}"
 
       # default search paths by system
       potential_paths = []


### PR DESCRIPTION
@macumber I know that we are talking about a better way to handle this, but for now, can you allow `.` in the find_energyplus path?

Note that EnergyPlus 8.2 installer does use dashes, I just override them to follow the dot convention.

```
root@d90a48a16aca:/usr/local# ls -alt
total 532
drwxr-xr-x  2 root root   4096 Oct  3 01:02 bin
drwxr-xr-x 22 root root   4096 Oct  3 01:02 .
drwxr-xr-x  9 root root   4096 Oct  3 01:02 EnergyPlus-8.2.0
drwxr-xr-x  9 root root   4096 Oct  3 00:46 EnergyPlus-8.1.0
```
