### PR TITLE
[#81405496] Do not allow inspection of GridView name column in IG.

### DIFF
--- a/openstudiocore/src/openstudio_lib/RefrigerationGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/RefrigerationGridView.cpp
@@ -563,6 +563,7 @@ void RefrigerationCaseGridController::addColumns(std::vector<QString> & fields)
       //boost::optional<CurveCubic> defrostEnergyCorrectionCurve() const; TODO
     }else if(field == NAME){
       addNameLineEditColumn(QString(NAME),
+                            false,
                             CastNullAdapter<model::RefrigerationCase>(&model::RefrigerationCase::name),
                             CastNullAdapter<model::RefrigerationCase>(&model::RefrigerationCase::setName));
     }else{
@@ -947,8 +948,9 @@ void RefrigerationWalkInGridController::addColumns(std::vector<QString> & fields
       //std::vector<RefrigerationWalkInZoneBoundary> zoneBoundaries() const; TODO
     }else if(field == NAME){
       addNameLineEditColumn(QString(NAME),
-                              CastNullAdapter<model::RefrigerationWalkIn>(&model::RefrigerationWalkIn::name),
-                              CastNullAdapter<model::RefrigerationWalkIn>(&model::RefrigerationWalkIn::setName));
+                            false,
+                            CastNullAdapter<model::RefrigerationWalkIn>(&model::RefrigerationWalkIn::name),
+                            CastNullAdapter<model::RefrigerationWalkIn>(&model::RefrigerationWalkIn::setName));
     }else if(field == RACK){
       addComboBoxColumn<model::RefrigerationSystem,model::RefrigerationWalkIn>(
           QString(RACK),

--- a/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
@@ -246,6 +246,7 @@ void SpaceTypesGridController::addColumns(std::vector<QString> & fields)
       auto setter = CastNullAdapter<model::SpaceType>(&model::SpaceType::setName);
 
       addNameLineEditColumn(QString(NAME),
+        false,
         getter,
         setter);
 
@@ -890,6 +891,7 @@ void SpaceTypesGridController::addColumns(std::vector<QString> & fields)
         );
 
         addNameLineEditColumn(QString(DEFINITION),
+          true,
           CastNullAdapter<model::SpaceLoadDefinition>(&model::SpaceLoadDefinition::name),
           CastNullAdapter<model::SpaceLoadDefinition>(&model::SpaceLoadDefinition::setName),
           boost::optional<std::function<void (model::SpaceLoadDefinition *)>>(),
@@ -966,6 +968,7 @@ void SpaceTypesGridController::addColumns(std::vector<QString> & fields)
       );
 
       addNameLineEditColumn(QString(SPACEINFILTRATIONDESIGNFLOWRATES),
+        true,
         CastNullAdapter<model::SpaceInfiltrationDesignFlowRate>(&model::SpaceInfiltrationDesignFlowRate::name),
         CastNullAdapter<model::SpaceInfiltrationDesignFlowRate>(&model::SpaceInfiltrationDesignFlowRate::setName),
         boost::optional<std::function<void (model::SpaceInfiltrationDesignFlowRate *)>>(
@@ -1000,6 +1003,7 @@ void SpaceTypesGridController::addColumns(std::vector<QString> & fields)
       );
 
       addNameLineEditColumn(QString(SPACEINFILTRATIONEFFECTIVELEAKAGEAREAS),
+        true,
         CastNullAdapter<model::SpaceInfiltrationEffectiveLeakageArea>(&model::SpaceInfiltrationEffectiveLeakageArea::name),
         CastNullAdapter<model::SpaceInfiltrationEffectiveLeakageArea>(&model::SpaceInfiltrationEffectiveLeakageArea::setName),
         boost::optional<std::function<void(model::SpaceInfiltrationEffectiveLeakageArea *)>>(

--- a/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
@@ -599,6 +599,7 @@ void ThermalZonesGridController::addColumns(std::vector<QString> & fields)
       );
 
       addNameLineEditColumn(QString(ZONEEQUIPMENT),
+        false,
         CastNullAdapter<model::ModelObject>(&model::ModelObject::name),
         CastNullAdapter<model::ModelObject>(&model::ModelObject::setName),
         boost::optional<std::function<void(model::ModelObject *)>>(
@@ -619,6 +620,7 @@ void ThermalZonesGridController::addColumns(std::vector<QString> & fields)
 
     }else if(field == NAME){
       addNameLineEditColumn(QString(NAME),
+                            true,
                             CastNullAdapter<model::ThermalZone>(&model::ThermalZone::name),
                             CastNullAdapter<model::ThermalZone>(&model::ThermalZone::setName),
                             boost::optional<std::function<void (model::ThermalZone *)>>());
@@ -627,6 +629,7 @@ void ThermalZonesGridController::addColumns(std::vector<QString> & fields)
       // Notes: this only requires a static_cast because `name` comes from IdfObject
       // we are passing in an empty std::function for the separate parameter because there's no way to set it
       addNameLineEditColumn(QString(AIRLOOPNAME),
+                            true,
                             ProxyAdapter(static_cast<boost::optional<std::string> (model::AirLoopHVAC::*)(bool) const>(&model::AirLoopHVAC::name), 
                               &model::ThermalZone::airLoopHVAC, boost::optional<std::string>("None")),
                             std::function<boost::optional<std::string>(model::HVACComponent*, const std::string &)>(),

--- a/openstudiocore/src/shared_gui_components/OSConcepts.hpp
+++ b/openstudiocore/src/shared_gui_components/OSConcepts.hpp
@@ -991,8 +991,10 @@ class NameLineEditConcept : public BaseConcept
 {
   public:
 
-  NameLineEditConcept(QString t_headingLabel)
-    : BaseConcept(t_headingLabel)
+  NameLineEditConcept(QString t_headingLabel,
+    bool isInspectable)
+    : BaseConcept(t_headingLabel),
+    m_isInspectable(isInspectable)
   {
   }
 
@@ -1002,6 +1004,12 @@ class NameLineEditConcept : public BaseConcept
   virtual boost::optional<std::string> set(const ConceptProxy & obj, const std::string &) = 0;
   virtual void reset(const ConceptProxy & obj) = 0;
   virtual bool readOnly() const = 0;
+  bool isInspectable() { return m_isInspectable; }
+
+  private:
+
+  bool m_isInspectable;
+
 };
 
 template<typename DataSourceType>
@@ -1010,10 +1018,12 @@ class NameLineEditConceptImpl : public NameLineEditConcept
   public:
 
   NameLineEditConceptImpl(QString t_headingLabel,
+    bool isInspectable,
     std::function<boost::optional<std::string> (DataSourceType *, bool)>  t_getter,
     std::function<boost::optional<std::string> (DataSourceType *, const std::string &)> t_setter,
     boost::optional<std::function<void(DataSourceType*)> > t_reset = boost::none)
-    : NameLineEditConcept(t_headingLabel),
+    : NameLineEditConcept(t_headingLabel,
+      isInspectable),
       m_getter(t_getter),
       m_setter(t_setter),
       m_reset(t_reset)

--- a/openstudiocore/src/shared_gui_components/OSGridController.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.cpp
@@ -331,14 +331,16 @@ QWidget * OSGridController::makeWidget(model::ModelObject t_mo, const QSharedPoi
                        nameLineEditConcept->readOnly() ? boost::none : boost::optional<StringSetter>(std::bind(&NameLineEditConcept::set,nameLineEditConcept.data(),t_mo,std::placeholders::_1)),
                        boost::optional<NoFailAction>(std::bind(&NameLineEditConcept::reset, nameLineEditConcept.data(), t_mo)));
 
-    isConnected = connect(nameLineEdit, SIGNAL(itemClicked(OSItem*)), gridView(), SIGNAL(dropZoneItemClicked(OSItem*)));
-    OS_ASSERT(isConnected);
+    if (nameLineEditConcept->isInspectable()) {
+      isConnected = connect(nameLineEdit, SIGNAL(itemClicked(OSItem*)), gridView(), SIGNAL(dropZoneItemClicked(OSItem*)));
+      OS_ASSERT(isConnected);
 
-    isConnected = connect(nameLineEdit, SIGNAL(itemClicked(OSItem*)), this, SLOT(onDropZoneItemClicked(OSItem*)));
-    OS_ASSERT(isConnected);
+      isConnected = connect(nameLineEdit, SIGNAL(itemClicked(OSItem*)), this, SLOT(onDropZoneItemClicked(OSItem*)));
+      OS_ASSERT(isConnected);
 
-    isConnected = connect(nameLineEdit, SIGNAL(objectRemoved(boost::optional<model::ParentObject>)), this, SLOT(onObjectRemoved(boost::optional<model::ParentObject>)));
-    OS_ASSERT(isConnected);
+      isConnected = connect(nameLineEdit, SIGNAL(objectRemoved(boost::optional<model::ParentObject>)), this, SLOT(onObjectRemoved(boost::optional<model::ParentObject>)));
+      OS_ASSERT(isConnected);
+    }
 
     widget = nameLineEdit;
 

--- a/openstudiocore/src/shared_gui_components/OSGridController.hpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.hpp
@@ -336,12 +336,13 @@ public:
 
   template<typename DataSourceType>
   void addNameLineEditColumn(QString headingLabel,
+                             bool isInspectable,
                              const std::function<boost::optional<std::string> (DataSourceType *, bool)>  &getter,
                              const std::function<boost::optional<std::string> (DataSourceType *, const std::string &)> &setter,
                              const boost::optional<std::function<void (DataSourceType *)>> &resetter = boost::none,
                              const boost::optional<DataSource> &t_source = boost::none)
   {
-    m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<NameLineEditConcept>(new NameLineEditConceptImpl<DataSourceType>(headingLabel,getter,setter,resetter)), t_source));
+    m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<NameLineEditConcept>(new NameLineEditConceptImpl<DataSourceType>(headingLabel, isInspectable, getter, setter, resetter)), t_source));
   }
 
   template<typename DataSourceType>


### PR DESCRIPTION
@kbenne would you mind taking a look at this?  I think that it appropriately fixes the above-mentioned bug.
