### PR TITLE
Fix remote execution of moved PAT Projects

### DIFF
--- a/openstudiocore/src/runmanager/lib/RunManager_Impl.cpp
+++ b/openstudiocore/src/runmanager/lib/RunManager_Impl.cpp
@@ -1106,7 +1106,7 @@ namespace detail {
           // don't let boost mess with us in the string/path converions
           return t_path;
         } else {
-          return openstudio::toString(t_path);
+          return openstudio::toString(fixedUp);
         }
       }
 


### PR DESCRIPTION
This came up while investigating the "Measures Have Two Required Files"
bug [#80045638] #1219 .

The measures only had two required files when attempting to execute a PAT
Project on the cloud which had been moved from its original location.

This change is extremely small, but might have unforseen cloud impact. It
does fix the known issue in my tests, however.

The previous fix for path fixing up was a bit overzealous
https://github.com/NREL/OpenStudio/commit/7eb7585b3856527bfb6b1fb4d0990b42dcf244bd
as it never actually returned the fixed-up path.

@macumber
