### PR TITLE
Adjust PIU fan schedule

### DIFF
--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -23,6 +23,16 @@
 #include "AirLoopHVACSupplyPlenum_Impl.hpp"
 #include "AirLoopHVACReturnPlenum.hpp"
 #include "AirLoopHVACReturnPlenum_Impl.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp"
+#include "AirTerminalSingleDuctParallelPIUReheat.hpp"
+#include "AirTerminalSingleDuctParallelPIUReheat_Impl.hpp"
+#include "FanConstantVolume.hpp"
+#include "FanConstantVolume_Impl.hpp"
+#include "FanVariableVolume.hpp"
+#include "FanVariableVolume_Impl.hpp"
+#include "FanOnOff.hpp"
+#include "FanOnOff_Impl.hpp"
 #include "SizingSystem.hpp"
 #include "SizingSystem_Impl.hpp"
 #include "Node.hpp"
@@ -883,6 +893,16 @@ namespace detail {
   void AirLoopHVAC_Impl::setAvailabilitySchedule(Schedule & schedule)
   {
     availabilityManagerAssignmentList().availabilityManagerScheduled().setSchedule(schedule);
+
+    auto seriesPIUs = subsetCastVector<AirTerminalSingleDuctSeriesPIUReheat>(demandComponents(AirTerminalSingleDuctSeriesPIUReheat::iddObjectType()));
+    for( auto & piu : seriesPIUs ) {
+      piu.getImpl<detail::AirTerminalSingleDuctSeriesPIUReheat_Impl>()->setFanAvailabilitySchedule(schedule);
+    }
+
+    auto parallelPIUs = subsetCastVector<AirTerminalSingleDuctParallelPIUReheat>(demandComponents(AirTerminalSingleDuctParallelPIUReheat::iddObjectType()));
+    for( auto & piu : parallelPIUs ) {
+      piu.getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->setFanAvailabilitySchedule(schedule);
+    }
   }
   
   bool AirLoopHVAC_Impl::setNightCycleControlType(std::string controlType)

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
@@ -21,6 +21,12 @@
 #include "AirTerminalSingleDuctParallelPIUReheat_Impl.hpp"
 #include "AirLoopHVACReturnPlenum.hpp"
 #include "AirLoopHVACReturnPlenum_Impl.hpp"
+#include "FanConstantVolume.hpp"
+#include "FanConstantVolume_Impl.hpp"
+#include "FanVariableVolume.hpp"
+#include "FanVariableVolume_Impl.hpp"
+#include "FanOnOff.hpp"
+#include "FanOnOff_Impl.hpp"
 #include "Schedule.hpp"
 #include "Schedule_Impl.hpp"
 #include "Node.hpp"
@@ -464,6 +470,11 @@ namespace detail {
                 thermalZone->addEquipment(mo);
               }
 
+              if( auto airLoopHVAC = node.airLoopHVAC() ) {
+                auto schedule = airLoopHVAC->availabilitySchedule();
+                setFanAvailabilitySchedule(schedule);
+              }
+
               return true; 
             }
           }
@@ -630,6 +641,17 @@ namespace detail {
 
     return result;
   }
+
+  void AirTerminalSingleDuctParallelPIUReheat_Impl::setFanAvailabilitySchedule(Schedule & schedule) {
+    auto component = fan();
+    if( auto constantFan = component.optionalCast<FanConstantVolume>() ) {
+      constantFan->setAvailabilitySchedule(schedule);
+    } else if(  auto onOffFan = component.optionalCast<FanOnOff>() ) {
+      onOffFan->setAvailabilitySchedule(schedule);
+    } else if( auto variableFan = component.optionalCast<FanVariableVolume>() ) {
+      variableFan->setAvailabilitySchedule(schedule);
+    }
+  };
 
 } // detail
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat_Impl.hpp
@@ -174,6 +174,8 @@ namespace detail {
     // Use carefully.  Removing (or moving) plenum will leave model in invalid state
     bool setInducedAirPlenumZone(ThermalZone & thermalZone);
 
+    void setFanAvailabilitySchedule(Schedule & schedule);
+
     //@}
    protected:
    private:

--- a/openstudiocore/src/model/AirTerminalSingleDuctSeriesPIUReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctSeriesPIUReheat.cpp
@@ -21,6 +21,12 @@
 #include "AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp"
 #include "AirLoopHVACReturnPlenum.hpp"
 #include "AirLoopHVACReturnPlenum_Impl.hpp"
+#include "FanVariableVolume.hpp"
+#include "FanVariableVolume_Impl.hpp"
+#include "FanConstantVolume.hpp"
+#include "FanConstantVolume_Impl.hpp"
+#include "FanOnOff.hpp"
+#include "FanOnOff_Impl.hpp"
 #include "Model.hpp"
 #include "Model_Impl.hpp"
 #include "PortList.hpp"
@@ -377,6 +383,11 @@ namespace detail {
                 thermalZone->addEquipment(mo);
               }
 
+              if( auto airLoopHVAC = node.airLoopHVAC() ) {
+                auto schedule = airLoopHVAC->availabilitySchedule();
+                setFanAvailabilitySchedule(schedule);
+              }
+
               return true; 
             }
           }
@@ -462,6 +473,17 @@ namespace detail {
 
     return result;
   }
+
+  void AirTerminalSingleDuctSeriesPIUReheat_Impl::setFanAvailabilitySchedule(Schedule & schedule) {
+    auto component = fan();
+    if( auto constantFan = component.optionalCast<FanConstantVolume>() ) {
+      constantFan->setAvailabilitySchedule(schedule);
+    } else if(  auto onOffFan = component.optionalCast<FanOnOff>() ) {
+      onOffFan->setAvailabilitySchedule(schedule);
+    } else if( auto variableFan = component.optionalCast<FanVariableVolume>() ) {
+      variableFan->setAvailabilitySchedule(schedule);
+    }
+  };
 
 } // detail
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp
@@ -136,6 +136,7 @@ namespace detail {
     bool addToNode(Node & node);
     std::vector<ModelObject> children() const;
     ModelObject clone(Model model) const;
+    void setFanAvailabilitySchedule(Schedule & schedule);
 
     // This is a non publlic method to draw recirculation air from a plenum
     // Use carefully.  Removing (or moving) plenum will leave model in invalid state

--- a/openstudiocore/src/model/test/AirTerminalSingleDuctSeriesPIUReheat_GTest.cpp
+++ b/openstudiocore/src/model/test/AirTerminalSingleDuctSeriesPIUReheat_GTest.cpp
@@ -31,6 +31,8 @@
 #include "../FanConstantVolume_Impl.hpp"
 #include "../CoilHeatingElectric.hpp"
 #include "../CoilHeatingElectric_Impl.hpp"
+#include "../ScheduleRuleset.hpp"
+#include "../ScheduleRuleset_Impl.hpp"
 #include "../Model.hpp"
 #include "../Model_Impl.hpp"
 
@@ -85,6 +87,42 @@ TEST_F(ModelFixture,AirTerminalSingleDuctSeriesPIUReheat)
 
     EXPECT_NE(terminalClone.reheatCoil(),terminal.reheatCoil());
     EXPECT_NE(terminalClone.fan(),terminal.fan());
+  }
+
+  // test that setAvailabilitySchedule also set PIU fan schedule
+  {
+    Model m; 
+    Schedule schedule = m.alwaysOnDiscreteSchedule();
+    FanConstantVolume fan(m,schedule);
+    CoilHeatingElectric coil(m,schedule);
+    AirTerminalSingleDuctSeriesPIUReheat terminal(m,fan,coil);
+
+    AirLoopHVAC airLoopHVAC(m);
+    airLoopHVAC.addBranchForHVACComponent(terminal);
+
+    ScheduleRuleset hvacSchedule(m);
+    airLoopHVAC.setAvailabilitySchedule(hvacSchedule);
+
+    auto fanSchedule = fan.availabilitySchedule();
+    ASSERT_EQ(hvacSchedule.handle(),fanSchedule.handle()); 
+  }
+
+  // test that addToNode (by proxy addBranchForHVACComponent) sets the fan schedule to match system availabilitySchedule
+  {
+    Model m; 
+    Schedule schedule = m.alwaysOnDiscreteSchedule();
+    FanConstantVolume fan(m,schedule);
+    CoilHeatingElectric coil(m,schedule);
+    AirTerminalSingleDuctSeriesPIUReheat terminal(m,fan,coil);
+
+    AirLoopHVAC airLoopHVAC(m);
+
+    ScheduleRuleset hvacSchedule(m);
+    airLoopHVAC.setAvailabilitySchedule(hvacSchedule);
+
+    airLoopHVAC.addBranchForHVACComponent(terminal);
+    auto fanSchedule = fan.availabilitySchedule();
+    ASSERT_EQ(hvacSchedule.handle(),fanSchedule.handle()); 
   }
 }
 


### PR DESCRIPTION
When setting AirLoopHVAC::availabilitySchedule or when adding a new piu
terminal to an existing AirLoopHVAC, make sure the piu fan matches the
system availability schedule.  This is especially useful when night
cycle option is used on the AirLoopHVAC system.

A user can still set the fan availabilty schedule directly to ovrride
this default behavior.

[#84632652]