### PR TITLE
Fix min oa schedule complications

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateControllerMechanicalVentilation.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateControllerMechanicalVentilation.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- *  Copyright (c) 2008-2015, Alliance for Sustainable Energy.
+ *  Copyright (c) 2008-2014, Alliance for Sustainable Energy.
  *  All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
@@ -64,10 +64,35 @@ boost::optional<IdfObject> ForwardTranslator::translateControllerMechanicalVenti
   }
 
   // Availability Schedule
-  Schedule availabilitySchedule = modelObject.availabilitySchedule();
-  boost::optional<IdfObject> availabilityScheduleIdf = translateAndMapModelObject(availabilitySchedule);
-  if( availabilityScheduleIdf )
-  {
+  // If there is a ControllerOutdoorAir::minimumOutdoorAirSchedule 
+  // then use that for the ControllerMechanicalVentilation::availabilitySchedule
+  // Note that this scheme will not support fractions (schedule values above 0) because anything greater than 0 will
+  // make the mechanical ventilation controller avaiable and thus taking precedence.
+  bool useAvailabiltySchedule = true;
+
+  // Find the associated oa controller
+  auto oaControllers = modelObject.model().getConcreteModelObjects<ControllerOutdoorAir>();
+  auto predicate = [&] (const ControllerOutdoorAir & oaController) {
+    auto mechanicalVentilationController = oaController.controllerMechanicalVentilation();
+    if( mechanicalVentilationController.handle() == modelObject.handle() ) {
+      return true;
+    }
+    return false;
+  };
+  auto oaController = std::find_if(oaControllers.begin(),oaControllers.end(),predicate);
+  if( oaController != oaControllers.end() ) {
+    if( auto minOASchedule = oaController->minimumOutdoorAirSchedule() ) {
+      auto _schedule = translateAndMapModelObject(minOASchedule.get());
+      OS_ASSERT(_schedule);
+      idfObject.setString(Controller_MechanicalVentilationFields::AvailabilityScheduleName,_schedule->name().get());
+      useAvailabiltySchedule = false;
+    }
+  }
+
+  if( useAvailabiltySchedule ) {
+    Schedule availabilitySchedule = modelObject.availabilitySchedule();
+    boost::optional<IdfObject> availabilityScheduleIdf = translateAndMapModelObject(availabilitySchedule);
+    OS_ASSERT(availabilityScheduleIdf);
     idfObject.setString(openstudio::Controller_MechanicalVentilationFields::AvailabilityScheduleName,availabilityScheduleIdf->name().get());
   }
 


### PR DESCRIPTION
ControllerOutdoorAir::miniimumOutdoorAirSchedule has not generally had
an effect on turning off ventilation during off hours.  This is because
ControllerMechanicalVentilation overpowers the minimum oa schedule and
OpenStudio consistently prefers to write the
ControllerMechanicalVentilation.  To rectify this situation, if there is
a ControllerOutdoorAir::minimumOutdoorAirSchedule, then that schedule
will now also be written to the
ControllerMechanicalVentilation::AvailabilitySchedule field when
exporting the idf.  This will disable the mechanical ventilation
controller for periods when minimuOutdoorAirSchedule is zero, thereby
removing its interference.  Fractional schedule values will still not
have this benefit.

[#84418526]

See also https://github.com/NREL/EnergyPlus/issues/4633