### PR TITLE
Improve IG validation

### DIFF
--- a/openstudiocore/src/model_editor/InspectorGadget.cpp
+++ b/openstudiocore/src/model_editor/InspectorGadget.cpp
@@ -648,32 +648,42 @@ void InspectorGadget::layoutText( QVBoxLayout* layout,
       if(prop.minBoundType != IddFieldProperties::Unbounded)
       {
         double d = *(prop.minBoundValue);
-        if(prop.minBoundType == IddFieldProperties::ExclusiveBound) {
-          d = d + std::numeric_limits<double>::epsilon();
-        }
         if (m_unitSystem == IP) {
           OptionalQuantity minQ = convert(Quantity(d,u_si),u);
+          if(prop.minBoundType == IddFieldProperties::ExclusiveBound) {
+            if( minQ ) {
+              minQ->setValue(minQ->value() + std::numeric_limits<double>::epsilon());
+            }
+          }
           if (minQ) {
             text->setMin(minQ->value());
           }
         }
         else {
-          text->setMin( d );
+          if(prop.minBoundType == IddFieldProperties::ExclusiveBound) {
+            d = d + std::numeric_limits<double>::epsilon();
+            text->setMin( d );
+          }
         }
       }
       if(prop.maxBoundType != IddFieldProperties::Unbounded)
       { 
         double d = *(prop.maxBoundValue);
-        if(prop.maxBoundType == IddFieldProperties::ExclusiveBound) {
-          d = d - std::numeric_limits<double>::epsilon();
-        }
         if (m_unitSystem == IP) {
           OptionalQuantity maxQ = convert(Quantity(d,u_si),u);
+          if( maxQ ) {
+            if(prop.maxBoundType == IddFieldProperties::ExclusiveBound) {
+              maxQ->setValue(maxQ->value() - std::numeric_limits<double>::epsilon());
+            }
+          }
           if (maxQ) {
             text->setMax(maxQ->value());
           }
         }
         else {
+          if(prop.maxBoundType == IddFieldProperties::ExclusiveBound) {
+            d = d - std::numeric_limits<double>::epsilon();
+          }
           text->setMax( d );
         }
       }

--- a/openstudiocore/src/model_editor/InspectorGadget.cpp
+++ b/openstudiocore/src/model_editor/InspectorGadget.cpp
@@ -662,8 +662,8 @@ void InspectorGadget::layoutText( QVBoxLayout* layout,
         else {
           if(prop.minBoundType == IddFieldProperties::ExclusiveBound) {
             d = d + std::numeric_limits<double>::epsilon();
-            text->setMin( d );
           }
+          text->setMin( d );
         }
       }
       if(prop.maxBoundType != IddFieldProperties::Unbounded)

--- a/openstudiocore/src/model_editor/InspectorGadget.cpp
+++ b/openstudiocore/src/model_editor/InspectorGadget.cpp
@@ -648,6 +648,9 @@ void InspectorGadget::layoutText( QVBoxLayout* layout,
       if(prop.minBoundType != IddFieldProperties::Unbounded)
       {
         double d = *(prop.minBoundValue);
+        if(prop.minBoundType == IddFieldProperties::ExclusiveBound) {
+          d = d + std::numeric_limits<double>::epsilon();
+        }
         if (m_unitSystem == IP) {
           OptionalQuantity minQ = convert(Quantity(d,u_si),u);
           if (minQ) {
@@ -661,6 +664,9 @@ void InspectorGadget::layoutText( QVBoxLayout* layout,
       if(prop.maxBoundType != IddFieldProperties::Unbounded)
       { 
         double d = *(prop.maxBoundValue);
+        if(prop.maxBoundType == IddFieldProperties::ExclusiveBound) {
+          d = d - std::numeric_limits<double>::epsilon();
+        }
         if (m_unitSystem == IP) {
           OptionalQuantity maxQ = convert(Quantity(d,u_si),u);
           if (maxQ) {


### PR DESCRIPTION
Some autosizable fields were reported to not accept 0 as a value.
Change from autosize to hardsize with 0, and the IG would appear to
accept that.  But leave IG and come back and you will find that the
field is still set to autosize.

The root of this problem seems to be that some idd fields use exclusive
limits.  ie > not >=.  However the IG input field validators don't
discern the difference and therefore just default to inclusive limits.
This lets the IG interface lead you to believe you set a value that
really didn't validate and get written to the model.

This is a change to to add / subtract epsilon if the limit is exclusive,
so that you will know right away if a value is not accepted.

[fix #85606174]
fix #1286