### PR TITLE
I had hoped to fix all the size_t to int warnings in the project but tha...

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -307,13 +307,18 @@ if(MSVC)
   # be linked against the same runtime
   add_definitions(/wd4251)
   
-  if(NOT CMAKE_CL_64)
-    # treat warnings as errors
-    add_definitions(/WX)
-  else()
-    add_definitions(/bigobj)
-  endif()
+  if(CMAKE_CL_64)
 
+    add_definitions(/bigobj)
+    
+    # ignore conversion from size_t to int for now
+    add_definitions(/wd4267)  
+
+  endif()
+  
+  # treat warnings as errors
+  add_definitions(/WX)
+    
   # ignore warnings about the stl being insecure
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 

--- a/openstudiocore/src/expat/CMakeLists.txt
+++ b/openstudiocore/src/expat/CMakeLists.txt
@@ -19,6 +19,9 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/l
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  
+  # Disable warning about conversion to int in expat
+  add_definitions(/wd4244)
 endif()
 
 set(zkexpat_SRCS

--- a/openstudiocore/src/utilities/core/Finder.hpp
+++ b/openstudiocore/src/utilities/core/Finder.hpp
@@ -103,7 +103,7 @@ namespace openstudio{
     typename std::vector<T>::const_iterator it;
     it = find_if(vec.begin(),vec.end(),finder);
     if (it != vec.end()) {
-      index = it - vec.begin();
+      index = (int)(it - vec.begin());
     }
     return index;
   }


### PR DESCRIPTION
...t is just not feasible.  Going forward I am not hot about converting all the APIs to size_t or fixing all of these errors.  Therefore, I just selectively disabled this warning so we can turn /WX back on for MSVC 64 bit builds