### PR TITLE
86956490 spm magic

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator.hpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.hpp
@@ -793,6 +793,10 @@ class ENERGYPLUS_API ForwardTranslator {
   void resolveMatchedSurfaceConstructionConflicts(model::Model& model);
   void resolveMatchedSubSurfaceConstructionConflicts(model::Model& model);
 
+  // ugly hack to fix upstream mixed air setpoint managers that have internal fans
+  // This should be used by the various translateUnitaryFoo methods.
+  void fixSPMsForUnitarySystem(const model::HVACComponent & unitary,const std::string & fanInletNodeName, const std::string & FanOutletNodeName);
+
   void createStandardOutputRequests();
 
   std::string stripOS2(const std::string& s);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
@@ -90,83 +90,84 @@ namespace openstudio {
 
 namespace energyplus {
 
-boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVAC( AirLoopHVAC & airLoopHVAC )
+// Attempt to add all required setpoint managers upstream of the supply outlet node.
+// This algorithm requires there to be a setpoint manager on the supply outlet node.
+// This is a good method to consider adding to Model, as a method of AirLoopHVAC class.
+void addRequiredSetpointManagers(const AirLoopHVAC & airLoopHVAC)
 {
-  // First fixup a few things about the AirLoopHVAC Model object.
-  // Add necessary setpoint managers if they are not provided by model.
-  
-  Model t_model = airLoopHVAC.model();
-
-  auto fanOrUnitary = airLoopHVAC.supplyFan();
-  auto supplyComponents = airLoopHVAC.supplyComponents();
-
-  if( ! fanOrUnitary ) {
-    auto airLoopHVACUnitarySystems = subsetCastVector<AirLoopHVACUnitarySystem>(supplyComponents);
-    if( ! airLoopHVACUnitarySystems.empty() ) {
-      auto unitary = airLoopHVACUnitarySystems.back();
-      if( unitary.supplyFan() ) {
-        fanOrUnitary = unitary;
-      }
-    }
-  }
-
-  if( ! fanOrUnitary ) {
-    auto airLoopHVACUnitaryHeatCoolVAVChangeoverBypass = subsetCastVector<AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass>(supplyComponents);
-    if( ! airLoopHVACUnitaryHeatCoolVAVChangeoverBypass.empty() ) {
-      fanOrUnitary = airLoopHVACUnitaryHeatCoolVAVChangeoverBypass.back();
-    }
-  }
-
-  if( ! fanOrUnitary ) {
-    auto airLoopHVACUnitaryHeatPumpAirToAir = subsetCastVector<AirLoopHVACUnitaryHeatPumpAirToAir>(supplyComponents);
-    if( ! airLoopHVACUnitaryHeatPumpAirToAir.empty() ) {
-      fanOrUnitary = airLoopHVACUnitaryHeatPumpAirToAir.back();
-    }
-  }
-
-  if( ! fanOrUnitary ) {
-    auto airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed = subsetCastVector<AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed>(supplyComponents);
-    if( ! airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.empty() ) {
-      fanOrUnitary = airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.back();
-    }
-  }
-
-  std::vector<Node> upperNodes;
-  std::vector<Node> lowerNodes;
-  if( fanOrUnitary )
-  {
-    upperNodes = subsetCastVector<Node>(airLoopHVAC.supplyComponents(airLoopHVAC.supplyInletNode(),fanOrUnitary.get()));
-    upperNodes.erase(upperNodes.begin());
-    lowerNodes = subsetCastVector<Node>(airLoopHVAC.supplyComponents(fanOrUnitary.get(),airLoopHVAC.supplyOutletNode()));
-    lowerNodes.erase(lowerNodes.end() - 1);
-  }
-  else
-  {
-    // Note if we don't have a fan this is going to be a problem for EnergyPlus,
-    // but at this point it will be allowed in OS
-    lowerNodes = subsetCastVector<Node>(supplyComponents);
-    // We should at least have a supply inlet and outlet node
-    OS_ASSERT(lowerNodes.size() >= 2);
-    lowerNodes.erase(lowerNodes.begin());
-    lowerNodes.erase(lowerNodes.end() - 1);
-  }
-
-  auto isTemperatureControl = [] ( SetpointManager & spm ) -> bool {
-    return istringEqual("Temperature",spm.controlVariable());
-  };
-
-  for( auto & upperNode : upperNodes )
-  {
-    std::vector<SetpointManager> _setpointManagers = upperNode.setpointManagers();
-    if( std::find_if(_setpointManagers.begin(),_setpointManagers.end(),isTemperatureControl) == _setpointManagers.end() ) {
-      SetpointManagerMixedAir spm(t_model);
-      spm.addToNode(upperNode);
-    }
-  } 
-
   std::vector<SetpointManager> _supplyOutletSetpointManagers = airLoopHVAC.supplyOutletNode().setpointManagers();
   if( ! _supplyOutletSetpointManagers.empty() )
   {
+    auto t_model = airLoopHVAC.model();
+    auto supplyComponents = airLoopHVAC.supplyComponents();
+
+    auto fanOrUnitary = airLoopHVAC.supplyFan();
+
+    if( ! fanOrUnitary ) {
+      auto airLoopHVACUnitarySystems = subsetCastVector<AirLoopHVACUnitarySystem>(supplyComponents);
+      if( ! airLoopHVACUnitarySystems.empty() ) {
+        auto unitary = airLoopHVACUnitarySystems.back();
+        if( unitary.supplyFan() ) {
+          fanOrUnitary = unitary;
+        }
+      }
+    }
+
+    if( ! fanOrUnitary ) {
+      auto airLoopHVACUnitaryHeatCoolVAVChangeoverBypass = subsetCastVector<AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass>(supplyComponents);
+      if( ! airLoopHVACUnitaryHeatCoolVAVChangeoverBypass.empty() ) {
+        fanOrUnitary = airLoopHVACUnitaryHeatCoolVAVChangeoverBypass.back();
+      }
+    }
+
+    if( ! fanOrUnitary ) {
+      auto airLoopHVACUnitaryHeatPumpAirToAir = subsetCastVector<AirLoopHVACUnitaryHeatPumpAirToAir>(supplyComponents);
+      if( ! airLoopHVACUnitaryHeatPumpAirToAir.empty() ) {
+        fanOrUnitary = airLoopHVACUnitaryHeatPumpAirToAir.back();
+      }
+    }
+
+    if( ! fanOrUnitary ) {
+      auto airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed = subsetCastVector<AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed>(supplyComponents);
+      if( ! airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.empty() ) {
+        fanOrUnitary = airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.back();
+      }
+    }
+
+    std::vector<Node> upperNodes;
+    std::vector<Node> lowerNodes;
+    if( fanOrUnitary )
+    {
+      upperNodes = subsetCastVector<Node>(airLoopHVAC.supplyComponents(airLoopHVAC.supplyInletNode(),fanOrUnitary.get()));
+      upperNodes.erase(upperNodes.begin());
+      lowerNodes = subsetCastVector<Node>(airLoopHVAC.supplyComponents(fanOrUnitary.get(),airLoopHVAC.supplyOutletNode()));
+      lowerNodes.erase(lowerNodes.end() - 1);
+    }
+    else
+    {
+      // Note if we don't have a fan this is going to be a problem for EnergyPlus,
+      // but at this point it will be allowed in OS
+      lowerNodes = subsetCastVector<Node>(supplyComponents);
+      // We should at least have a supply inlet and outlet node
+      OS_ASSERT(lowerNodes.size() >= 2);
+      lowerNodes.erase(lowerNodes.begin());
+      lowerNodes.erase(lowerNodes.end() - 1);
+    }
+
+    auto isTemperatureControl = [] ( SetpointManager & spm ) -> bool {
+      return istringEqual("Temperature",spm.controlVariable());
+    };
+
+    for( auto & upperNode : upperNodes )
+    {
+      std::vector<SetpointManager> _setpointManagers = upperNode.setpointManagers();
+      if( std::find_if(_setpointManagers.begin(),_setpointManagers.end(),isTemperatureControl) == _setpointManagers.end() ) {
+        SetpointManagerMixedAir spm(t_model);
+        spm.addToNode(upperNode);
+        spm.setName(upperNode.name().get() + " OS Default SPM");
+      }
+    } 
+
     for( auto & lowerNode : lowerNodes )
     {
       std::vector<SetpointManager> _setpointManagers = lowerNode.setpointManagers();
@@ -175,30 +176,39 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVAC( AirLoopHVAC 
         {
           SetpointManager spmClone = _setpointManager.clone(t_model).cast<SetpointManager>();
           spmClone.addToNode(lowerNode);
+          spmClone.setName(lowerNode.name().get() + " OS Default SPM");
         }
       }
     }
-  }
 
-  if( boost::optional<AirLoopHVACOutdoorAirSystem> oaSystem = airLoopHVAC.airLoopHVACOutdoorAirSystem() )
-  {
-    boost::optional<Node> outboardOANode = oaSystem->outboardOANode(); 
-    std::vector<Node> oaNodes = subsetCastVector<Node>(oaSystem->oaComponents());
-    if( outboardOANode )
+    if( boost::optional<AirLoopHVACOutdoorAirSystem> oaSystem = airLoopHVAC.airLoopHVACOutdoorAirSystem() )
     {
-      for( auto & oaNode : oaNodes )
+      boost::optional<Node> outboardOANode = oaSystem->outboardOANode(); 
+      std::vector<Node> oaNodes = subsetCastVector<Node>(oaSystem->oaComponents());
+      if( outboardOANode )
       {
-        if( oaNode != outboardOANode.get() )
+        for( auto & oaNode : oaNodes )
         {
-          std::vector<SetpointManager> _setpointManagers = oaNode.setpointManagers();
-          if( std::find_if(_setpointManagers.begin(),_setpointManagers.end(),isTemperatureControl) == _setpointManagers.end() ) {
-            SetpointManagerMixedAir spm(t_model);
-            spm.addToNode(oaNode);
+          if( oaNode != outboardOANode.get() )
+          {
+            std::vector<SetpointManager> _setpointManagers = oaNode.setpointManagers();
+            if( std::find_if(_setpointManagers.begin(),_setpointManagers.end(),isTemperatureControl) == _setpointManagers.end() ) {
+              SetpointManagerMixedAir spm(t_model);
+              spm.addToNode(oaNode);
+              spm.setName(oaNode.name().get() + " OS Default SPM");
+            }
           }
         }
       }
     }
   }
+}
+
+boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVAC( AirLoopHVAC & airLoopHVAC )
+{
+  Model t_model = airLoopHVAC.model();
+
+  addRequiredSetpointManagers(airLoopHVAC);
   
   // Create a new IddObjectType::AirLoopHVAC
   IdfObject idfObject(IddObjectType::AirLoopHVAC);
@@ -230,6 +240,7 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVAC( AirLoopHVAC 
   idfObject.setName(airLoopHVACName);
 
   std::vector<ModelObject> controllers;
+  auto supplyComponents = airLoopHVAC.supplyComponents();
 
   for( const auto & supplyComponent : supplyComponents )
   {

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACOutdoorAirSystem.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACOutdoorAirSystem.cpp
@@ -187,15 +187,12 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACOutdoorAirSyst
        oaIt != oaModelObjects.end();
        ++oaIt )
   {
-    if( ! oaIt->optionalCast<Node>() )
+    if( boost::optional<IdfObject> idfObject = translateAndMapModelObject(*oaIt) )
     {
-      if( boost::optional<IdfObject> idfObject = translateAndMapModelObject(*oaIt) )
-      {
-        equipmentListIdf.setString(i,idfObject->iddObject().name());
-        i++;
-        equipmentListIdf.setString(i,idfObject->name().get());
-        i++;
-      }
+      equipmentListIdf.setString(i,idfObject->iddObject().name());
+      i++;
+      equipmentListIdf.setString(i,idfObject->name().get());
+      i++;
     }
   }
 
@@ -204,15 +201,12 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACOutdoorAirSyst
        reliefIt != reliefModelObjects.end();
        ++reliefIt )
   {
-    if( (! reliefIt->optionalCast<Node>()) && (! reliefIt->optionalCast<AirToAirComponent>()) )
+    if( boost::optional<IdfObject> idfObject = translateAndMapModelObject(*reliefIt) )
     {
-      if( boost::optional<IdfObject> idfObject = translateAndMapModelObject(*reliefIt) )
-      {
-        equipmentListIdf.setString(i,idfObject->iddObject().name());
-        i++;
-        equipmentListIdf.setString(i,idfObject->name().get());
-        i++;
-      }
+      equipmentListIdf.setString(i,idfObject->iddObject().name());
+      i++;
+      equipmentListIdf.setString(i,idfObject->name().get());
+      i++;
     }
   }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
@@ -284,6 +284,8 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatCoo
       _fan->setString(Fan_OnOffFields::AirOutletNodeName,fanOutletNodeName);
     }
 
+    fixSPMsForUnitarySystem(modelObject,fanInletNodeName,fanOutletNodeName);
+
     if( _coolingCoil->iddObject().type() == IddObjectType::Coil_Cooling_DX_SingleSpeed )
     {
       _coolingCoil->setString(Coil_Cooling_DX_SingleSpeedFields::AirInletNodeName,coolInletNodeName);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAir.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAir.cpp
@@ -281,9 +281,12 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatPum
   //  //_heatingCoil->setString(Coil_Heating_DX_SingleSpeedFields::AirOutletNodeName,airOutletNodeName.get());
   //}
 
+  std::string fanOutletNodeName;
+
   if( _fan && _coolingCoil )
   {
     std::string nodeName = modelObject.name().get() + " Fan - Cooling Coil Node";
+    fanOutletNodeName = nodeName;
 
     if( _fan->iddObject().type() == IddObjectType::Fan_ConstantVolume )
     {
@@ -295,6 +298,11 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatPum
     }
 
     _coolingCoil->setString(Coil_Cooling_DX_SingleSpeedFields::AirInletNodeName,nodeName);
+  }
+
+  if( airInletNodeName )
+  {
+    fixSPMsForUnitarySystem(modelObject,airInletNodeName.get(),fanOutletNodeName);
   }
 
   if( _coolingCoil && _heatingCoil )

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.cpp
@@ -330,6 +330,8 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatPum
     }
   }
 
+  fixSPMsForUnitarySystem(modelObject,fanInletNodeName,fanOutletNodeName);
+
   if( _coolingCoil ) {
     if( _coolingCoil->iddObject().type() == IddObjectType::Coil_Cooling_DX_MultiSpeed ) {
       _coolingCoil->setString(Coil_Cooling_DX_MultiSpeedFields::AirInletNodeName,coolingCoilInletNodeName);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
@@ -27,6 +27,12 @@
 #include "../../model/ThermalZone_Impl.hpp"
 #include "../../model/Schedule.hpp"
 #include "../../model/Schedule_Impl.hpp"
+#include "../../model/AirLoopHVAC.hpp"
+#include "../../model/AirLoopHVAC_Impl.hpp"
+#include "../../model/SetpointManagerMixedAir.hpp"
+#include "../../model/SetpointManagerMixedAir_Impl.hpp"
+#include "../../model/AirLoopHVACOutdoorAirSystem.hpp"
+#include "../../model/AirLoopHVACOutdoorAirSystem_Impl.hpp"
 #include <utilities/idd/AirLoopHVAC_UnitarySystem_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_DX_SingleSpeed_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_DX_TwoSpeed_FieldEnums.hxx>
@@ -41,6 +47,7 @@
 #include <utilities/idd/Fan_ConstantVolume_FieldEnums.hxx>
 #include <utilities/idd/Fan_OnOff_FieldEnums.hxx>
 #include <utilities/idd/Fan_VariableVolume_FieldEnums.hxx>
+#include <utilities/idd/SetpointManager_MixedAir_FieldEnums.hxx>
 #include "../../utilities/idd/IddEnums.hpp"
 #include <utilities/idd/IddEnums.hxx>
 #include <utilities/idd/IddFactory.hxx>
@@ -488,6 +495,8 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitarySystem(
       _fan->setString(Fan_OnOffFields::AirInletNodeName,inletNodeName);
       _fan->setString(Fan_OnOffFields::AirOutletNodeName,outletNodeName);
     }
+
+    fixSPMsForUnitarySystem(modelObject,inletNodeName,outletNodeName);
   }
 
   if( _coolingCoil )

--- a/openstudiocore/src/model/AirLoopHVAC.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC.hpp
@@ -195,6 +195,21 @@ class MODEL_API AirLoopHVAC : public Loop
    */
   boost::optional<AirLoopHVACOutdoorAirSystem> airLoopHVACOutdoorAirSystem() const;
 
+  /** Returns the fan in the mixed air stream (after outdoor air system) of the air system.
+   *  If there is no outdoor air system or there are multiple fans in the mixed air stream, 
+   *  then the fan closest to the supply outlet node will be returned.
+   */
+  boost::optional<HVACComponent> supplyFan() const;
+
+  /** Returns the fan in the return air stream (before the outdoor air system.
+   *  If there is no outdoor air system then this method will return false.
+   *  If there are multiple fans, then return the fan nearest the oa system.
+   */
+  boost::optional<HVACComponent> returnFan() const;
+
+  /** Returns the most outboard fan on the relief air stream of the outdoor air system */
+  boost::optional<HVACComponent> reliefFan() const;
+
   /** Adds a new branch on the demand side of the air loop for a zone labeled zoneLabel
    * and returns true if the operation was successful. The method will return false if the Zone
    * is already connected to an air loop.

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -124,6 +124,12 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   Mixer demandMixer();
 
+  boost::optional<HVACComponent> supplyFan() const;
+
+  boost::optional<HVACComponent> returnFan() const;
+
+  boost::optional<HVACComponent> reliefFan() const;
+
   bool addBranchForZone(openstudio::model::ThermalZone & thermalZone);
 
   bool addBranchForZone(ThermalZone & thermalZone, StraightComponent & airTerminal);


### PR DESCRIPTION
Fix the SPM magic so that fans inside unitary systems are accounted for.  This is done during OS -> IDF translation.

Add methods AirLoopHVAC::supplyFan, ::returnFan, ::reliefFan.  These DO NOT account for fans inside compound objects like unitary systems.

https://www.pivotaltracker.com/story/show/86956490