### PR TITLE
[#87219700] A number of Simulation Settings Tab fields should be OSCombo...

### DIFF
--- a/openstudiocore/src/openstudio_lib/SimSettingsView.cpp
+++ b/openstudiocore/src/openstudio_lib/SimSettingsView.cpp
@@ -1362,22 +1362,41 @@ void SimSettingsView::attachSurfaceConvectionAlgorithmInside()
 {
   model::InsideSurfaceConvectionAlgorithm mo = m_model.getUniqueModelObject<model::InsideSurfaceConvectionAlgorithm>();
 
-  m_algorithmSurfaceConvectionInside->bind(mo,"algorithmSurfaceConvectionInside");
+  m_algorithmSurfaceConvectionInside->bind<std::string>(
+    mo,
+    static_cast<std::string(*)(const std::string&)>(&openstudio::toString),
+    std::bind(model::InsideSurfaceConvectionAlgorithm::validAlgorithmValues),
+    std::function<boost::optional<std::string>()>(std::bind(&model::InsideSurfaceConvectionAlgorithm::algorithm, mo)),
+    std::bind(&model::InsideSurfaceConvectionAlgorithm::setAlgorithm, mo, std::placeholders::_1),
+    NoFailAction(std::bind(&model::InsideSurfaceConvectionAlgorithm::resetAlgorithm, mo)));
 }
 
 void SimSettingsView::attachSurfaceConvectionAlgorithmOutside()
 {
   model::OutsideSurfaceConvectionAlgorithm mo = m_model.getUniqueModelObject<model::OutsideSurfaceConvectionAlgorithm>();
 
-  m_algorithmSurfaceConvectionOutside->bind(mo,"algorithmSurfaceConvectionOutside");
+  m_algorithmSurfaceConvectionOutside->bind<std::string>(
+    mo,
+    static_cast<std::string(*)(const std::string&)>(&openstudio::toString),
+    std::bind(model::OutsideSurfaceConvectionAlgorithm::validAlgorithmValues),
+    std::function<boost::optional<std::string>()>(std::bind(&model::OutsideSurfaceConvectionAlgorithm::algorithm, mo)),
+    std::bind(&model::OutsideSurfaceConvectionAlgorithm::setAlgorithm, mo, std::placeholders::_1),
+    NoFailAction(std::bind(&model::OutsideSurfaceConvectionAlgorithm::resetAlgorithm, mo)));
 }
 
 void SimSettingsView::attachHeatBalanceAlgorithm()
 {
   model::HeatBalanceAlgorithm mo = m_model.getUniqueModelObject<model::HeatBalanceAlgorithm>();
 
-  m_algorithmHeatBalance->bind(mo,"algorithmHeatBalance");
-  m_surfaceTemperatureUpperLimit->bind(mo,"surfaceTemperatureUpperLimit",m_isIP);
+  m_algorithmHeatBalance->bind<std::string>(
+    mo,
+    static_cast<std::string(*)(const std::string&)>(&openstudio::toString),
+    std::bind(model::HeatBalanceAlgorithm::algorithmValues),
+    std::function<boost::optional<std::string>()>(std::bind(&model::HeatBalanceAlgorithm::algorithm, mo)),
+    std::bind(&model::HeatBalanceAlgorithm::setAlgorithm, mo, std::placeholders::_1),
+    NoFailAction(std::bind(&model::HeatBalanceAlgorithm::resetAlgorithm, mo)));
+
+  m_surfaceTemperatureUpperLimit->bind(mo, "surfaceTemperatureUpperLimit", m_isIP);
   m_minimumSurfaceConvectionHeatTransferCoefficientValue->bind(mo,"minimumSurfaceConvectionHeatTransferCoefficientValue",m_isIP);
   m_maximumSurfaceConvectionHeatTransferCoefficientValue->bind(mo,"maximumSurfaceConvectionHeatTransferCoefficientValue",m_isIP);
 }
@@ -1386,7 +1405,13 @@ void SimSettingsView::attachZoneAirHeatBalanceAlgorithm()
 {
   model::ZoneAirHeatBalanceAlgorithm mo = m_model.getUniqueModelObject<model::ZoneAirHeatBalanceAlgorithm>();
 
-  m_algorithmZoneAirHeatBalance->bind(mo,"algorithmZoneAirHeatBalance");
+  m_algorithmZoneAirHeatBalance->bind<std::string>(
+    mo,
+    static_cast<std::string(*)(const std::string&)>(&openstudio::toString),
+    std::bind(model::ZoneAirHeatBalanceAlgorithm::validAlgorithmValues),
+    std::function<boost::optional<std::string>()>(std::bind(&model::ZoneAirHeatBalanceAlgorithm::algorithm, mo)),
+    std::bind(&model::ZoneAirHeatBalanceAlgorithm::setAlgorithm, mo, std::placeholders::_1),
+    NoFailAction(std::bind(&model::ZoneAirHeatBalanceAlgorithm::resetAlgorithm, mo)));
 }
 
 void SimSettingsView::attachZoneAirContaminantBalance()

--- a/openstudiocore/src/openstudio_lib/SimSettingsView.hpp
+++ b/openstudiocore/src/openstudio_lib/SimSettingsView.hpp
@@ -294,19 +294,23 @@ private:
   OSComboBox2 * m_skyDiffuseModelingAlgorithm;
 
   // SurfaceConvectionAlgorithmInside
-  OSLineEdit * m_algorithmSurfaceConvectionInside;
+  //OSLineEdit * m_algorithmSurfaceConvectionInside;
+  OSComboBox2 * m_algorithmSurfaceConvectionInside;
 
   // SurfaceConvectionAlgorithmOutside
-  OSLineEdit * m_algorithmSurfaceConvectionOutside;
+  //OSLineEdit * m_algorithmSurfaceConvectionOutside;
+  OSComboBox2 * m_algorithmSurfaceConvectionOutside;
 
   // HeatBalance
-  OSLineEdit * m_algorithmHeatBalance;
+  //OSLineEdit * m_algorithmHeatBalance;
+  OSComboBox2 * m_algorithmHeatBalance;
   OSQuantityEdit * m_surfaceTemperatureUpperLimit;
   OSQuantityEdit * m_minimumSurfaceConvectionHeatTransferCoefficientValue;
   OSQuantityEdit * m_maximumSurfaceConvectionHeatTransferCoefficientValue;
 
   // ZoneAirHeatBalanceAlgorithm
-  OSLineEdit * m_algorithmZoneAirHeatBalance;
+  //OSLineEdit * m_algorithmZoneAirHeatBalance;
+  OSComboBox2 * m_algorithmZoneAirHeatBalance;
 
   // ZoneAirContaminantBalance
   OSSwitch * m_carbonDioxideConcentration;


### PR DESCRIPTION
...Boxes rather than OSLineEdits #7