### PR TITLE
Switching to QWebEngine if building with Qt >= 5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,8 +283,6 @@ find_package(Qt5Widgets HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Widgets
 find_package(Qt5Sql HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Sql
 find_package(Qt5Network HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Network
 find_package(Qt5Xml HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Xml
-find_package(Qt5WebKit HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5WebKit
-find_package(Qt5WebKitWidgets HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5WebKit, Qt5WebKitWidgets, Qt5Widgets
 #find_package(Qt5WinExtras HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5WinExtras
 find_package(Qt5Concurrent HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Concurrent
 find_package(Qt5PrintSupport HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5PrintSupport, Qt5Widgets
@@ -304,8 +302,6 @@ mark_as_advanced(
   Qt5Quick_DIR
   Qt5Sensors_DIR
   Qt5Sql_DIR
-  Qt5WebKit_DIR
-  Qt5WebKitWidgets_DIR
   Qt5Widgets_DIR
   #Qt5WinExtras_DIR
   Qt5Xml_DIR
@@ -318,6 +314,15 @@ if(Qt5Widgets_DIR)
   if(${Qt5Widgets_VERSION} VERSION_LESS "5.2.1")
     message(FATAL_ERROR "Minimum supported Qt is v5.2.1")
   endif()
+  if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+    find_package(Qt5WebKit HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5WebKit
+    find_package(Qt5WebKitWidgets HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5WebKit, Qt5WebKitWidgets, Qt5Widgets
+    mark_as_advanced(Qt5WebKit_DIR Qt5WebKitWidgets_DIR)
+  else()
+    find_package(Qt5WebEngine HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5Qml, Qt5Quick, Qt5WebEngine
+    find_package(Qt5WebEngineWidgets HINTS ${QT_HINT_DIR}) #Qt5Core, Qt5Gui, Qt5Network, Qt5Qml, Qt5Quick, Qt5WebEngine, Qt5WebEngineWidgets, Qt5Widgets
+    mark_as_advanced(Qt5WebEngine_DIR Qt5WebEngineWidgets_DIR)
+  endif()
 elseif(UNIX)
   option(BUILD_QT "Build Qt" ON)
 endif()
@@ -325,7 +330,7 @@ endif()
 include(ExternalProject)
 include(ProcessorCount)
 
-# set number of cores to be used when building boost and qt, idea is you will do make -jX so boost and qt will build in parralel
+# set number of cores to be used when building boost and qt, idea is you will do make -jX so boost and qt will build in parallel
 ProcessorCount(CPUCOUNT)
 if(CPUCOUNT EQUAL 0)
   set(CPUCOUNT 1)
@@ -668,8 +673,13 @@ if(BUILD_QT)
   set(Qt5Sql_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5Sql)
   set(Qt5Network_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5Network)
   set(Qt5Xml_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5Xml)
-  set(Qt5WebKit_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebKit)
-  set(Qt5WebKitWidgets_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebKitWidgets)
+  if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+    set(Qt5WebKit_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebKit)
+    set(Qt5WebKitWidgets_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebKitWidgets)
+  else()
+    set(Qt5WebEngine_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebEngine)
+    set(Qt5WebEngineWidgets_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5WebEngineWidgets)
+  endif()
   set(Qt5Concurrent_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5Concurrent)
   set(Qt5PrintSupport_DIR ${CMAKE_BINARY_DIR}/Qt-prefix/src/Qt-install/lib/cmake/Qt5PrintSupport)
 
@@ -795,6 +805,8 @@ ExternalProject_Add(OSCore
     -DQt5Xml_DIR:STRING=${Qt5Xml_DIR}
     -DQt5WebKit_DIR:STRING=${Qt5WebKit_DIR}
     -DQt5WebKitWidgets_DIR:STRING=${Qt5WebKitWidgets_DIR}
+    -DQt5WebEngine_DIR:STRING=${Qt5WebEngine_DIR}
+    -DQt5WebEngineWidgets_DIR:STRING=${Qt5WebEngineWidgets_DIR}
     #-DQt5WinExtras_DIR:STRING=${Qt5WinExtras_DIR}
     -DQt5Concurrent_DIR:STRING=${Qt5Concurrent_DIR}
     -DQt5PrintSupport_DIR:STRING=${Qt5PrintSupport_DIR}
@@ -900,6 +912,8 @@ if (BUILD_REGRESSIONS)
       -DQt5Xml_DIR:STRING=${Qt5Xml_DIR}
       -DQt5WebKit_DIR:STRING=${Qt5WebKit_DIR}
       -DQt5WebKitWidgets_DIR:STRING=${Qt5WebKitWidgets_DIR}
+      -DQt5WebEngine_DIR:STRING=${Qt5WebEngine_DIR}
+      -DQt5WebEngineWidgets_DIR:STRING=${Qt5WebEngineWidgets_DIR}
       #-DQt5WinExtras_DIR:STRING=${Qt5WinExtras_DIR}
       -DQt5Concurrent_DIR:STRING=${Qt5Concurrent_DIR}
       -DQt5PrintSupport_DIR:STRING=${Qt5PrintSupport_DIR}

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -612,8 +612,6 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Sql REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Xml REQUIRED)
-find_package(Qt5WebKit REQUIRED)
-find_package(Qt5WebKitWidgets REQUIRED)
 #find_package(Qt5WinExtras)
 find_package(Qt5Concurrent REQUIRED)
 find_package(Qt5PrintSupport REQUIRED)
@@ -633,12 +631,20 @@ mark_as_advanced(
   Qt5Quick_DIR
   Qt5Sensors_DIR
   Qt5Sql_DIR
-  Qt5WebKit_DIR
-  Qt5WebKitWidgets_DIR
   Qt5Widgets_DIR
   #Qt5WinExtras_DIR
   Qt5Xml_DIR
 )
+
+if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+  find_package(Qt5WebKit REQUIRED)
+  find_package(Qt5WebKitWidgets REQUIRED)
+  mark_as_advanced(Qt5WebKit_DIR Qt5WebKitWidgets_DIR)
+else()
+  find_package(Qt5WebEngine REQUIRED)
+  find_package(Qt5WebEngineWidgets REQUIRED)
+  mark_as_advanced(Qt5WebEngine_DIR Qt5WebEngineWidgets_DIR)
+endif()
 
 set(CMAKE_AUTOMOC OFF)
 
@@ -647,8 +653,13 @@ include_directories(${Qt5Widgets_INCLUDE_DIRS})
 include_directories(${Qt5Sql_INCLUDE_DIRS})
 include_directories(${Qt5Network_INCLUDE_DIRS})
 include_directories(${Qt5Xml_INCLUDE_DIRS})
-include_directories(${Qt5WebKit_INCLUDE_DIRS})
-include_directories(${Qt5WebKitWidgets_INCLUDE_DIRS})
+if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+  include_directories(${Qt5WebKit_INCLUDE_DIRS})
+  include_directories(${Qt5WebKitWidgets_INCLUDE_DIRS})
+else()
+  include_directories(${Qt5WebEngine_INCLUDE_DIRS})
+  include_directories(${Qt5WebEngineWidgets_INCLUDE_DIRS})
+endif()
 #include_directories(${Qt5WinExtras_INCLUDE_DIRS})
 include_directories(${Qt5Concurrent_INCLUDE_DIRS})
 include_directories(${Qt5PrintSupport_INCLUDE_DIRS})
@@ -663,8 +674,13 @@ list(APPEND QT_LIBS ${Qt5Widgets_LIBRARIES})
 list(APPEND QT_LIBS ${Qt5Sql_LIBRARIES})
 list(APPEND QT_LIBS ${Qt5Network_LIBRARIES})
 list(APPEND QT_LIBS ${Qt5Xml_LIBRARIES})
-list(APPEND QT_LIBS ${Qt5WebKit_LIBRARIES})
-list(APPEND QT_LIBS ${Qt5WebKitWidgets_LIBRARIES})
+if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+  list(APPEND QT_LIBS ${Qt5WebKit_LIBRARIES})
+  list(APPEND QT_LIBS ${Qt5WebKitWidgets_LIBRARIES})
+else()
+  list(APPEND QT_LIBS ${Qt5WebEngine_LIBRARIES})
+  list(APPEND QT_LIBS ${Qt5WebEngineWidgets_LIBRARIES})
+endif()
 #list(APPEND QT_LIBS ${Qt5WinExtras_LIBRARIES})
 list(APPEND QT_LIBS ${Qt5Concurrent_LIBRARIES})
 list(APPEND QT_LIBS ${Qt5PrintSupport_LIBRARIES})

--- a/openstudiocore/src/openstudio_lib/CMakeLists.txt
+++ b/openstudiocore/src/openstudio_lib/CMakeLists.txt
@@ -693,6 +693,12 @@ set(${target_name}_moc
 
 )
 
+if(${Qt5Widgets_VERSION} VERSION_LESS "5.4.0")
+  list(APPEND ${target_name}_moc ResultsWebView.hpp)
+else()
+  list(APPEND ${target_name}_moc ResultsWebEngineView.hpp)
+endif()
+
 # resource files
 set(${target_name}_qrc
   openstudio.qrc

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
@@ -18,6 +18,11 @@
 **********************************************************************/
 
 #include "ResultsTabView.hpp"
+#if QT_VERSION >= 0x050400
+#include "ResultsWebEngineView.hpp"
+#else
+#include "ResultsWebView.hpp"
+#endif
 
 #include "OSDocument.hpp"
 

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
@@ -33,7 +33,6 @@
 #include <QPushButton>
 #include <QString>
 #include <QRegExp>
-//#include <QWebInspector>
 
 #include "../runmanager/lib/FileInfo.hpp"
 #include "../runmanager/lib/JobStatusWidget.hpp"
@@ -110,20 +109,14 @@ ResultsView::ResultsView(QWidget *t_parent)
   m_view->setContextMenuPolicy(Qt::NoContextMenu);
   m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   mainLayout->addWidget(m_view, 0, Qt::AlignTop);
-
-//#if _DEBUG || (__GNUC__ && !NDEBUG)
-//  m_view->page()->settings()->setAttribute(QWebSettings::DeveloperExtrasEnabled, true);
-//  QWebInspector *inspector = new QWebInspector;
-//  inspector->setPage(m_view->page());
-//  inspector->setVisible(true);
-//#endif
-
 }
 
 ResultsView::~ResultsView()
 {
   delete m_view;
+#if QT_VERSION < 0x050400
   QWebSettings::clearMemoryCaches();
+#endif
 }
 
 void ResultsView::openResultsViewerClicked()
@@ -353,8 +346,12 @@ void ResultsView::comboBoxChanged(int index)
   m_view->load(QUrl(filename));
 }
 
-ResultsWebView::ResultsWebView(QWidget * parent)
-  : QWebView(parent)
+ResultsWebView::ResultsWebView(QWidget * parent) :
+#if QT_VERSION >= 0x050400
+  QWebEngineView(parent)
+#else
+  QWebView(parent)
+#endif
 {
 }
 

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.hpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.hpp
@@ -110,21 +110,6 @@ namespace openstudio {
       REGISTER_LOGGER("openstudio::ResultsTabView");
   };
 
-#if QT_VERSION >= 0x050400
-  class ResultsWebView : public QWebEngineView
-#else
-  class ResultsWebView : public QWebView
-#endif
-  {
-    Q_OBJECT;
-
-    public:
-
-      ResultsWebView(QWidget * parent = 0);
-      
-      QSize sizeHint() const;
-  };
-
 } // openstudio
 
 #endif // OPENSTUDIO_RESULTSTABVIEW_HPP

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.hpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.hpp
@@ -28,7 +28,11 @@
 #include "../runmanager/lib/RunManager.hpp"
 
 #include <QWidget>
+#if QT_VERSION >= 0x050400
+#include <QWebEngineView>
+#else
 #include <QWebView>
+#endif
 
 class QComboBox;
 class QPushButton;
@@ -69,7 +73,11 @@ namespace openstudio {
       openstudio::path m_sqlFilePath;
       openstudio::path m_radianceResultsPath;
 
+#if QT_VERSION >= 0x050400
+      QWebEngineView * m_view;
+#else
       QWebView * m_view;
+#endif
       QComboBox * m_comboBox;
   };
 
@@ -102,7 +110,11 @@ namespace openstudio {
       REGISTER_LOGGER("openstudio::ResultsTabView");
   };
 
+#if QT_VERSION >= 0x050400
+  class ResultsWebView : public QWebEngineView
+#else
   class ResultsWebView : public QWebView
+#endif
   {
     Q_OBJECT;
 

--- a/openstudiocore/src/openstudio_lib/ResultsWebEngineView.hpp
+++ b/openstudiocore/src/openstudio_lib/ResultsWebEngineView.hpp
@@ -1,0 +1,40 @@
+/**********************************************************************
+ *  Copyright (c) 2008-2015, Alliance for Sustainable Energy.  
+ *  All rights reserved.
+ *  
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ **********************************************************************/
+
+#ifndef OPENSTUDIO_RESULTSWEBENGINEVIEW_HPP
+#define OPENSTUDIO_RESULTSWEBENGINEVIEW_HPP
+
+#include <QWidget>
+#include <QWebEngineView>
+
+namespace openstudio {
+  class ResultsWebView : public QWebEngineView
+  {
+    Q_OBJECT;
+
+    public:
+
+      ResultsWebView(QWidget * parent = 0);
+
+      QSize sizeHint() const;
+  };
+
+} // openstudio
+
+#endif // OPENSTUDIO_RESULTSWEBENGINEVIEW_HPP

--- a/openstudiocore/src/openstudio_lib/ResultsWebView.hpp
+++ b/openstudiocore/src/openstudio_lib/ResultsWebView.hpp
@@ -1,0 +1,40 @@
+/**********************************************************************
+ *  Copyright (c) 2008-2015, Alliance for Sustainable Energy.  
+ *  All rights reserved.
+ *  
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ **********************************************************************/
+
+#ifndef OPENSTUDIO_RESULTSWEBVIEW_HPP
+#define OPENSTUDIO_RESULTSWEBVIEW_HPP
+
+#include <QWidget>
+#include <QWebView>
+
+namespace openstudio {
+  class ResultsWebView : public QWebView
+  {
+    Q_OBJECT;
+
+    public:
+
+      ResultsWebView(QWidget * parent = 0);
+
+      QSize sizeHint() const;
+  };
+
+} // openstudio
+
+#endif // OPENSTUDIO_RESULTSWEBVIEW_HPP


### PR DESCRIPTION
I'm seeing a 2.8x performance increase for JavaScript, according to the SunSpider benchmark.  This should alleviate #1211 while remaining backwards-compatible.