### PR TITLE
Add tests for exhaust and inlet port lists

### DIFF
--- a/openstudiocore/src/model/test/ThermalZone_GTest.cpp
+++ b/openstudiocore/src/model/test/ThermalZone_GTest.cpp
@@ -53,6 +53,8 @@
 #include "../ScheduleRuleset_Impl.hpp"
 #include "../ThermostatSetpointDualSetpoint.hpp"
 #include "../ThermostatSetpointDualSetpoint_Impl.hpp"
+#include "../PortList.hpp"
+#include "../PortList_Impl.hpp"
 
 #include "../../utilities/data/Attribute.hpp"
 #include "../../utilities/geometry/Point3d.hpp"
@@ -565,5 +567,24 @@ TEST_F(ModelFixture, ThermalZone_Clone)
   auto heatingSchedule2 = thermostatClone->cast<ThermostatSetpointDualSetpoint>().heatingSetpointTemperatureSchedule();
   ASSERT_TRUE(heatingSchedule2);
   ASSERT_EQ(heatingSchedule,heatingSchedule2.get());
+}
+
+TEST_F(ModelFixture, ThermalZone_Ports)
+{
+  Model m;
+  ThermalZone zone(m);
+
+  auto inletPortList = zone.inletPortList();
+  auto exhaustPortList = zone.exhaustPortList();
+
+  auto inletPortListZone = inletPortList.thermalZone();
+  auto exhaustPortListZone = exhaustPortList.thermalZone();
+
+  EXPECT_EQ(zone.handle(),inletPortListZone.handle());
+  EXPECT_EQ(zone.handle(),exhaustPortListZone.handle());
+
+  zone.remove();
+  EXPECT_TRUE(inletPortList.handle().isNull());
+  EXPECT_TRUE(exhaustPortList.handle().isNull());
 }
 


### PR DESCRIPTION
ThermalZone objects are attached to inlet "port lists" and exhaust "port
lists" because they can have multiple connections at those locations.
The ThermalZone class has ThermalZone::exhaustPortList and
ThermalZone::inletPortList that both return the PortList class.
PortList keeps a reference back to the associated ThermalZone and
ThermalZone keeps a reference back to the PortList so that the lookup
is fast in either direction.  User model for issue #447 had a missing
reference from PortList back to ThermalZone.  It is unknown why this
situation occured (model was from version 1.0) but here unit tests are
added to verify that the issue no longer exists.