### PR TITLE
Fix AirToAirComponent being counted twice on OA EquipmentList

### DIFF
--- a/openstudiocore/src/model/AirLoopHVACOutdoorAirSystem.cpp
+++ b/openstudiocore/src/model/AirLoopHVACOutdoorAirSystem.cpp
@@ -344,7 +344,6 @@ namespace detail {
       }
       else if( boost::optional<AirToAirComponent> comp = modelObject->optionalCast<AirToAirComponent>() )
       {
-        modelObjects.push_back(*comp);
         modelObject = comp->secondaryAirOutletModelObject();
       }
       else if( boost::optional<WaterToAirComponent> comp = modelObject->optionalCast<WaterToAirComponent>() )


### PR DESCRIPTION
Fixes #1676 

Since AirToAirComponents are on both OA and RA loops in the OA system, it was being output twice to the OA EquipmentList.