### PR TITLE
Fix error in ThermalZone::clone

### DIFF
--- a/openstudiocore/src/model/ThermalZone.cpp
+++ b/openstudiocore/src/model/ThermalZone.cpp
@@ -1880,6 +1880,11 @@ namespace detail {
   ModelObject ThermalZone_Impl::clone(Model model) const
   {
     ThermalZone tz = HVACComponent_Impl::clone(model).cast<ThermalZone>();
+    // We need this because "connect" is first going to try to disconnect from anything 
+    // currently attached.  At this point tz is left pointing (through a connection) to the old zone air node, 
+    // (because of ModelObject::clone behavior) so connecting to the new node will remove the connection joining
+    // the original zone and the original node.
+    tz.setString(OS_ThermalZoneFields::ZoneAirNodeName,"");
 
     Node node(model);
     model.connect(tz,tz.zoneAirPort(),node,node.inletPort());

--- a/openstudiocore/src/model/test/ThermalZone_GTest.cpp
+++ b/openstudiocore/src/model/test/ThermalZone_GTest.cpp
@@ -538,6 +538,8 @@ TEST_F(ModelFixture, ThermalZone_Clone)
   Model m;
   ThermalZone thermalZone(m);
   
+  auto zoneAirNode = thermalZone.zoneAirNode();
+  
   ZoneControlHumidistat humidistat(m);
   thermalZone.setZoneControlHumidistat(humidistat);
   ScheduleRuleset humidSchedule(m);
@@ -573,6 +575,10 @@ TEST_F(ModelFixture, ThermalZone_Clone)
   auto heatingSchedule2 = thermostatClone->cast<ThermostatSetpointDualSetpoint>().heatingSetpointTemperatureSchedule();
   ASSERT_TRUE(heatingSchedule2);
   ASSERT_EQ(heatingSchedule,heatingSchedule2.get());
+
+  EXPECT_FALSE(thermalZoneClone.zoneAirNode().handle().isNull());
+  EXPECT_EQ(zoneAirNode,thermalZone.zoneAirNode());
+  EXPECT_FALSE(thermalZone.zoneAirNode().handle().isNull());
 }
 
 TEST_F(ModelFixture, ThermalZone_SonOfClone)


### PR DESCRIPTION
A bug was removing the connection to between the original zone (non
clone) and the zone air node during ThermalZone::clone

close #1687