### PR TITLE
TimeSeries Fix

### DIFF
--- a/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
+++ b/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
@@ -1187,17 +1187,15 @@ TEST_F(DataFixture, TimeSeries_Yearly)
   idioticVector[0] = 1.0;
 
   std::vector<double> daysFromFirstReport0 = { 0.0 };
-  std::vector<double> daysFromFirstReport8760 = { 8760.0 };
+  std::vector<double> daysFromFirstReport8760 = { 365.0 };
 
   TimeSeries intervalTimeSeries(firstReportDateTime, interval, idioticVector, units);
-  TimeSeries firstAndDaysTimeSeries0(firstReportDateTime, daysFromFirstReport0, values, units);
+  ASSERT_THROW(TimeSeries firstAndDaysTimeSeries0(firstReportDateTime, daysFromFirstReport0, values, units), openstudio::Exception);
   TimeSeries firstAndDaysTimeSeries8760(firstReportDateTime, daysFromFirstReport8760, values, units);
 
   // Check computations
   EXPECT_EQ(31536000, intervalTimeSeries.integrate());
   EXPECT_EQ(1, intervalTimeSeries.averageValue());
-  EXPECT_EQ(31536000, firstAndDaysTimeSeries0.integrate());
-  EXPECT_EQ(1, firstAndDaysTimeSeries0.averageValue());
   EXPECT_EQ(31536000, firstAndDaysTimeSeries8760.integrate());
   EXPECT_EQ(1, firstAndDaysTimeSeries8760.averageValue());
 
@@ -1218,12 +1216,9 @@ TEST_F(DataFixture, TimeSeries_Monthly)
   std::vector<double> daysFromStart = { 31.0, 59.0, 90.0, 120.0, 151.0, 181.0, 212.0, 243.0, 273.0, 304.0, 334.0, 365.0 };
   // 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 
 
-  TimeSeries firstTimeSeries(firstReportDateTime, daysFromFirstReport, values, units);
+  ASSERT_THROW(TimeSeries firstTimeSeries(firstReportDateTime, daysFromFirstReport, values, units), openstudio::Exception);
   TimeSeries startTimeSeries(firstReportDateTime, daysFromStart, values, units);
 
   // Check computations
-  EXPECT_EQ(205804800, firstTimeSeries.integrate());
-  //EXPECT_EQ(6.526027397, firstTimeSeries.averageValue());
   EXPECT_EQ(205804800, startTimeSeries.integrate());
-  //EXPECT_EQ(6.526027397, startTimeSeries.averageValue());
 }

--- a/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
+++ b/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
@@ -1186,16 +1186,21 @@ TEST_F(DataFixture, TimeSeries_Yearly)
   Vector idioticVector(1);
   idioticVector[0] = 1.0;
 
-  std::vector<double> daysFromFirstReport = { 0.0 };
+  std::vector<double> daysFromFirstReport0 = { 0.0 };
+  std::vector<double> daysFromFirstReport8760 = { 8760.0 };
 
   TimeSeries intervalTimeSeries(firstReportDateTime, interval, idioticVector, units);
-  TimeSeries firstAndDaysTimeSeries(firstReportDateTime, daysFromFirstReport, values, units);
+  TimeSeries firstAndDaysTimeSeries0(firstReportDateTime, daysFromFirstReport0, values, units);
+  TimeSeries firstAndDaysTimeSeries8760(firstReportDateTime, daysFromFirstReport8760, values, units);
 
   // Check computations
   EXPECT_EQ(31536000, intervalTimeSeries.integrate());
   EXPECT_EQ(1, intervalTimeSeries.averageValue());
-  EXPECT_EQ(31536000, firstAndDaysTimeSeries.integrate());
-  EXPECT_EQ(1, firstAndDaysTimeSeries.averageValue());
+  EXPECT_EQ(31536000, firstAndDaysTimeSeries0.integrate());
+  EXPECT_EQ(1, firstAndDaysTimeSeries0.averageValue());
+  EXPECT_EQ(31536000, firstAndDaysTimeSeries8760.integrate());
+  EXPECT_EQ(1, firstAndDaysTimeSeries8760.averageValue());
+
 }
 
 TEST_F(DataFixture, TimeSeries_Monthly)

--- a/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
+++ b/openstudiocore/src/utilities/data/Test/TimeSeries_GTest.cpp
@@ -1173,3 +1173,52 @@ TEST_F(DataFixture, TimeSeries_Multiply8760)
 
 }
 
+TEST_F(DataFixture, TimeSeries_Yearly)
+{
+  std::string units = "W";
+
+  Date startDate(MonthOfYear(MonthOfYear::Jan), 1);
+  DateTime startDateTime(startDate);
+  Time interval(0, 8760, 0, 0);
+  DateTime firstReportDateTime(startDate, interval);
+
+  std::vector<double> values = { 1.0 };
+  Vector idioticVector(1);
+  idioticVector[0] = 1.0;
+
+  std::vector<double> daysFromFirstReport = { 0.0 };
+
+  TimeSeries intervalTimeSeries(firstReportDateTime, interval, idioticVector, units);
+  TimeSeries firstAndDaysTimeSeries(firstReportDateTime, daysFromFirstReport, values, units);
+
+  // Check computations
+  EXPECT_EQ(31536000, intervalTimeSeries.integrate());
+  EXPECT_EQ(1, intervalTimeSeries.averageValue());
+  EXPECT_EQ(31536000, firstAndDaysTimeSeries.integrate());
+  EXPECT_EQ(1, firstAndDaysTimeSeries.averageValue());
+}
+
+TEST_F(DataFixture, TimeSeries_Monthly)
+{
+  std::string units = "W";
+
+  Date startDate(MonthOfYear(MonthOfYear::Jan), 1);
+  DateTime startDateTime(startDate);
+  Time interval = Date(MonthOfYear(MonthOfYear::Feb), 1) - startDate;
+  DateTime firstReportDateTime(startDate, interval);
+
+  std::vector<double> values = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 };
+
+  std::vector<double> daysFromFirstReport = { 0.0, 28.0, 59.0, 89.0, 120.0, 150.0, 181.0, 212.0, 242.0, 273.0, 303.0, 334.0 };
+  std::vector<double> daysFromStart = { 31.0, 59.0, 90.0, 120.0, 151.0, 181.0, 212.0, 243.0, 273.0, 304.0, 334.0, 365.0 };
+  // 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 
+
+  TimeSeries firstTimeSeries(firstReportDateTime, daysFromFirstReport, values, units);
+  TimeSeries startTimeSeries(firstReportDateTime, daysFromStart, values, units);
+
+  // Check computations
+  EXPECT_EQ(205804800, firstTimeSeries.integrate());
+  //EXPECT_EQ(6.526027397, firstTimeSeries.averageValue());
+  EXPECT_EQ(205804800, startTimeSeries.integrate());
+  //EXPECT_EQ(6.526027397, startTimeSeries.averageValue());
+}

--- a/openstudiocore/src/utilities/data/TimeSeries.cpp
+++ b/openstudiocore/src/utilities/data/TimeSeries.cpp
@@ -359,7 +359,6 @@ TimeSeries_Impl::TimeSeries_Impl(const DateTime& firstReportDateTime, const std:
   if (timeInSeconds.size() != values.size()) {
     LOG_AND_THROW("Length of values (" << values.size() << ") must match length of times (" << timeInSeconds.size() << ")");
   }
-
   if (values.empty() || timeInSeconds.empty()) {
     LOG(Warn, "Creating empty timeseries");
     m_startDateTime = firstReportDateTime;

--- a/openstudiocore/src/utilities/data/TimeSeries.cpp
+++ b/openstudiocore/src/utilities/data/TimeSeries.cpp
@@ -129,9 +129,9 @@ TimeSeries_Impl::TimeSeries_Impl(const DateTime& firstReportDateTime, const Vect
     if (timeInDays[0] == 0) { // This is the old, BROKEN way
       int firstIntervalSeconds = firstReportDateTime.time().totalSeconds();
       if (firstIntervalSeconds == 0) {
-        LOG_AND_THROW("Cannot calculate or assume the series start date for first report at the beginning of a day");
+        LOG_AND_THROW("Cannot calculate the series start date for first report at the beginning of a day");
       }
-      LOG(Warn, "Assuming that time series begins at the start of the day of first report");
+      LOG(Warn, "Assuming time series begins at the start of the day of first report. This behavior is deprecated and will instead be an error in the future.");
       m_startDateTime = DateTime(m_firstReportDateTime.date());
 
       for (unsigned i = 0; i < values.size(); ++i) {
@@ -197,9 +197,9 @@ TimeSeries_Impl::TimeSeries_Impl(const DateTime& firstReportDateTime, const std:
     if (timeInDays[0] == 0) { // This is the old, BROKEN way
       int firstIntervalSeconds = firstReportDateTime.time().totalSeconds();
       if (firstIntervalSeconds == 0) {
-        LOG_AND_THROW("Cannot calculate or assume the series start date for first report at the beginning of a day");
+        LOG_AND_THROW("Cannot calculate the series start date for first report at the beginning of a day");
       }
-      LOG(Warn, "Assuming that time series begins at the start of the day of first report");
+      LOG(Warn, "Assuming time series begins at the start of the day of first report. This behavior is deprecated and will instead be an error in the future.");
       m_startDateTime = DateTime(m_firstReportDateTime.date());
 
       for (unsigned i = 0; i < values.size(); ++i) {
@@ -334,9 +334,9 @@ TimeSeries_Impl::TimeSeries_Impl(const DateTimeVector& inDateTimes, const Vector
         m_startDateTime = m_firstReportDateTime - Time(0, 0, 0, delta);
       } else {
         if (m_firstReportDateTime.time().totalSeconds() == 0) {
-          LOG_AND_THROW("Cannot calculate or assume the series start date for first report at the beginning of a day");
+          LOG_AND_THROW("Cannot calculate the series start date for first report at the beginning of a day");
         }
-        LOG(Warn, "Assuming that time series begins at the start of the day of first report");
+        LOG(Warn, "Assuming time series begins at the start of the day of first report. This behavior is deprecated and will instead be an error in the future.");
         m_startDateTime = DateTime(m_firstReportDateTime.date());
       }
     }
@@ -373,9 +373,9 @@ TimeSeries_Impl::TimeSeries_Impl(const DateTime& firstReportDateTime, const std:
 
     if (timeInSeconds[0] == 0) { // This is the old, BROKEN way
       if (firstReportDateTime.time().totalSeconds() == 0) {
-        LOG_AND_THROW("Cannot calculate or assume the series start date for first report at the beginning of a day");
+        LOG_AND_THROW("Cannot calculate the series start date for first report at the beginning of a day");
       }
-      LOG(Warn, "Assuming that time series begins at the start of the day of first report");
+      LOG(Warn, "Assuming time series begins at the start of the day of first report. This behavior is deprecated and will instead be an error in the future.");
       m_startDateTime = DateTime(firstReportDateTime.date());
       m_firstReportDateTime = firstReportDateTime;
       int firstIntervalSeconds = m_firstReportDateTime.time().totalSeconds();

--- a/openstudiocore/src/utilities/sql/SqlFile_Impl.cpp
+++ b/openstudiocore/src/utilities/sql/SqlFile_Impl.cpp
@@ -2424,9 +2424,9 @@ namespace openstudio{
             }
           }
 
-          stdSecondsFromFirstReport.push_back(cumulativeSeconds);
-           
+          // Use the new way to create the time series with nonzero first entry
           cumulativeSeconds += 60*intervalMinutes;
+          stdSecondsFromFirstReport.push_back(cumulativeSeconds);
 
           // check if this interval is same as the others
           if (isIntervalTimeSeries && !reportingIntervalMinutes){


### PR DESCRIPTION
@axelstudios @macumber This should hopefully fix at least part of the time series issue that came up today. Part of the problem is in SqlFile's timeSeries method. I have changed it to use the new TimeSeries creation behavior, but it still creates "RunPeriod" time series using the detailed ctor rather than the interval ctor. That is not ideal, but is acceptable for now as far as I can tell.