### PR TITLE
Update DiagnosticScript to remove cruft from badly initialized zones

### DIFF
--- a/openstudiocore/ruby/openstudio/sketchup_plugin/lib/interfaces/DrawingInterface.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/lib/interfaces/DrawingInterface.rb
@@ -255,12 +255,20 @@ module OpenStudio
       if @model_object.nil?
         return(false)
       elsif @model_object.handle.isNull
+        # object may have been deleted or not fully initialized
         return(false)
       else
+        # check that this object is accessible in the workspace
+        object = @model_interface.openstudio_model.getObject(@model_object.handle)
+        if object.empty?
+          msg  = "A partially initialized object was detected in the plug-in.\n\n"
+          msg += "It advised that you save a backup of your current OpenStudio model and restart SketchUp."
+          UI.messagebox(msg)
+        end
+     
         return(true)
       end
     end
-
 
     # Updates the ModelObject with new information from the SketchUp entity.
     def update_model_object

--- a/openstudiocore/ruby/openstudio/sketchup_plugin/user_scripts/Reports/OSM_Diagnostic_Script.rb
+++ b/openstudiocore/ruby/openstudio/sketchup_plugin/user_scripts/Reports/OSM_Diagnostic_Script.rb
@@ -302,7 +302,7 @@ class DiagnosticScript < OpenStudio::Ruleset::UtilityUserScript
     end
     if switch == 0 then puts "none" end
   
-  # Find duplicate vertices within surface
+    # Find duplicate vertices within surface
     puts ""
     puts "Surfaces and SubSurfaces which have duplicate vertices"
     switch = 0
@@ -373,33 +373,85 @@ class DiagnosticScript < OpenStudio::Ruleset::UtilityUserScript
     end
     if switch == 0 then puts "none" end
     
-      # find and remove orphan sizing:zone objects
-      puts ""
-      puts "Removing sizing:zone objects that are not connected to any thermal zone"
-      #get all sizing:zone objects in the model
-      sizing_zones = model.getObjectsByType("OS:Sizing:Zone".to_IddObjectType)
-      #make an array to store the names of the orphan sizing:zone objects
-      orphaned_sizing_zones = Array.new
-      #loop through all sizing:zone objects, checking for missing ThermalZone field
-      sizing_zones.each do |sizing_zone|
-        sizing_zone = sizing_zone.to_SizingZone.get
-        if sizing_zone.isEmpty(1)
-          orphaned_sizing_zones << sizing_zone.handle
-          puts "*(error)#{sizing_zone.name} is not connected to a thermal zone"
-          if remove_errors
-            puts "**(removing object)#{sizing_zone.name} is not connected to a thermal zone"
-            sizing_zone.remove
-            savediagnostic = true
-          end
+    # find and remove orphan sizing:zone objects
+    puts ""
+    puts "Removing sizing:zone objects that are not connected to any thermal zone"
+    #get all sizing:zone objects in the model
+    sizing_zones = model.getObjectsByType("OS:Sizing:Zone".to_IddObjectType)
+    #make an array to store the names of the orphan sizing:zone objects
+    orphaned_sizing_zones = Array.new
+    #loop through all sizing:zone objects, checking for missing ThermalZone field
+    sizing_zones.each do |sizing_zone|
+      sizing_zone = sizing_zone.to_SizingZone.get
+      if sizing_zone.isEmpty(1)
+        orphaned_sizing_zones << sizing_zone.handle
+        puts "*(error)#{sizing_zone.name} is not connected to a thermal zone"
+        if remove_errors
+          puts "**(removing object)#{sizing_zone.name} is not connected to a thermal zone"
+          sizing_zone.remove
+          savediagnostic = true
         end
       end
-      #summarize the results
-      if orphaned_sizing_zones.length > 0
-        puts "#{orphaned_sizing_zones.length} orphaned sizing:zone objects were found"
-      else
-        puts "no orphaned sizing:zone objects were found"
+    end
+    #summarize the results
+    if orphaned_sizing_zones.length > 0
+      puts "#{orphaned_sizing_zones.length} orphaned sizing:zone objects were found"
+    else
+      puts "no orphaned sizing:zone objects were found"
+    end
+    
+    # find and remove orphan ZoneHVAC:EquipmentList objects
+    puts ""
+    puts "Removing ZoneHVAC:EquipmentList objects that are not connected to any thermal zone"
+    #get all ZoneHVAC:EquipmentList objects in the model
+    zonehvac_equipmentlists = model.getObjectsByType("OS:ZoneHVAC:EquipmentList".to_IddObjectType)
+    #make an array to store the names of the orphan ZoneHVAC:EquipmentList objects
+    orphaned_zonehvac_equipmentlists = Array.new
+    #loop through all ZoneHVAC:EquipmentList objects, checking for missing ThermalZone field
+    zonehvac_equipmentlists.each do |zonehvac_equipmentlist|
+      if zonehvac_equipmentlist.isEmpty(2)
+        orphaned_zonehvac_equipmentlists << zonehvac_equipmentlist.handle
+        puts "*(error)#{zonehvac_equipmentlist.name} is not connected to a thermal zone"
+        if remove_errors
+          puts "**(removing object)#{zonehvac_equipmentlist.name} is not connected to a thermal zone"
+          zonehvac_equipmentlist.remove
+          savediagnostic = true
+        end
       end
-
+    end
+    #summarize the results
+    if orphaned_zonehvac_equipmentlists.length > 0
+      puts "#{orphaned_zonehvac_equipmentlists.length} orphaned ZoneHVAC:EquipmentList objects were found"
+    else
+      puts "no orphaned ZoneHVAC:EquipmentList objects were found"
+    end
+    
+    # find and remove orphan PortList objects
+    puts ""
+    puts "Removing PortList objects that are not connected to any equipment"
+    #get all PortList objects in the model
+    port_lists = model.getObjectsByType("OS:PortList".to_IddObjectType)
+    #make an array to store the names of the orphan PortList objects
+    orphaned_port_lists = Array.new
+    #loop through all PortList objects, checking for missing HVAC Component field
+    port_lists.each do |port_list|
+      if port_list.isEmpty(2)
+        orphaned_port_lists << port_list.handle
+        puts "*(error)#{port_list.name} is not connected to any equipment"
+        if remove_errors
+          puts "**(removing object)#{port_list.name} is not connected to any equipment"
+          port_list.remove
+          savediagnostic = true
+        end
+      end
+    end
+    #summarize the results
+    if orphaned_port_lists.length > 0
+      puts "#{orphaned_port_lists.length} orphaned PortList objects were found"
+    else
+      puts "no orphaned PortList objects were found"
+    end
+    
     puts ""
     puts ">>diagnostic test complete"
 

--- a/openstudiocore/src/model/ThermalZone.cpp
+++ b/openstudiocore/src/model/ThermalZone.cpp
@@ -1682,7 +1682,9 @@ namespace detail {
 
     std::vector<SizingZone> sizingObjects;
     
-    sizingObjects = model().getConcreteModelObjects<SizingZone>();
+    //sizingObjects = model().getConcreteModelObjects<SizingZone>();
+
+    sizingObjects = getObject<ModelObject>().getModelObjectSources<SizingZone>(SizingZone::iddObjectType());
 
     for( const auto & sizingObject : sizingObjects )
     {
@@ -1828,7 +1830,9 @@ namespace detail {
   {
     boost::optional<ZoneHVACEquipmentList> result;
 
-    std::vector<ZoneHVACEquipmentList> list = model().getConcreteModelObjects<ZoneHVACEquipmentList>();
+    std::vector<ZoneHVACEquipmentList> list = getObject<ModelObject>().getModelObjectSources<ZoneHVACEquipmentList>(ZoneHVACEquipmentList::iddObjectType());
+
+    //std::vector<ZoneHVACEquipmentList> list = model().getConcreteModelObjects<ZoneHVACEquipmentList>();
 
     for( const auto & elem : list )
     {
@@ -1838,9 +1842,13 @@ namespace detail {
       }
     }
 
-    OS_ASSERT(result);
-
-    return result.get();
+    if (result)
+    {
+      return result.get();
+    } else
+    {
+      LOG_AND_THROW("ThermalZone missing ZoneHVAC:EquipmentList object");
+    }
   }
 
   void ThermalZone_Impl::addEquipment(const ModelObject & equipment)


### PR DESCRIPTION
Add catch if object is passed to check_model_object but not yet available in workspace (I think this was the underlying issue but have not been able to reproduce)

Update thermal zone methods for performance (also prevents this crash)