### PR TITLE
Convert new coils to using ModelObjectList

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -14210,7 +14210,6 @@ OS:Coil:Heating:WaterToAirHeatPump:EquationFit,
       
 OS:Coil:Heating:DX:MultiSpeed,
        \min-fields 19
-       \extensible:1
   A1 , \field Handle
        \type handle
        \required-field
@@ -14302,10 +14301,9 @@ OS:Coil:Heating:DX:MultiSpeed,
        \type integer
        \minimum 1
        \maximum 6
-  A11; \field Stage Data
-       \begin-extensible
+  A11; \field Stage Data List
        \type object-list
-       \object-list CoilHeatingDXMultiSpeedStageData
+       \object-list ModelObjectLists
 
 OS:Coil:Heating:DX:MultiSpeed:StageData,
        \min-fields 12
@@ -14375,7 +14373,6 @@ OS:Coil:Heating:DX:MultiSpeed:StageData,
 
 OS:Coil:Heating:DX:VariableSpeed,
         \min-fields 19
-        \extensible:1
    A1,  \field Handle
         \type handle
         \required-field
@@ -14462,10 +14459,9 @@ OS:Coil:Heating:DX:VariableSpeed,
         \autosizable
         \units W
         \ip-units W
-   A9;  \field Speed Data
-        \begin-extensible
+   A9;  \field Speed Data List
         \type object-list
-        \object-list CoilHeatingDXVariableSpeedSpeedData
+        \object-list ModelObjectLists
 
 OS:Coil:Heating:DX:VariableSpeed:SpeedData,
         \min-fields 9
@@ -14515,7 +14511,6 @@ OS:Coil:Heating:DX:VariableSpeed:SpeedData,
 
 OS:Coil:Cooling:DX:VariableSpeed,
         \min-fields 21
-        \extensible:1
    A1,  \field Handle
         \type handle
         \required-field
@@ -14605,10 +14600,9 @@ OS:Coil:Cooling:DX:VariableSpeed,
    A10, \field Basin Heater Operating Schedule Name
         \type object-list
         \object-list ScheduleNames
-   A11; \field Speed Data
-        \begin-extensible
+   A11; \field Speed Data List
         \type object-list
-        \object-list CoilCoolingDXVariableSpeedSpeedData
+        \object-list ModelObjectLists
 
 OS:Coil:Cooling:DX:VariableSpeed:SpeedData,
         \min-fields 12
@@ -14674,7 +14668,6 @@ OS:Coil:Cooling:DX:VariableSpeed:SpeedData,
 
 OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \min-fields 12
-        \extensible:1
    A1,  \field Handle
         \type handle
         \required-field
@@ -14724,10 +14717,9 @@ OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \type object-list
         \object-list QuadraticCubicCurves
         \object-list UniVariateTables
-   A8;  \field Speed Data
-        \begin-extensible
+   A8;  \field Speed Data List
         \type object-list
-        \object-list CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData
+        \object-list ModelObjectLists
 
 OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit:SpeedData,
         \min-fields 14
@@ -14802,7 +14794,6 @@ OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit:SpeedData,
 
 OS:Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \min-fields 15
-        \extensible:1
    A1,  \field Handle
         \type handle
         \required-field
@@ -14867,10 +14858,9 @@ OS:Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \type object-list
         \object-list QuadraticCubicCurves
         \object-list UniVariateTables
-   A8;  \field Speed Data
-        \begin-extensible
+   A8;  \field Speed Data List
         \type object-list
-        \object-list CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData
+        \object-list ModelObjectLists
 
 OS:Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit:SpeedData,
         \min-fields 15

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilCoolingDXVariableSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilCoolingDXVariableSpeed.cpp
@@ -136,12 +136,14 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilCoolingDXVariableSpee
     }
   }
   
+  auto const speeds = modelObject.speeds();
+
   // NumberofSpeeds
-  if( auto num = modelObject.speeds().size() ) {
+  if( auto num = speeds.size() ) {
     idfObject.setInt(Coil_Cooling_DX_VariableSpeedFields::NumberofSpeeds,num);
   }
 
-  for( auto speed: modelObject.speeds() ) {
+  for( auto const & speed : speeds ) {
     auto eg = idfObject.pushExtensibleGroup();
 
     // SpeedReferenceUnitGrossRatedTotalCoolingCapacity

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -119,12 +119,14 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilCoolingWaterToAirHeat
     }
   }
 
+  auto const speeds = modelObject.speeds();
+
   // NumberofSpeeds
-  if( auto num = modelObject.speeds().size() ) {
+  if( auto num = speeds.size() ) {
     idfObject.setInt(Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitFields::NumberofSpeeds,num);
   }
 
-  for( auto speed: modelObject.speeds() ) {
+  for( auto const & speed : speeds ) {
     auto eg = idfObject.pushExtensibleGroup();
 
     // SpeedReferenceUnitGrossRatedTotalCoolingCapacity

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingDXMultiSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingDXMultiSpeed.cpp
@@ -131,13 +131,15 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingDXMultiSpeed( 
   if( auto num = modelObject.regionnumberforCalculatingHSPF() ) {
     idfObject.setInt(Coil_Heating_DX_MultiSpeedFields::RegionnumberforCalculatingHSPF,num);
   }
+
+  auto const stages = modelObject.stages();
   
   // NumberofSpeeds
-  if( auto num = modelObject.stages().size() ) {
+  if( auto num = stages.size() ) {
     idfObject.setInt(Coil_Heating_DX_MultiSpeedFields::NumberofSpeeds,num);
   }
 
-  for( auto stage: modelObject.stages() ) {
+  for( auto const & stage : stages ) {
     auto eg = idfObject.pushExtensibleGroup();
   
     // GrossRatedHeatingCapacity

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingDXVariableSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingDXVariableSpeed.cpp
@@ -135,12 +135,14 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingDXVariableSpee
     idfObject.setDouble(Coil_Heating_DX_VariableSpeedFields::ResistiveDefrostHeaterCapacity,value.get());
   }
   
+  auto const speeds = modelObject.speeds();
+  
   // NumberofSpeeds
-  if( auto num = modelObject.speeds().size() ) {
+  if( auto num = speeds.size() ) {
     idfObject.setInt(Coil_Heating_DX_VariableSpeedFields::NumberofSpeeds,num);
   }
 
-  for( auto speed: modelObject.speeds() ) {
+  for( auto const & speed : speeds ) {
     auto eg = idfObject.pushExtensibleGroup();
 
     // SpeedReferenceUnitGrossRatedHeatingCapacity

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -102,12 +102,14 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingWaterToAirHeat
     }
   }
 
+  auto const speeds = modelObject.speeds();
+
   // NumberofSpeeds
-  if( auto num = modelObject.speeds().size() ) {
+  if( auto num = speeds.size() ) {
     idfObject.setInt(Coil_Heating_WaterToAirHeatPump_VariableSpeedEquationFitFields::NumberofSpeeds,num);
   }
 
-  for( auto speed: modelObject.speeds() ) {
+  for( auto const & speed : speeds ) {
     auto eg = idfObject.pushExtensibleGroup();
 
     // SpeedReferenceUnitGrossRatedHeatingCapacity

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed.cpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed.cpp
@@ -27,7 +27,7 @@
 #include "CoilCoolingDXVariableSpeedSpeedData_Impl.hpp"
 // #include "WaterStorageTank.hpp"
 // #include "WaterStorageTank_Impl.hpp"
-
+#include "ModelObjectList.hpp"
 #include "AirLoopHVACUnitarySystem.hpp"
 #include "AirLoopHVACUnitarySystem_Impl.hpp"
 #include "AirLoopHVACUnitaryHeatPumpAirToAir.hpp"
@@ -379,10 +379,9 @@ namespace detail {
   ModelObject CoilCoolingDXVariableSpeed_Impl::clone(Model model) const {
     auto t_clone = StraightComponent_Impl::clone(model).cast<CoilCoolingDXVariableSpeed>();
 
-    auto t_speeds = speeds();
-    for( auto speed : t_speeds ) {
-      auto speedClone = speed.clone(model).cast<CoilCoolingDXVariableSpeedSpeedData>();
-      t_clone.addSpeed(speedClone);
+    if (auto speedDataList = this->speedDataList()) {
+      auto speedDataListClone = speedDataList->clone(model).cast<ModelObjectList>();
+      t_clone.getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataListClone);
     }
 
     t_clone.setEnergyPartLoadFractionCurve( energyPartLoadFractionCurve().clone(model).cast<Curve>() );
@@ -391,29 +390,60 @@ namespace detail {
   }
 
   std::vector<ModelObject> CoilCoolingDXVariableSpeed_Impl::children() const {
-    auto children = subsetCastVector<ModelObject>( speeds() );
+    std::vector<ModelObject children;
     children.push_back( energyPartLoadFractionCurve() );
+    if( auto const speedDataList = speedDataList() ) {
+      children.push_back( speedDataList.get() );
+    }
     return children;
+  }
+
+  boost::optional<ModelObjectList> CoilCoolingDXVariableSpeed_Impl::speedDataList() const {
+    return getObject<ModelObject>().getModelObjectTarget<ModelObjectList>(OS_Coil_Cooling_DX_VariableSpeedFields::SpeedDataList);
+  }
+
+  bool CoilCoolingDXVariableSpeed_Impl::addSpeed( const CoilCoolingDXVariableSpeedSpeedData & speed) {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      modelObjectList->addModelObject(speed);
+    }
+    return false;
+  }
+
+  void CoilCoolingDXVariableSpeed_Impl::removeSpeed( const CoilCoolingDXVariableSpeedSpeedData & speed) {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      modelObjectList->removeModelObject(speed);
+    }
+  }
+
+  void CoilCoolingDXVariableSpeed_Impl::removeAllSpeeds() {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      auto const modelObjects = modelObjectList->modelObjects();
+
+      for(const auto & elem : modelObjects) {
+          auto const modelObject = elem.optionalCast<CoilCoolingDXVariableSpeedSpeedData>();
+          if (modelObject) {
+            modelObjectList->removeModelObject(elem);
+          }
+      }
+    }
   }
 
   std::vector<CoilCoolingDXVariableSpeedSpeedData> CoilCoolingDXVariableSpeed_Impl::speeds() const {
     std::vector<CoilCoolingDXVariableSpeedSpeedData> result;
-    auto groups = extensibleGroups();
-    for( auto group : groups ) {
-      auto target = group.cast<WorkspaceExtensibleGroup>().getTarget(OS_Coil_Cooling_DX_VariableSpeedExtensibleFields::SpeedData);
-      if( target ) {
-        if( auto speed = target->optionalCast<CoilCoolingDXVariableSpeedSpeedData>() ) {
-          result.push_back(speed.get());
-        }
+    auto const modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      auto const modelObjects = modelObjectList->modelObjects();
+
+      for(const auto & elem : modelObjects) {
+          auto const modelObject = elem.optionalCast<CoilCoolingDXVariableSpeedSpeedData>();
+          if (modelObject) {
+            result.push_back(modelObject.get());
+          }
       }
     }
-    return result;
-  }
-
-  void CoilCoolingDXVariableSpeed_Impl::addSpeed(CoilCoolingDXVariableSpeedSpeedData& speed) {
-    auto group = getObject<ModelObject>().pushExtensibleGroup().cast<WorkspaceExtensibleGroup>();
-    OS_ASSERT(! group.empty());
-    group.setPointer(OS_Coil_Cooling_DX_VariableSpeedExtensibleFields::SpeedData,speed.handle());
   }
 
   boost::optional<HVACComponent> CoilCoolingDXVariableSpeed_Impl::containingHVACComponent() const
@@ -488,6 +518,23 @@ namespace detail {
     return false;
   }
 
+  bool CoilCoolingDXVariableSpeed_Impl::setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList) {
+    bool result(false);
+    if (modelObjectList) {
+      result = setPointer(OS_Coil_Cooling_DX_VariableSpeedFields::SpeedDataList, modelObjectList.get().handle());
+    }
+    else {
+      resetSpeedDataList();
+      result = true;
+    }
+    return result;
+  }
+
+  void CoilCoolingDXVariableSpeed_Impl::resetSpeedDataList() {
+    bool result = setString(OS_Coil_Cooling_DX_VariableSpeedFields::SpeedDataList, "");
+    OS_ASSERT(result);
+  }
+
 } // detail
 
 CoilCoolingDXVariableSpeed::CoilCoolingDXVariableSpeed(const Model& model)
@@ -529,6 +576,10 @@ CoilCoolingDXVariableSpeed::CoilCoolingDXVariableSpeed(const Model& model)
   OS_ASSERT(ok);
   ok = setBasinHeaterSetpointTemperature(2.0);
   OS_ASSERT(ok);
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  bool ok = getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
 
 }
 
@@ -748,8 +799,16 @@ std::vector<CoilCoolingDXVariableSpeedSpeedData> CoilCoolingDXVariableSpeed::spe
   return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->speeds();
 }
 
-void CoilCoolingDXVariableSpeed::addSpeed(CoilCoolingDXVariableSpeedSpeedData& speed) {
+void CoilCoolingDXVariableSpeed::addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed) {
   return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->addSpeed(speed);
+}
+
+void CoilCoolingDXVariableSpeed::removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed) {
+  return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeSpeed(speed);
+}
+
+void CoilCoolingDXVariableSpeed::removeAllSpeeds() {
+  return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed.cpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed.cpp
@@ -28,6 +28,7 @@
 // #include "WaterStorageTank.hpp"
 // #include "WaterStorageTank_Impl.hpp"
 #include "ModelObjectList.hpp"
+#include "ModelObjectList_Impl.hpp"
 #include "AirLoopHVACUnitarySystem.hpp"
 #include "AirLoopHVACUnitarySystem_Impl.hpp"
 #include "AirLoopHVACUnitaryHeatPumpAirToAir.hpp"
@@ -390,10 +391,10 @@ namespace detail {
   }
 
   std::vector<ModelObject> CoilCoolingDXVariableSpeed_Impl::children() const {
-    std::vector<ModelObject children;
+    std::vector<ModelObject> children;
     children.push_back( energyPartLoadFractionCurve() );
-    if( auto const speedDataList = speedDataList() ) {
-      children.push_back( speedDataList.get() );
+    if( auto const _stageDataList = speedDataList() ) {
+      children.push_back( _stageDataList.get() );
     }
     return children;
   }
@@ -444,6 +445,7 @@ namespace detail {
           }
       }
     }
+    return result;
   }
 
   boost::optional<HVACComponent> CoilCoolingDXVariableSpeed_Impl::containingHVACComponent() const
@@ -579,7 +581,8 @@ CoilCoolingDXVariableSpeed::CoilCoolingDXVariableSpeed(const Model& model)
 
   auto speedDataList = ModelObjectList(model);
   speedDataList.setName(this->name().get() + " Speed Data List");
-  bool ok = getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
+  ok = getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
+  OS_ASSERT(ok);
 
 }
 
@@ -614,6 +617,11 @@ CoilCoolingDXVariableSpeed::CoilCoolingDXVariableSpeed(const Model& model,
   ok = setBasinHeaterCapacity(0.0);
   OS_ASSERT(ok);
   ok = setBasinHeaterSetpointTemperature(2.0);
+  OS_ASSERT(ok);
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  ok = getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
   OS_ASSERT(ok);
 
 }
@@ -799,16 +807,16 @@ std::vector<CoilCoolingDXVariableSpeedSpeedData> CoilCoolingDXVariableSpeed::spe
   return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->speeds();
 }
 
-void CoilCoolingDXVariableSpeed::addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed) {
+bool CoilCoolingDXVariableSpeed::addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed) {
   return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->addSpeed(speed);
 }
 
 void CoilCoolingDXVariableSpeed::removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed) {
-  return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeSpeed(speed);
+  getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeSpeed(speed);
 }
 
 void CoilCoolingDXVariableSpeed::removeAllSpeeds() {
-  return getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeAllSpeeds();
+  getImpl<detail::CoilCoolingDXVariableSpeed_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed.hpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed.hpp
@@ -153,7 +153,7 @@ class MODEL_API CoilCoolingDXVariableSpeed : public StraightComponent {
 
   std::vector<CoilCoolingDXVariableSpeedSpeedData> speeds() const;
 
-  void addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+  bool addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
 
   void removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed.hpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed.hpp
@@ -97,8 +97,6 @@ class MODEL_API CoilCoolingDXVariableSpeed : public StraightComponent {
 
   boost::optional<Schedule> basinHeaterOperatingSchedule() const;
 
-  std::vector<CoilCoolingDXVariableSpeedSpeedData> speeds() const;
-
   //@}
   /** @name Setters */
   //@{
@@ -149,11 +147,17 @@ class MODEL_API CoilCoolingDXVariableSpeed : public StraightComponent {
 
   void resetBasinHeaterOperatingSchedule();
 
-  void addSpeed(CoilCoolingDXVariableSpeedSpeedData& speed);
-
   //@}
   /** @name Other */
   //@{
+
+  std::vector<CoilCoolingDXVariableSpeedSpeedData> speeds() const;
+
+  void addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+
+  void removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+
+  void removeAllSpeeds();
 
   //@}
  protected:

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed_Impl.hpp
@@ -30,6 +30,7 @@ class Curve;
 // class WaterStorageTank;
 class Schedule;
 class CoilCoolingDXVariableSpeedSpeedData;
+class ModelObjectList;
 
 namespace detail {
 
@@ -173,9 +174,19 @@ namespace detail {
     /** @name Other */
     //@{
 
+    bool setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList);
+
+    void resetSpeedDataList();
+
+    boost::optional<ModelObjectList> speedDataList() const;
+
     std::vector<CoilCoolingDXVariableSpeedSpeedData> speeds() const;
 
-    void addSpeed(CoilCoolingDXVariableSpeedSpeedData& speed);
+    void addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+
+    void removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+
+    void removeAllSpeeds();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilCoolingDXVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilCoolingDXVariableSpeed_Impl.hpp
@@ -182,7 +182,7 @@ namespace detail {
 
     std::vector<CoilCoolingDXVariableSpeedSpeedData> speeds() const;
 
-    void addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
+    bool addSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
 
     void removeSpeed(const CoilCoolingDXVariableSpeedSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -240,6 +240,11 @@ namespace detail {
   {
     auto newCoil = WaterToAirComponent_Impl::clone(model).cast<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit>();
 
+    if (auto speedDataList = this->speedDataList()) {
+      auto speedDataListClone = speedDataList->clone(model).cast<ModelObjectList>();
+      newCoil.getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataListClone);
+    }
+
     newCoil.setEnergyPartLoadFractionCurve( energyPartLoadFractionCurve().clone(model).cast<Curve>() );
 
     return newCoil;
@@ -247,6 +252,11 @@ namespace detail {
 
   std::vector<ModelObject> CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::children() const {
     std::vector<ModelObject> children;
+
+    if( auto const speedDataList = speedDataList() ) {
+      children.push_back( speedDataList.get() );
+    }
+
     children.push_back( energyPartLoadFractionCurve() );
     return children;
   }
@@ -298,24 +308,69 @@ namespace detail {
     return boost::none;
   }
 
+  boost::optional<ModelObjectList> CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::speedDataList() const {
+    return getObject<ModelObject>().getModelObjectTarget<ModelObjectList>(OS_Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitFields::SpeedDataList);
+  }
+
+  bool CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::addSpeed( const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData & speed) {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      modelObjectList->addModelObject(speed);
+    }
+    return false;
+  }
+
+  void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::removeSpeed( const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData & speed) {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      modelObjectList->removeModelObject(speed);
+    }
+  }
+
+  void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::removeAllSpeeds() {
+    auto modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      auto const modelObjects = modelObjectList->modelObjects();
+
+      for(const auto & elem : modelObjects) {
+          auto const modelObject = elem.optionalCast<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData>();
+          if (modelObject) {
+            modelObjectList->removeModelObject(elem);
+          }
+      }
+    }
+  }
+
   std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::speeds() const {
     std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> result;
-    auto groups = extensibleGroups();
-    for( auto group : groups ) {
-      auto target = group.cast<WorkspaceExtensibleGroup>().getTarget(OS_Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitExtensibleFields::SpeedData);
-      if( target ) {
-        if( auto speed = target->optionalCast<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData>() ) {
-          result.push_back(speed.get());
-        }
+    auto const modelObjectList = speedDataList();
+    if( modelObjectList ) {
+      auto const modelObjects = modelObjectList->modelObjects();
+
+      for(const auto & elem : modelObjects) {
+          auto const modelObject = elem.optionalCast<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData>();
+          if (modelObject) {
+            result.push_back(modelObject.get());
+          }
       }
+    }
+  }
+
+bool CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList) {
+    bool result(false);
+    if (modelObjectList) {
+      result = setPointer(OS_Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitFields::SpeedDataList, modelObjectList.get().handle());
+    }
+    else {
+      resetSpeedDataList();
+      result = true;
     }
     return result;
   }
 
-  void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
-    auto group = getObject<ModelObject>().pushExtensibleGroup().cast<WorkspaceExtensibleGroup>();
-    OS_ASSERT(! group.empty());
-    group.setPointer(OS_Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitExtensibleFields::SpeedData,speed.handle());
+  void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::resetSpeedDataList() {
+    bool result = setString(OS_Coil_Cooling_WaterToAirHeatPump_VariableSpeedEquationFitFields::SpeedDataList, "");
+    OS_ASSERT(result);
   }
 
 } // detail
@@ -345,6 +400,10 @@ CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::CoilCoolingWaterToAirHeat
 
   ok = setEnergyPartLoadFractionCurve(partLoadFraction);
   OS_ASSERT(ok);
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  bool ok = getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
 }
 
 CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit(const Model& model,
@@ -465,6 +524,14 @@ std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> Coil
 
 void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
   return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->addSpeed(speed);
+}
+
+void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
+  return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeSpeed(speed);
+}
+
+void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::removeAllSpeeds() {
+  return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -27,6 +27,8 @@
 #include "CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData_Impl.hpp"
 #include "ZoneHVACComponent.hpp"
 #include "HVACComponent.hpp"
+#include "ModelObjectList.hpp"
+#include "ModelObjectList_Impl.hpp"
 #include "ZoneHVACWaterToAirHeatPump.hpp"
 #include "ZoneHVACWaterToAirHeatPump_Impl.hpp"
 #include "AirLoopHVACUnitarySystem.hpp"
@@ -253,8 +255,8 @@ namespace detail {
   std::vector<ModelObject> CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::children() const {
     std::vector<ModelObject> children;
 
-    if( auto const speedDataList = speedDataList() ) {
-      children.push_back( speedDataList.get() );
+    if( auto const _stageDataList = speedDataList() ) {
+      children.push_back( _stageDataList.get() );
     }
 
     children.push_back( energyPartLoadFractionCurve() );
@@ -354,6 +356,7 @@ namespace detail {
           }
       }
     }
+    return result;
   }
 
 bool CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList) {
@@ -403,7 +406,8 @@ CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::CoilCoolingWaterToAirHeat
 
   auto speedDataList = ModelObjectList(model);
   speedDataList.setName(this->name().get() + " Speed Data List");
-  bool ok = getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
+  ok = getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
+  OS_ASSERT(ok);
 }
 
 CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit(const Model& model,
@@ -423,6 +427,11 @@ CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::CoilCoolingWaterToAirHeat
   OS_ASSERT(ok);
   setUseHotGasReheat(false);
   ok = setEnergyPartLoadFractionCurve(partLoadFraction);
+  OS_ASSERT(ok);
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  ok = getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
   OS_ASSERT(ok);
 }
 
@@ -522,16 +531,16 @@ std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> Coil
   return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->speeds();
 }
 
-void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
+bool CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
   return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->addSpeed(speed);
 }
 
 void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
-  return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeSpeed(speed);
+  getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeSpeed(speed);
 }
 
 void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit::removeAllSpeeds() {
-  return getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeAllSpeeds();
+  getImpl<detail::CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
@@ -109,7 +109,7 @@ class MODEL_API CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit : public W
 
   std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
-  void addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+  bool addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
   void removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
@@ -111,6 +111,10 @@ class MODEL_API CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit : public W
 
   void addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
+  void removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+  void removeAllSpeeds();
+
   //@}
  protected:
   /// @cond

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
@@ -28,6 +28,7 @@ namespace model {
 
 class Curve;
 class CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData;
+class ModelObjectList;
 
 namespace detail {
 
@@ -133,9 +134,19 @@ namespace detail {
     /** @name Other */
     //@{
 
+    bool setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList);
+
+    void resetSpeedDataList();
+
+    boost::optional<ModelObjectList> speedDataList() const;
+
     std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
     void addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+    void removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+    void removeAllSpeeds();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
+++ b/openstudiocore/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
@@ -142,7 +142,7 @@ namespace detail {
 
     std::vector<CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
-    void addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+    bool addSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
     void removeSpeed(const CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilHeatingDXMultiSpeed.cpp
+++ b/openstudiocore/src/model/CoilHeatingDXMultiSpeed.cpp
@@ -27,6 +27,7 @@
 #include "Model.hpp"
 #include "Model_Impl.hpp"
 #include "ModelObjectList.hpp"
+#include "ModelObjectList_Impl.hpp"
 #include "CoilHeatingDXMultiSpeedStageData.hpp"
 #include "CoilHeatingDXMultiSpeedStageData_Impl.hpp"
 #include "AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.hpp"
@@ -312,9 +313,9 @@ namespace detail {
   }
 
   std::vector<ModelObject> CoilHeatingDXMultiSpeed_Impl::children() const {
-    std::vector<ModelObject children;
-    if( auto const stageDataList = stageDataList() ) {
-      children.push_back( stageDataList.get() );
+    std::vector<ModelObject> children;
+    if( auto const _stageDataList = stageDataList() ) {
+      children.push_back( _stageDataList.get() );
     }
     if ( auto const curve = defrostEnergyInputRatioFunctionofTemperatureCurve() ) {
       children.push_back( curve.get() );
@@ -329,7 +330,7 @@ namespace detail {
   bool CoilHeatingDXMultiSpeed_Impl::addStage( const CoilHeatingDXMultiSpeedStageData & stage) {
     auto modelObjectList = stageDataList();
     if( modelObjectList ) {
-      modelObjectList->addModelObject(speed);
+      modelObjectList->addModelObject(stage);
     }
     return false;
   }
@@ -337,7 +338,7 @@ namespace detail {
   void CoilHeatingDXMultiSpeed_Impl::removeStage( const CoilHeatingDXMultiSpeedStageData & stage) {
     auto modelObjectList = stageDataList();
     if( modelObjectList ) {
-      modelObjectList->removeModelObject(speed);
+      modelObjectList->removeModelObject(stage);
     }
   }
 
@@ -368,6 +369,7 @@ namespace detail {
           }
       }
     }
+    return result;
   }
 
   boost::optional<HVACComponent> CoilHeatingDXMultiSpeed_Impl::containingHVACComponent() const
@@ -441,7 +443,8 @@ CoilHeatingDXMultiSpeed::CoilHeatingDXMultiSpeed(const Model& model)
 
   auto stageDataList = ModelObjectList(model);
   stageDataList.setName(this->name().get() + " Stage Data List");
-  bool ok = getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->setStageDataList(stageDataList);
+  ok = getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->setStageDataList(stageDataList);
+  OS_ASSERT(ok);
 
 }
 
@@ -600,8 +603,16 @@ std::vector<CoilHeatingDXMultiSpeedStageData> CoilHeatingDXMultiSpeed::stages() 
   return getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->stages();
 }
 
-void CoilHeatingDXMultiSpeed::addStage(const CoilHeatingDXMultiSpeedStageData& stage) {
+bool CoilHeatingDXMultiSpeed::addStage(const CoilHeatingDXMultiSpeedStageData& stage) {
   return getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->addStage(stage);
+}
+
+void CoilHeatingDXMultiSpeed::removeStage(const CoilHeatingDXMultiSpeedStageData& stage) {
+  getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->removeStage(stage);
+}
+
+void CoilHeatingDXMultiSpeed::removeAllStages() {
+  getImpl<detail::CoilHeatingDXMultiSpeed_Impl>()->removeAllStages();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilHeatingDXMultiSpeed.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXMultiSpeed.hpp
@@ -138,7 +138,7 @@ class MODEL_API CoilHeatingDXMultiSpeed : public StraightComponent {
   std::vector<CoilHeatingDXMultiSpeedStageData> stages() const;
 
   /** Add a new stage after all of the existing stages **/
-  void addStage(const CoilHeatingDXMultiSpeedStageData& stage);
+  bool addStage(const CoilHeatingDXMultiSpeedStageData& stage);
 
   /** Remove a stage **/
   void removeStage(const CoilHeatingDXMultiSpeedStageData& stage);

--- a/openstudiocore/src/model/CoilHeatingDXMultiSpeed.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXMultiSpeed.hpp
@@ -140,6 +140,12 @@ class MODEL_API CoilHeatingDXMultiSpeed : public StraightComponent {
   /** Add a new stage after all of the existing stages **/
   void addStage(const CoilHeatingDXMultiSpeedStageData& stage);
 
+  /** Remove a stage **/
+  void removeStage(const CoilHeatingDXMultiSpeedStageData& stage);
+
+  /** Remove all stages **/
+  void removeAllStages();
+
   //@}
  protected:
   /// @cond

--- a/openstudiocore/src/model/CoilHeatingDXMultiSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXMultiSpeed_Impl.hpp
@@ -29,6 +29,7 @@ namespace model {
 class Schedule;
 class Curve;
 class CoilHeatingDXMultiSpeedStageData;
+class ModelObjectList;
 
 namespace detail {
 
@@ -152,9 +153,19 @@ namespace detail {
     /** @name Other */
     //@{
 
+    bool setStageDataList(const boost::optional<ModelObjectList>& modelObjectList);
+
+    void resetStageDataList();
+
+    boost::optional<ModelObjectList> stageDataList() const;
+
     std::vector<CoilHeatingDXMultiSpeedStageData> stages() const;
 
     void addStage(const CoilHeatingDXMultiSpeedStageData& stage);
+
+    void removeStage(const CoilHeatingDXMultiSpeedStageData& stage);
+
+    void removeAllStagess();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilHeatingDXMultiSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXMultiSpeed_Impl.hpp
@@ -161,11 +161,11 @@ namespace detail {
 
     std::vector<CoilHeatingDXMultiSpeedStageData> stages() const;
 
-    void addStage(const CoilHeatingDXMultiSpeedStageData& stage);
+    bool addStage(const CoilHeatingDXMultiSpeedStageData& stage);
 
     void removeStage(const CoilHeatingDXMultiSpeedStageData& stage);
 
-    void removeAllStagess();
+    void removeAllStages();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilHeatingDXVariableSpeed.cpp
+++ b/openstudiocore/src/model/CoilHeatingDXVariableSpeed.cpp
@@ -26,6 +26,7 @@
 #include "CoilHeatingDXVariableSpeedSpeedData.hpp"
 #include "CoilHeatingDXVariableSpeedSpeedData_Impl.hpp"
 #include "ModelObjectList.hpp"
+#include "ModelObjectList_Impl.hpp"
 #include "AirLoopHVACUnitarySystem.hpp"
 #include "AirLoopHVACUnitarySystem_Impl.hpp"
 #include "AirLoopHVACUnitaryHeatPumpAirToAir.hpp"
@@ -337,9 +338,9 @@ namespace detail {
   }
 
   std::vector<ModelObject> CoilHeatingDXVariableSpeed_Impl::children() const {
-    std::vector<ModelObject children;
-    if( auto const speedDataList = speedDataList() ) {
-      children.push_back( speedDataList.get() );
+    std::vector<ModelObject> children;
+    if( auto const _stageDataList = speedDataList() ) {
+      children.push_back( _stageDataList.get() );
     }
     children.push_back( energyPartLoadFractionCurve() );
     if ( auto curve = defrostEnergyInputRatioFunctionofTemperatureCurve() ) {
@@ -394,6 +395,7 @@ namespace detail {
           }
       }
     }
+    return result;
   }
 
   boost::optional<HVACComponent> CoilHeatingDXVariableSpeed_Impl::containingHVACComponent() const
@@ -511,7 +513,8 @@ CoilHeatingDXVariableSpeed::CoilHeatingDXVariableSpeed(const Model& model)
 
   auto speedDataList = ModelObjectList(model);
   speedDataList.setName(this->name().get() + " Speed Data List");
-  bool ok = getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
+  ok = getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
+  OS_ASSERT(ok);
 
 }
 
@@ -542,6 +545,11 @@ CoilHeatingDXVariableSpeed::CoilHeatingDXVariableSpeed(const Model& model,
   ok = setDefrostTimePeriodFraction(0.166667);
   OS_ASSERT(ok);
   autosizeResistiveDefrostHeaterCapacity();
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  ok = getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->setSpeedDataList(speedDataList);
+  OS_ASSERT(ok);
 
 }
 
@@ -707,16 +715,16 @@ std::vector<CoilHeatingDXVariableSpeedSpeedData> CoilHeatingDXVariableSpeed::spe
   return getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->speeds();
 }
 
-void CoilHeatingDXVariableSpeed::addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed) {
+bool CoilHeatingDXVariableSpeed::addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed) {
   return getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->addSpeed(speed);
 }
 
 void CoilHeatingDXVariableSpeed::removeSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed) {
-  return getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->removeSpeed(speed);
+  getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->removeSpeed(speed);
 }
 
 void CoilHeatingDXVariableSpeed::removeAllSpeeds() {
-  return getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->removeAllSpeeds();
+  getImpl<detail::CoilHeatingDXVariableSpeed_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilHeatingDXVariableSpeed.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXVariableSpeed.hpp
@@ -141,7 +141,7 @@ class MODEL_API CoilHeatingDXVariableSpeed : public StraightComponent {
 
   std::vector<CoilHeatingDXVariableSpeedSpeedData> speeds() const;
 
-  void addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+  bool addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
 
   void removeSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilHeatingDXVariableSpeed.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXVariableSpeed.hpp
@@ -93,8 +93,6 @@ class MODEL_API CoilHeatingDXVariableSpeed : public StraightComponent {
 
   bool isResistiveDefrostHeaterCapacityAutosized() const;
 
-  std::vector<CoilHeatingDXVariableSpeedSpeedData> speeds() const;
-
   //@}
   /** @name Setters */
   //@{
@@ -137,11 +135,17 @@ class MODEL_API CoilHeatingDXVariableSpeed : public StraightComponent {
 
   void autosizeResistiveDefrostHeaterCapacity();
 
-  void addSpeed(CoilHeatingDXVariableSpeedSpeedData& speed);
-
   //@}
   /** @name Other */
   //@{
+
+  std::vector<CoilHeatingDXVariableSpeedSpeedData> speeds() const;
+
+  void addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+
+  void removeSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+
+  void removeAllSpeeds();
 
   //@}
  protected:

--- a/openstudiocore/src/model/CoilHeatingDXVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXVariableSpeed_Impl.hpp
@@ -28,6 +28,7 @@ namespace model {
 
 class Curve;
 class CoilHeatingDXVariableSpeedSpeedData;
+class ModelObjectList;
 
 namespace detail {
 
@@ -157,9 +158,19 @@ namespace detail {
     /** @name Other */
     //@{
 
+    bool setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList);
+
+    void resetSpeedDataList();
+
+    boost::optional<ModelObjectList> speedDataList() const;
+
     std::vector<CoilHeatingDXVariableSpeedSpeedData> speeds() const;
 
-    void addSpeed(CoilHeatingDXVariableSpeedSpeedData& speed);
+    void addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+
+    void removeSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+
+    void removeAllSpeeds();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilHeatingDXVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingDXVariableSpeed_Impl.hpp
@@ -166,7 +166,7 @@ namespace detail {
 
     std::vector<CoilHeatingDXVariableSpeedSpeedData> speeds() const;
 
-    void addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
+    bool addSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
 
     void removeSpeed(const CoilHeatingDXVariableSpeedSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -26,6 +26,7 @@
 #include "CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData.hpp"
 #include "CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData_Impl.hpp"
 #include "ModelObjectList.hpp"
+#include "ModelObjectList_Impl.hpp"
 #include "ZoneHVACComponent.hpp"
 #include "HVACComponent.hpp"
 #include "ZoneHVACWaterToAirHeatPump.hpp"
@@ -221,8 +222,8 @@ namespace detail {
 
   std::vector<ModelObject> CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::children() const {
     std::vector<ModelObject> children;
-    if( auto const speedDataList = speedDataList() ) {
-      children.push_back( speedDataList.get() );
+    if( auto const _stageDataList = speedDataList() ) {
+      children.push_back( _stageDataList.get() );
     }
     children.push_back( energyPartLoadFractionCurve() );
     return children;
@@ -321,6 +322,7 @@ namespace detail {
           }
       }
     }
+    return result;
   }
 
   bool CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList) {
@@ -365,7 +367,8 @@ CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::CoilHeatingWaterToAirHeat
 
   auto speedDataList = ModelObjectList(model);
   speedDataList.setName(this->name().get() + " Speed Data List");
-  bool ok = getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
+  ok = getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
+  OS_ASSERT(ok);
 }
 
 CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit(const Model& model,
@@ -380,6 +383,11 @@ CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::CoilHeatingWaterToAirHeat
   autosizeRatedAirFlowRateAtSelectedNominalSpeedLevel();
   autosizeRatedWaterFlowRateAtSelectedNominalSpeedLevel();
   ok = setEnergyPartLoadFractionCurve(partLoadFraction);
+  OS_ASSERT(ok);
+
+  auto speedDataList = ModelObjectList(model);
+  speedDataList.setName(this->name().get() + " Speed Data List");
+  ok = getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->setSpeedDataList(speedDataList);
   OS_ASSERT(ok);
 }
 
@@ -455,16 +463,16 @@ std::vector<CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> Coil
   return getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->speeds();
 }
 
-void CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
+bool CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
   return getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->addSpeed(speed);
 }
 
 void CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::removeSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed) {
-  return getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeSpeed(speed);
+  getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeSpeed(speed);
 }
 
 void CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit::removeAllSpeeds() {
-  return getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeAllSpeeds();
+  getImpl<detail::CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl>()->removeAllSpeeds();
 }
 
 /// @cond

--- a/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
@@ -99,6 +99,10 @@ class MODEL_API CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit : public W
 
   void addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
+  void removeSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+  void removeAllSpeeds();
+
   //@}
  protected:
   /// @cond

--- a/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.hpp
@@ -97,7 +97,7 @@ class MODEL_API CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit : public W
 
   std::vector<CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
-  void addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+  bool addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
   void removeSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 

--- a/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
@@ -28,6 +28,7 @@ namespace model {
 
 class Curve;
 class CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData;
+class ModelObjectList;
 
 namespace detail {
 
@@ -121,9 +122,19 @@ namespace detail {
     /** @name Other */
     //@{
 
+    bool setSpeedDataList(const boost::optional<ModelObjectList>& modelObjectList);
+
+    void resetSpeedDataList();
+
+    boost::optional<ModelObjectList> speedDataList() const;
+
     std::vector<CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
     void addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+    void removeSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+
+    void removeAllSpeeds();
 
     //@}
    protected:

--- a/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl.hpp
@@ -130,7 +130,7 @@ namespace detail {
 
     std::vector<CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData> speeds() const;
 
-    void addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
+    bool addSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 
     void removeSpeed(const CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFitSpeedData& speed);
 


### PR DESCRIPTION
This converts the new coils from using extensible fields to ModelObjectList instead. This is a better approach.