### PR TITLE
Coil heating dx multi speed adjustments

### DIFF
--- a/openstudiocore/resources/energyplus/ProposedEnergy+.idd
+++ b/openstudiocore/resources/energyplus/ProposedEnergy+.idd
@@ -33457,6 +33457,7 @@ AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed,
         \type object-list
         \object-list HeatingCoilsElectricMultiStage
         \object-list HeatingCoilsGasMultiStage
+        \object-list HeatingCoilsDXMultiSpeed
    N1 , \field Minimum Outdoor Dry-Bulb Temperature for Compressor Operation
         \type real
         \default -8.0

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -8198,6 +8198,7 @@ OS:AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed,
         \type object-list
         \object-list HeatingCoilsElectricMultiStage
         \object-list HeatingCoilsGasMultiStage
+        \object-list HeatingCoilsDXMultiSpeed
    N1 , \field Minimum Outdoor Dry-Bulb Temperature for Compressor Operation
         \type real
         \minimum -20.0

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.cpp
@@ -37,6 +37,7 @@
 #include <utilities/idd/Coil_Heating_Gas_MultiStage_FieldEnums.hxx>
 #include <utilities/idd/Coil_Heating_Electric_FieldEnums.hxx>
 #include <utilities/idd/Coil_Heating_Water_FieldEnums.hxx>
+#include <utilities/idd/Coil_Heating_DX_MultiSpeed_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_DX_MultiSpeed_FieldEnums.hxx>
 #include "../../utilities/idd/IddEnums.hpp"
 #include <utilities/idd/IddEnums.hxx>
@@ -346,6 +347,9 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatPum
     } else if( _heatingCoil->iddObject().type() == IddObjectType::Coil_Heating_Water ) {
       _heatingCoil->setString(Coil_Heating_WaterFields::AirInletNodeName,heatingCoilInletNodeName);
       _heatingCoil->setString(Coil_Heating_WaterFields::AirOutletNodeName,heatingCoilOutletNodeName);
+    } else if( _heatingCoil->iddObject().type() == IddObjectType::Coil_Heating_DX_MultiSpeed ) {
+      _heatingCoil->setString(Coil_Heating_DX_MultiSpeedFields::AirInletNodeName,heatingCoilInletNodeName);
+      _heatingCoil->setString(Coil_Heating_DX_MultiSpeedFields::AirOutletNodeName,heatingCoilOutletNodeName);
     }
   }
 

--- a/openstudiocore/src/model/CoilCoolingDXMultiSpeedStageData.cpp
+++ b/openstudiocore/src/model/CoilCoolingDXMultiSpeedStageData.cpp
@@ -23,6 +23,10 @@
 #include "../model/Curve_Impl.hpp"
 #include "../model/Model.hpp"
 #include "../model/Model_Impl.hpp"
+#include "../model/CurveBiquadratic.hpp"
+#include "../model/CurveBiquadratic_Impl.hpp"
+#include "../model/CurveQuadratic.hpp"
+#include "../model/CurveQuadratic_Impl.hpp"
 #include <utilities/idd/OS_Coil_Cooling_DX_MultiSpeed_StageData_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include "../utilities/units/Unit.hpp"
@@ -421,6 +425,91 @@ namespace detail {
   }
 
 } // detail
+
+CoilCoolingDXMultiSpeedStageData::CoilCoolingDXMultiSpeedStageData(const Model& model)
+  : ParentObject(CoilCoolingDXMultiSpeedStageData::iddObjectType(),model)
+{
+  OS_ASSERT(getImpl<detail::CoilCoolingDXMultiSpeedStageData_Impl>());
+
+  autosizeGrossRatedTotalCoolingCapacity();
+  autosizeGrossRatedSensibleHeatRatio();
+  setGrossRatedCoolingCOP(3.0);
+  autosizeRatedAirFlowRate();
+  autosizeRatedEvaporativeCondenserPumpPowerConsumption();
+  setNominalTimeforCondensateRemovaltoBegin(0.0);
+  setRatioofInitialMoistureEvaporationRateandSteadyStateLatentCapacity(0.0);
+  setMaximumCyclingRate(0.0);
+  setLatentCapacityTimeConstant(0.0);
+  setRatedWasteHeatFractionofPowerInput(0.0);
+  setEvaporativeCondenserEffectiveness(0.9);
+  autosizeEvaporativeCondenserAirFlowRate();
+  autosizeRatedEvaporativeCondenserPumpPowerConsumption();
+  setRatedEvaporatorFanPowerPerVolumeFlowRate(773.3);
+  setRatedWasteHeatFractionofPowerInput(0.5);
+
+  CurveBiquadratic coolingCapacityFunctionofTemperature(model);
+  coolingCapacityFunctionofTemperature.setCoefficient1Constant(0.766956);
+  coolingCapacityFunctionofTemperature.setCoefficient2x(0.0107756);
+  coolingCapacityFunctionofTemperature.setCoefficient3xPOW2(-0.0000414703);
+  coolingCapacityFunctionofTemperature.setCoefficient4y(0.00134961);
+  coolingCapacityFunctionofTemperature.setCoefficient5yPOW2(-0.000261144);
+  coolingCapacityFunctionofTemperature.setCoefficient6xTIMESY(0.000457488);
+  coolingCapacityFunctionofTemperature.setMinimumValueofx(17.0);
+  coolingCapacityFunctionofTemperature.setMaximumValueofx(22.0);
+  coolingCapacityFunctionofTemperature.setMinimumValueofy(13.0);
+  coolingCapacityFunctionofTemperature.setMaximumValueofy(46.0);
+  setTotalCoolingCapacityFunctionofTemperatureCurve(coolingCapacityFunctionofTemperature);
+
+  CurveQuadratic coolingCapacityFuncionofFlowFraction(model);
+  coolingCapacityFuncionofFlowFraction.setCoefficient1Constant(0.8);
+  coolingCapacityFuncionofFlowFraction.setCoefficient2x(0.2);
+  coolingCapacityFuncionofFlowFraction.setCoefficient3xPOW2(0.0);
+  coolingCapacityFuncionofFlowFraction.setMinimumValueofx(0.5);
+  coolingCapacityFuncionofFlowFraction.setMaximumValueofx(1.5);
+  setTotalCoolingCapacityFunctionofFlowFractionCurve(coolingCapacityFuncionofFlowFraction);
+
+  CurveBiquadratic energyInputRatioFunctionofTemperature(model);
+  energyInputRatioFunctionofTemperature.setCoefficient1Constant(0.297145);
+  energyInputRatioFunctionofTemperature.setCoefficient2x(0.0430933);
+  energyInputRatioFunctionofTemperature.setCoefficient3xPOW2(-0.000748766);
+  energyInputRatioFunctionofTemperature.setCoefficient4y(0.00597727);
+  energyInputRatioFunctionofTemperature.setCoefficient5yPOW2(0.000482112);
+  energyInputRatioFunctionofTemperature.setCoefficient6xTIMESY(-0.000956448);
+  energyInputRatioFunctionofTemperature.setMinimumValueofx(17.0);
+  energyInputRatioFunctionofTemperature.setMaximumValueofx(22.0);
+  energyInputRatioFunctionofTemperature.setMinimumValueofy(13.0);
+  energyInputRatioFunctionofTemperature.setMaximumValueofy(46.0);
+  setEnergyInputRatioFunctionofTemperatureCurve(energyInputRatioFunctionofTemperature);
+
+  CurveQuadratic energyInputRatioFunctionofFlowFraction(model);
+  energyInputRatioFunctionofFlowFraction.setCoefficient1Constant(1.156);
+  energyInputRatioFunctionofFlowFraction.setCoefficient2x(-0.1816);
+  energyInputRatioFunctionofFlowFraction.setCoefficient3xPOW2(0.0256);
+  energyInputRatioFunctionofFlowFraction.setMinimumValueofx(0.5);
+  energyInputRatioFunctionofFlowFraction.setMaximumValueofx(1.5);
+  setEnergyInputRatioFunctionofFlowFractionCurve(energyInputRatioFunctionofFlowFraction);
+
+  CurveQuadratic partLoadFractionCorrelation(model);
+  partLoadFractionCorrelation.setCoefficient1Constant(0.75);
+  partLoadFractionCorrelation.setCoefficient2x(0.25);
+  partLoadFractionCorrelation.setCoefficient3xPOW2(0.0);
+  partLoadFractionCorrelation.setMinimumValueofx(0.0);
+  partLoadFractionCorrelation.setMaximumValueofx(1.0);
+  setPartLoadFractionCorrelationCurve(partLoadFractionCorrelation);
+
+  CurveBiquadratic wasteHeatFunctionofTemperature(model);
+  wasteHeatFunctionofTemperature.setCoefficient1Constant(1);
+  wasteHeatFunctionofTemperature.setCoefficient2x(0.0);
+  wasteHeatFunctionofTemperature.setCoefficient3xPOW2(0.0);
+  wasteHeatFunctionofTemperature.setCoefficient4y(0.0);
+  wasteHeatFunctionofTemperature.setCoefficient5yPOW2(0.0);
+  wasteHeatFunctionofTemperature.setCoefficient6xTIMESY(0.0);
+  wasteHeatFunctionofTemperature.setMinimumValueofx(0.0);
+  wasteHeatFunctionofTemperature.setMaximumValueofx(0.0);
+  wasteHeatFunctionofTemperature.setMinimumValueofy(0.0);
+  wasteHeatFunctionofTemperature.setMaximumValueofy(0.0);
+  setWasteHeatFunctionofTemperatureCurve(wasteHeatFunctionofTemperature);
+}
 
 CoilCoolingDXMultiSpeedStageData::CoilCoolingDXMultiSpeedStageData(const Model& model,
   Curve& coolingCapacityFunctionofTemperature,

--- a/openstudiocore/src/model/CoilCoolingDXMultiSpeedStageData.hpp
+++ b/openstudiocore/src/model/CoilCoolingDXMultiSpeedStageData.hpp
@@ -49,6 +49,9 @@ class MODEL_API CoilCoolingDXMultiSpeedStageData : public ParentObject {
     Curve& partLoadFractionCorrelation,
     Curve& wasteHeatFunctionofTemperature);
 
+  /** Create CoilCoolingDXMultiSpeedStageData with default curves **/
+  explicit CoilCoolingDXMultiSpeedStageData(const Model& model);
+
   virtual ~CoilCoolingDXMultiSpeedStageData() {}
 
   //@}


### PR DESCRIPTION
@mbadams5 just a couple of changes to multi speed heating coil. The two commits pretty much say whats going on.

One commit is actually just a convenience addition to Coil *Cooling* multi speed to overload the ctor with a variation that provides curves. This came up in testing of the heating coil and brings the cooling coil inline with convention in other coil types.

The second commit is the important one which adds support for the multi speed heating coil inside the HP unitary. This is the only context indicated by the E+ example files and the only context that I know of where OS will support this coil type.  In other words to use the coil you need this commit. 