### PR TITLE
Fixup PlantComponentTemperatureSource

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantComponentTemperatureSource.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantComponentTemperatureSource.cpp
@@ -53,7 +53,9 @@ boost::optional<IdfObject> ForwardTranslator::translatePlantComponentTemperature
   }
 
   // DesignVolumeFlowRate
-  if( (value = modelObject.designVolumeFlowRate()) ) {
+  if( modelObject.isDesignVolumeFlowRateAutosized() ) {
+    idfObject.setString(PlantComponent_TemperatureSourceFields::DesignVolumeFlowRate,"Autosize"); 
+  } else if( (value = modelObject.designVolumeFlowRate()) ) {
     idfObject.setDouble(PlantComponent_TemperatureSourceFields::DesignVolumeFlowRate,value.get()); 
   }
 
@@ -68,8 +70,7 @@ boost::optional<IdfObject> ForwardTranslator::translatePlantComponentTemperature
   }
 
   // SourceTemperatureScheduleName
-  {
-    auto schedule = modelObject.sourceTemperatureSchedule();
+  if( auto schedule = modelObject.sourceTemperatureSchedule() ) {
     if( auto _schedule = translateAndMapModelObject(schedule.get()) ) {
       idfObject.setString(PlantComponent_TemperatureSourceFields::SourceTemperatureScheduleName,_schedule->name().get());
     }

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
@@ -75,6 +75,8 @@
 #include "../../model/SolarCollectorFlatPlateWater_Impl.hpp"
 #include "../../model/SolarCollectorFlatPlatePhotovoltaicThermal.hpp"
 #include "../../model/SolarCollectorFlatPlatePhotovoltaicThermal_Impl.hpp"
+#include "../../model/PlantComponentTemperatureSource.hpp"
+#include "../../model/PlantComponentTemperatureSource_Impl.hpp"
 #include "../../utilities/idf/IdfExtensibleGroup.hpp"
 #include "../../utilities/idf/Workspace.hpp"
 #include "../../utilities/idf/WorkspaceObjectOrder.hpp"
@@ -254,6 +256,12 @@ boost::optional<double> flowrate(const HVACComponent & component)
       result = mo.maximumFlowRate();
       break;
     }
+    case openstudio::IddObjectType::OS_PlantComponent_TemperatureSource :
+    {
+      auto mo = component.cast<PlantComponentTemperatureSource>();
+      result = mo.designVolumeFlowRate();
+      break;
+    }
     default:
     {
       break;
@@ -352,6 +360,10 @@ ComponentType componentType(const HVACComponent & component)
     case openstudio::IddObjectType::OS_SolarCollector_IntegralCollectorStorage :
     {
       return ComponentType::HEATING;
+    }
+    case openstudio::IddObjectType::OS_PlantComponent_TemperatureSource :
+    {
+      return ComponentType::BOTH;
     }
     default:
     {


### PR DESCRIPTION
Set default to autosize and add logic to default on an uncontrolled op
scheme unless an operation scheme is explicitly defined.