### PR TITLE
Make sure that SetpointManagerScheduled has a control type value

### DIFF
--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -192,6 +192,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_1_7_1_to_1_7_2(const IdfFile& idf_1_7_1, const IddFileAndFactoryWrapper& idd_1_7_2);
   std::string update_1_7_4_to_1_7_5(const IdfFile& idf_1_7_4, const IddFileAndFactoryWrapper& idd_1_7_5);
   std::string update_1_8_3_to_1_8_4(const IdfFile& idf_1_8_3, const IddFileAndFactoryWrapper& idd_1_8_4);
+  std::string update_1_8_4_to_1_8_5(const IdfFile& idf_1_8_4, const IddFileAndFactoryWrapper& idd_1_8_5);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
Using the version translator check to see if SetpointManagerScheduled
has a value for the control type field and if it doesn't set the value
to "Temperature". This should prevent any possibility of a crash since
this field is required and initialized on object contruction.

close #1747