### PR TITLE
Fixing potentially serious bug in measure xml updating, I cannot find…

### DIFF
--- a/openstudiocore/src/utilities/bcl/BCLMeasureArgument.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasureArgument.cpp
@@ -64,7 +64,7 @@ namespace openstudio{
     QDomElement choiceElement = element.firstChildElement("choices").firstChildElement("choice");
     while (!choiceElement.isNull()){
       if (choiceElement.hasChildNodes()){
-        std::string choiceValue = choiceElement.firstChildElement("type").firstChild().nodeValue().toStdString();
+        std::string choiceValue = choiceElement.firstChildElement("value").firstChild().nodeValue().toStdString();
         m_choiceValues.push_back(choiceValue);
 
         if (choiceElement.firstChildElement("display_name").isNull()){


### PR DESCRIPTION
… where this was introduced, seems to have been here since 1.5.0 https://github.com/NREL/OpenStudio/commit/bbdce4fe1802461456f3a4e38cb7543693bf245a

This was causing the value of my choice arguments to be replaced by blank values in the measure.xml when the measure was changed, has anyone else seen this?