### PR TITLE
Fix gbXML setConstruction assignment for subSurfaces

### DIFF
--- a/openstudiocore/src/gbxml/ReverseTranslator.cpp
+++ b/openstudiocore/src/gbxml/ReverseTranslator.cpp
@@ -680,7 +680,7 @@ namespace gbxml {
       std::string constructionName = escapeName(constructionIdRef);
       boost::optional<model::ConstructionBase> construction = model.getModelObjectByName<model::ConstructionBase>(constructionName);
       if (construction){
-        surface.setConstruction(*construction);
+        subSurface.setConstruction(*construction);
       }
     }
 


### PR DESCRIPTION
The gbXML reverse translator was assigning the subSurface's construction
to it's parent surface rather than the subSurface itself as noted in issue #1896. This change fixes that issue.