### PR TITLE
Fix zone ventilation when it is alone in a zone

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -515,7 +515,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
   // but for the E+ perspective it is not so we have to remove them,
   // and treat them differently.
   auto isZoneVentilationDesignFlowRate = [](const ModelObject & mo) {
-    return mo.optionalCast<model::ZoneVentilationDesignFlowRate>();
+    return (mo.iddObjectType() == ZoneVentilationDesignFlowRate::iddObjectType());
   };
   auto zoneVentilationBegin = std::remove_if(zoneEquipment.begin(),zoneEquipment.end(),isZoneVentilationDesignFlowRate);
   std::vector<model::ModelObject> zoneVentilationObjects(zoneVentilationBegin,zoneEquipment.end());

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -29,6 +29,8 @@
 #include "../../model/PortList_Impl.hpp"
 #include "../../model/ZoneHVACEquipmentList.hpp"
 #include "../../model/ZoneHVACEquipmentList_Impl.hpp"
+#include "../../model/ZoneVentilationDesignFlowRate.hpp"
+#include "../../model/ZoneVentilationDesignFlowRate_Impl.hpp"
 #include "../../model/SizingZone.hpp"
 #include "../../model/SizingZone_Impl.hpp"
 #include "../../model/Schedule.hpp"
@@ -507,8 +509,20 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
     translateAndMapModelObject(mixing);
   }
 
+  auto zoneEquipment = modelObject.equipment();
+  auto zoneVentilationObjects = subsetCastVector<model::ZoneVentilationDesignFlowRate>(zoneEquipment);
+
+  // In OS ZoneVentilationDesignFlowRate is considered zone equipment,
+  // but for the E+ perspective it is not so we have to remove them,
+  // and treat them differently.
+  auto isZoneVentilationDesignFlowRate = [](const ModelObject & mo) {
+    return mo.optionalCast<model::ZoneVentilationDesignFlowRate>();
+  };
+  zoneEquipment.erase(std::remove_if(zoneEquipment.begin(),zoneEquipment.end(),isZoneVentilationDesignFlowRate),
+    zoneEquipment.end());
+
   // translate thermostat and/or humidistat
-  if( ( modelObject.equipment().size() > 0 ) || modelObject.useIdealAirLoads() )
+  if( ( zoneEquipment.size() > 0 ) || modelObject.useIdealAirLoads() )
   {
     // Thermostat
     if( auto thermostat = modelObject.thermostat() )
@@ -580,12 +594,14 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
     m_idfObjects.push_back(idealLoadsAirSystem); 
   }
 
-  ModelObjectVector zoneEquipment = modelObject.equipment();
+  // ZoneVentilationDesignFlowRate does not go on equipment connections or associated list
+  for( auto & zone_vent : zoneVentilationObjects ) {
+    auto mo = zone_vent.cast<model::ModelObject>();
+    translateAndMapModelObject(mo);
+  }
 
-  if( zoneEquipment.size() > 0 )
-  {
+  if( zoneEquipment.size() > 0 ) {
     // ZoneHVAC_EquipmentConnections
-
     IdfObject connectionsObject(openstudio::IddObjectType::ZoneHVAC_EquipmentConnections);
     m_idfObjects.push_back(connectionsObject);
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACEquipmentList.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACEquipmentList.cpp
@@ -51,6 +51,12 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACEquipmentList( Zo
     return boost::none;
   }
 
+  // If there is nothing but ZoneVentilationDesignFlowRate then stop
+  // We don't want a zone hvac equipment list in the idf
+  if( subsetCastVector<model::ZoneVentilationDesignFlowRate>(objects).size() == objects.size() ) {
+    return boost::none;
+  }
+
   std::vector<ModelObject> coolingVector = modelObject.equipmentInCoolingOrder();
   std::vector<ModelObject> heatingVector = modelObject.equipmentInHeatingOrder();
 
@@ -121,16 +127,17 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACEquipmentList( Zo
     unsigned coolingPriority = coolingMap[elem];
     unsigned heatingPriority = heatingMap[elem];
 
-    boost::optional<IdfObject> _equipment = translateAndMapModelObject(elem);
+    boost::optional<IdfObject> _equipment;
 
-    if( _equipment && (! elem.optionalCast<ZoneVentilationDesignFlowRate>()) )
-    {
-      IdfExtensibleGroup eg = idfObject.pushExtensibleGroup();
-
-      eg.setString(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentObjectType,_equipment->iddObject().name()); 
-      eg.setString(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentName,_equipment->name().get()); 
-      eg.setUnsigned(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentCoolingSequence,coolingPriority); 
-      eg.setUnsigned(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentHeatingorNoLoadSequence,heatingPriority); 
+    // We will take care of ZoneVentilationDesignFlowRate elsewher since it doesn't belong on equipment list
+    if( ! elem.optionalCast<ZoneVentilationDesignFlowRate>() ) {
+      if( auto _equipment = translateAndMapModelObject(elem) ) {
+        IdfExtensibleGroup eg = idfObject.pushExtensibleGroup();
+        eg.setString(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentObjectType,_equipment->iddObject().name()); 
+        eg.setString(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentName,_equipment->name().get()); 
+        eg.setUnsigned(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentCoolingSequence,coolingPriority); 
+        eg.setUnsigned(ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipmentHeatingorNoLoadSequence,heatingPriority); 
+      }
     }
   }
 

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorDewpoint.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorDewpoint.cpp
@@ -64,12 +64,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorDewpoint_Impl::maximumUpperLimit() const
   {
-    return -70.0;
+    return 70.0;
   }
 
   double PlantEquipmentOperationOutdoorDewpoint_Impl::minimumLowerLimit() const
   {
-    return 70.0;
+    return -70.0;
   }
 
 } // detail

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorDewpointDifference.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorDewpointDifference.cpp
@@ -87,12 +87,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorDewpointDifference_Impl::maximumUpperLimit() const
   {
-    return -50.0;
+    return 100.0;
   }
 
   double PlantEquipmentOperationOutdoorDewpointDifference_Impl::minimumLowerLimit() const
   {
-    return 100.0;
+    return -50.0;
   }
 
 } // detail

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorDryBulb.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorDryBulb.cpp
@@ -64,12 +64,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorDryBulb_Impl::maximumUpperLimit() const
   {
-    return -70.0;
+    return 70.0;
   }
 
   double PlantEquipmentOperationOutdoorDryBulb_Impl::minimumLowerLimit() const
   {
-    return 70.0;
+    return -70.0;
   }
 
 } // detail

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorDryBulbDifference.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorDryBulbDifference.cpp
@@ -87,12 +87,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorDryBulbDifference_Impl::maximumUpperLimit() const
   {
-    return -50.0;
+    return 100.0;
   }
 
   double PlantEquipmentOperationOutdoorDryBulbDifference_Impl::minimumLowerLimit() const
   {
-    return 100.0;
+    return -50.0;
   }
 
 } // detail

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorRelativeHumidity.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorRelativeHumidity.cpp
@@ -64,12 +64,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorRelativeHumidity_Impl::maximumUpperLimit() const
   {
-    return 0.0;
+    return 100.0;
   }
 
   double PlantEquipmentOperationOutdoorRelativeHumidity_Impl::minimumLowerLimit() const
   {
-    return 100.0;
+    return 0.0;
   }
 
 } // detail

--- a/openstudiocore/src/model/PlantEquipmentOperationOutdoorWetBulbDifference.cpp
+++ b/openstudiocore/src/model/PlantEquipmentOperationOutdoorWetBulbDifference.cpp
@@ -87,12 +87,12 @@ namespace detail {
 
   double PlantEquipmentOperationOutdoorWetBulbDifference_Impl::maximumUpperLimit() const
   {
-    return -50.0;
+    return 100.0;
   }
 
   double PlantEquipmentOperationOutdoorWetBulbDifference_Impl::minimumLowerLimit() const
   {
-    return 100.0;
+    return -50.0;
   }
 
 } // detail


### PR DESCRIPTION
OS treats zone ventilation as zone equipment while E+ does not, this is
a fix to avoid writing the zone equipment connections and zone equipment
list when there is only zone ventilation.

close #1919