### PR TITLE
Radiance measure paths

### DIFF
--- a/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
+++ b/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
@@ -1887,7 +1887,7 @@ class RadianceMeasure < OpenStudio::Ruleset::ModelUserScript
     
     # settle in, it's gonna be a bumpy ride...
     Dir.chdir("#{radPath}")
-    print_statement("Radiance run directory: '#{Dir.pwd}'", runner)
+    print_statement("Radiance working directory: '#{Dir.pwd}'", runner)
 
     epwFile = OpenStudio::OptionalEpwFile.new(OpenStudio::EpwFile.new(epw_path))
 

--- a/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
+++ b/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
@@ -224,12 +224,15 @@ class RadianceMeasure < OpenStudio::Ruleset::ModelUserScript
         OpenStudio::Path.new("strawberry-perl-5.16.2.1-32bit-portable-reduced/perl/bin")
       end
       print_statement("Adding path for local perl: " + perlpath.to_s, runner)
-      ENV["PATH"] = ENV["PATH"] + ";" + path + ";" + perlpath.to_s
+      ENV["PATH"] = path + ";" + ENV["PATH"] + ";" + perlpath.to_s
       ENV["RAYPATH"] = path + ";" + raypath + ";."
     else
-      ENV["PATH"] = ENV["PATH"] + ":" + path
+      ENV["PATH"] = path + ":" + ENV["PATH"]
       ENV["RAYPATH"] = path + ":" + raypath + ":."
     end
+    
+    print_statement("Radiance bin: #{path}", runner)
+    print_statement("Radiance lib: #{raypath}", runner)
 
     if Dir.glob(epw2weapath + programExtension).empty?
       runner.registerError("Cannot find epw2wea tool in radiance installation at '#{radiancePath}'. You may need to install a newer version of Radiance.")

--- a/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
+++ b/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.rb
@@ -10,7 +10,7 @@ require 'date'
 require 'json'
 require 'erb'
 require 'matrix'
-
+require 'open3'
 
 class Array
   def average 
@@ -208,7 +208,7 @@ class RadianceMeasure < OpenStudio::Ruleset::ModelUserScript
     radiancePath = co.getTools().getLastByName("rad").localBinPath.parent_path
     path = OpenStudio::Path.new(radiancePath).to_s
     raypath = (OpenStudio::Path.new(radiancePath).parent_path() / 
-    OpenStudio::Path.new('lib')).to_s()
+    OpenStudio::Path.new('lib')).to_s()   
 
     epw2weapath = (OpenStudio::Path.new(radiancePath) / OpenStudio::Path.new('epw2wea')).to_s
 
@@ -231,9 +231,12 @@ class RadianceMeasure < OpenStudio::Ruleset::ModelUserScript
       ENV["RAYPATH"] = path + ":" + raypath + ":."
     end
     
-    print_statement("Radiance bin: #{path}", runner)
-    print_statement("Radiance lib: #{raypath}", runner)
-
+    # Radiance version detection and environment reportage                 
+    ver = Open3.capture2("#{path}/rcontrib -version")
+    print_statement("Radiance version info: #{ver[0]}", runner)
+    print_statement("Radiance binary dir: #{path}", runner)
+    print_statement("Radiance library dir: #{raypath}", runner)
+    
     if Dir.glob(epw2weapath + programExtension).empty?
       runner.registerError("Cannot find epw2wea tool in radiance installation at '#{radiancePath}'. You may need to install a newer version of Radiance.")
       exit false

--- a/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.xml
+++ b/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.xml
@@ -2,7 +2,7 @@
   <schema_version>3.0</schema_version>
   <name>radiance_measure</name>
   <uid>1e3cfef8-b051-4e60-8bb0-ed2d29d4f45d</uid>
-  <version_id>45d09d5d-a6ca-4244-81ff-99ebe245d051</version_id>
+  <version_id>e112d7a5-dbed-4ba0-a8b1-4deff47000bf</version_id>
   <xml_checksum>381B7733</xml_checksum>
   <class_name>RadianceMeasure</class_name>
   <display_name>Radiance Daylighting Measure</display_name>
@@ -149,7 +149,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>43E10886</checksum>
+      <checksum>46123F07</checksum>
     </file>
   </files>
 </measure>

--- a/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.xml
+++ b/openstudiocore/src/pat_app/Measures/RadianceMeasure/measure.xml
@@ -2,7 +2,7 @@
   <schema_version>3.0</schema_version>
   <name>radiance_measure</name>
   <uid>1e3cfef8-b051-4e60-8bb0-ed2d29d4f45d</uid>
-  <version_id>41a33715-def8-4bf8-bcae-5a7e0db317a0</version_id>
+  <version_id>45d09d5d-a6ca-4244-81ff-99ebe245d051</version_id>
   <xml_checksum>381B7733</xml_checksum>
   <class_name>RadianceMeasure</class_name>
   <display_name>Radiance Daylighting Measure</display_name>
@@ -149,7 +149,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>521573CE</checksum>
+      <checksum>43E10886</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
@macumber, could you give this a spin? It fixes the search order for Radiance stuff, and it reports the Radiance version, that's it. e.g.: 

```[Radiance Measure 2016-02-02 19:38:00 UTC]: Radiance version info: NREL 5.0.a.6 2010.10.15 based on RADIANCE 5.0 Official Release by G. Ward
[Radiance Measure 2016-02-02 19:38:00 UTC]: Radiance binary dir: /usr/local/radiance/bin
[Radiance Measure 2016-02-02 19:38:00 UTC]: Radiance library dir: /usr/local/radiance/lib```

or:

```[Radiance Measure 2016-02-02 19:42:13 UTC]: Radiance version info: RADIANCE 5.0a lastmod 10:24:00 by googs on rgugliel-W7-VM
[Radiance Measure 2016-02-02 19:42:13 UTC]: Radiance binary dir: C:\Users\rgugliel\src\OpenStudio\build\Radiance\bin
[Radiance Measure 2016-02-02 19:42:13 UTC]: Radiance library dir: C:\Users\rgugliel\src\OpenStudio\build\Radiance\lib```