### PR TITLE
Replace QUUID with boost::uuids::uuid

### DIFF
--- a/openstudiocore/src/model_editor/InspectorDialog.cpp
+++ b/openstudiocore/src/model_editor/InspectorDialog.cpp
@@ -193,7 +193,7 @@ bool InspectorDialog::setSelectedObjectHandles(const std::vector<openstudio::Han
 
     QString handleString = m_tableWidget->item(i,0)->data(Qt::UserRole).toString();
     //std::string temp = toString(handleString);
-    Handle handle(handleString);
+    Handle handle(toUUID(handleString));
 
     auto it = std::find(m_selectedObjectHandles.begin(),
                         m_selectedObjectHandles.end(),
@@ -1117,7 +1117,7 @@ void InspectorDialog::loadTableWidgetData()
 
     auto tableItem = new QTableWidgetItem(displayName);
     tableItem->setFlags(Qt::NoItemFlags | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-    QString handleString(object.handle().toString());
+    QString handleString(toQString(object.handle()));
     //std::string temp = toString(handleString);
     tableItem->setData(Qt::UserRole, handleString);
     m_tableWidget->setItem(i,j++,tableItem);
@@ -1151,7 +1151,7 @@ void InspectorDialog::getTableWidgetSelected(std::vector<openstudio::Handle>& se
     if (column == 0){
       QString handleString = selectedItems.at(i)->data(Qt::UserRole).toString();
       //std::string temp = toString(handleString);
-      selectedHandles.push_back(Handle(handleString));
+      selectedHandles.push_back(Handle(toUUID(handleString)));
     }
   }
 

--- a/openstudiocore/src/model_editor/ModalDialogs.cpp
+++ b/openstudiocore/src/model_editor/ModalDialogs.cpp
@@ -105,7 +105,7 @@ boost::optional<openstudio::model::ModelObject> ModelObjectSelectorDialog::selec
   if (currentIndex >= 0){
     QVariant itemData = m_comboBox->itemData(currentIndex);
     OS_ASSERT(itemData.isValid());
-    Handle handle(itemData.toString());
+    Handle handle(toUUID(itemData.toString()));
     result = m_model.getModelObject<ModelObject>(handle);
   }
   return result;
@@ -279,7 +279,7 @@ void ModelObjectSelectorDialog::loadComboBoxData()
   for (WorkspaceObject workspaceObject : workspaceObjects){
     OS_ASSERT(workspaceObject.name());
     std::string objectName = workspaceObject.name().get();
-    m_comboBox->addItem(toQString(objectName), workspaceObject.handle().toString());
+    m_comboBox->addItem(toQString(objectName), toQString(workspaceObject.handle()));
   }
 
   if (m_comboBox->count() > 0){

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -195,7 +195,7 @@ OpenStudioApp::OpenStudioApp( int & argc, char ** argv, const QSharedPointer<rul
           m_osDocument->setSavePath("");
           QTimer::singleShot(0, m_osDocument.get(), SLOT(markAsModified())); 
         }else{
-          LOG_FREE(Warn, "OpenStudio", "Incorrect second argument '" << args.at(1) << "'");
+          LOG_FREE(Warn, "OpenStudio", "Incorrect second argument '" << toString(args.at(1)) << "'");
         }
       }
 

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
@@ -203,13 +203,13 @@ void HVACSystemsController::update()
     auto airloops = m_model.getModelObjects<model::AirLoopHVAC>();
     std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
     for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
-      systemComboBox->addItem(QString::fromStdString(it->name().get()),it->handle().toString());
+      systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
     }
 
     auto plantloops = m_model.getModelObjects<model::PlantLoop>();
     std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
     for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
-      systemComboBox->addItem(QString::fromStdString(it->name().get()),it->handle().toString());
+      systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
     }
 
     systemComboBox->addItem("Service Hot Water",SHW);
@@ -219,7 +219,7 @@ void HVACSystemsController::update()
     // Set system combo box current index
     QString handle = currentHandle();
     if( handle == SHW  ||
-        m_model.getModelObject<model::WaterUseConnections>(handle)
+        m_model.getModelObject<model::WaterUseConnections>(toUUID(handle))
       )
     {
       int index = systemComboBox->findData(SHW);
@@ -479,7 +479,7 @@ void HVACLayoutController::addLibraryObjectToModelNode(OSItemId itemid, model::H
 
   if( auto component = doc->getComponent(itemid) ) {
     // Ugly hack to avoid the component being treated as a resource.
-    component->componentData().setString(OS_ComponentDataFields::UUID,createUUID().toString().toStdString());
+    component->componentData().setString(OS_ComponentDataFields::UUID, toString(createUUID()));
     if( auto componentData = comp.model().insertComponent(component.get()) ) {
       object = componentData->primaryComponentObject();
       remove = true;
@@ -552,12 +552,12 @@ void HVACLayoutController::addLibraryObjectToModelNode(OSItemId itemid, model::H
 
 boost::optional<model::Loop> HVACSystemsController::currentLoop() const
 {
-  return m_model.getModelObject<model::Loop>(m_currentHandle);
+  return m_model.getModelObject<model::Loop>(toUUID(m_currentHandle));
 }
 
 void HVACLayoutController::removeModelObject(model::ModelObject & modelObject)
 {
-  if( modelObject.handle() == nullptr ) return;
+  if( modelObject.handle().isNull() ) return;
 
   model::OptionalModelObject mo;
 
@@ -644,7 +644,7 @@ void HVACLayoutController::goToOtherLoop( model::ModelObject & modelObject )
 
   if( boost::optional<model::Loop> loop = modelObject.optionalCast<model::Loop>() )
   {
-    m_hvacSystemsController->setCurrentHandle(loop->handle().toString());
+    m_hvacSystemsController->setCurrentHandle(toQString(loop->handle()));
 
     return;
   }
@@ -659,7 +659,7 @@ void HVACLayoutController::goToOtherLoop( model::ModelObject & modelObject )
       {
         if( boost::optional<model::PlantLoop> plantLoop = comp->plantLoop() )
         {
-          m_hvacSystemsController->setCurrentHandle(plantLoop->handle().toString());
+          m_hvacSystemsController->setCurrentHandle(toQString(plantLoop->handle()));
         }
 
         return;
@@ -668,7 +668,7 @@ void HVACLayoutController::goToOtherLoop( model::ModelObject & modelObject )
       {
         if( boost::optional<model::AirLoopHVAC> airLoopHVAC = comp->airLoopHVAC() )
         {
-          m_hvacSystemsController->setCurrentHandle(airLoopHVAC->handle().toString());
+          m_hvacSystemsController->setCurrentHandle(toQString(airLoopHVAC->handle()));
         }
 
         return;
@@ -683,7 +683,7 @@ void HVACLayoutController::goToOtherLoop( model::ModelObject & modelObject )
         {
           if( boost::optional<model::PlantLoop> secondaryPlantLoop = comp->secondaryPlantLoop() )
           {
-            m_hvacSystemsController->setCurrentHandle(secondaryPlantLoop->handle().toString());
+            m_hvacSystemsController->setCurrentHandle(toQString(secondaryPlantLoop->handle()));
 
             return;
           }
@@ -696,7 +696,7 @@ void HVACLayoutController::goToOtherLoop( model::ModelObject & modelObject )
         {
           if( boost::optional<model::PlantLoop> plantLoop = comp->plantLoop() )
           {
-            m_hvacSystemsController->setCurrentHandle(plantLoop->handle().toString());
+            m_hvacSystemsController->setCurrentHandle(toQString(plantLoop->handle()));
 
             return;
           }
@@ -782,7 +782,7 @@ void HVACSystemsController::addToModel(AddToModelEnum addToModelEnum)
 
   if( loop )
   {
-    m_currentHandle = loop->handle().toString();
+    m_currentHandle = toQString(loop->handle());
   }
 }
 
@@ -831,15 +831,15 @@ void HVACSystemsController::onRemoveLoopClicked()
 
     QComboBox * chooser = m_hvacSystemsView->hvacToolbarView->systemComboBox;
 
-    int i = chooser->findData(loop->handle().toString());
+    int i = chooser->findData(toQString(loop->handle()));
 
     if( i == 0 )
     {
-      setCurrentHandle(QUuid(chooser->itemData(i + 1).toString()).toString());
+      setCurrentHandle(chooser->itemData(i + 1).toString());
     }
     else
     {
-      setCurrentHandle(QUuid(chooser->itemData(i - 1).toString()).toString());
+      setCurrentHandle(chooser->itemData(i - 1).toString());
     }
 
     loop->remove();
@@ -852,7 +852,7 @@ void HVACLayoutController::onModelObjectSelected(model::OptionalModelObject & mo
   {
     if( boost::optional<model::WaterUseConnections> waterUseConnections = modelObject->optionalCast<model::WaterUseConnections>() )
     {
-      m_hvacSystemsController->setCurrentHandle(waterUseConnections->handle().toString());
+      m_hvacSystemsController->setCurrentHandle(toQString(waterUseConnections->handle()));
     }
     else
     {
@@ -1106,14 +1106,14 @@ void HVACControlsController::update()
              it != thermalZones.end();
              ++it )
         {
-          m_singleZoneReheatSPMView->controlZoneComboBox->addItem(QString::fromStdString(it->name().get()),it->handle().toString());
+          m_singleZoneReheatSPMView->controlZoneComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
         }
 
-        m_singleZoneReheatSPMView->controlZoneComboBox->addItem("",QUuid().toString());
+        m_singleZoneReheatSPMView->controlZoneComboBox->addItem("",toQString(UUID()));
 
         if( boost::optional<model::ThermalZone> tz = spmSZR->controlZone() )
         {
-          int index = m_singleZoneReheatSPMView->controlZoneComboBox->findData(tz->handle().toString());
+          int index = m_singleZoneReheatSPMView->controlZoneComboBox->findData(toQString(tz->handle()));
 
           if( index > -1 )
           {
@@ -1121,7 +1121,7 @@ void HVACControlsController::update()
           }
           else
           {
-            m_singleZoneReheatSPMView->controlZoneComboBox->addItem(QString::fromStdString(tz->name().get()),tz->handle().toString());
+            m_singleZoneReheatSPMView->controlZoneComboBox->addItem(QString::fromStdString(tz->name().get()), toQString(tz->handle()));
 
             int i = m_singleZoneReheatSPMView->controlZoneComboBox->count() - 1;
 
@@ -1130,7 +1130,7 @@ void HVACControlsController::update()
         }
         else
         {
-          int index = m_singleZoneReheatSPMView->controlZoneComboBox->findData(QUuid().toString());
+          int index = m_singleZoneReheatSPMView->controlZoneComboBox->findData(toQString(UUID()));
 
           OS_ASSERT( index > -1 );
 
@@ -1186,14 +1186,14 @@ void HVACControlsController::update()
              it != thermalZones.end();
              ++it )
         {
-          m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem(QString::fromStdString(it->name().get()),it->handle().toString());
+          m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
         }
 
-        m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem("",QUuid().toString());
+        m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem("",toQString(UUID()));
 
         if( boost::optional<model::ThermalZone> tz = hp.controllingZone() )
         {
-          int index = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->findData(tz->handle().toString());
+          int index = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->findData(toQString(tz->handle()));
 
           if( index > -1 )
           {
@@ -1201,7 +1201,7 @@ void HVACControlsController::update()
           }
           else
           {
-            m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem(QString::fromStdString(tz->name().get()),tz->handle().toString());
+            m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->addItem(QString::fromStdString(tz->name().get()),toQString(tz->handle()));
 
             int i = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->count() - 1;
 
@@ -1210,7 +1210,7 @@ void HVACControlsController::update()
         }
         else
         {
-          int index = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->findData(QUuid().toString());
+          int index = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->findData(toQString(UUID()));
 
           OS_ASSERT( index > -1 );
 
@@ -1289,7 +1289,7 @@ void HVACControlsController::onControlZoneComboBoxChanged(int index)
 {
   QString stringHandle = m_singleZoneReheatSPMView->controlZoneComboBox->itemData(index).toString();
 
-  QUuid handle(stringHandle);
+  UUID handle(toUUID(stringHandle));
 
   model::Model t_model = m_hvacSystemsController->model();
 
@@ -1314,7 +1314,7 @@ void HVACControlsController::onUnitaryHeatPumpControlZoneChanged(int index)
 {
   QString stringHandle = m_airLoopHVACUnitaryHeatPumpAirToAirControlView->controlZoneComboBox->itemData(index).toString();
 
-  QUuid handle(stringHandle);
+  UUID handle(toUUID(stringHandle));
 
   model::Model t_model = m_hvacSystemsController->model();
 
@@ -1382,9 +1382,9 @@ HVACGraphicsView * HVACLayoutController::hvacGraphicsView() const
 
 void HVACLayoutController::goToServiceWaterScene()
 {
-  // A null QUuid signals the service water scene
+  // A null UUID signals the service water scene
 
-  m_hvacSystemsController->setCurrentHandle(QUuid().toString());
+  m_hvacSystemsController->setCurrentHandle(toQString(UUID()));
 }
 
 void HVACLayoutController::clearSceneSelection()
@@ -1409,7 +1409,7 @@ void HVACLayoutController::update()
 
     QString handle = m_hvacSystemsController->currentHandle();
 
-    boost::optional<model::ModelObject> mo = t_model.getModelObject<model::ModelObject>(handle);
+    boost::optional<model::ModelObject> mo = t_model.getModelObject<model::ModelObject>(toUUID(handle));
 
     if( mo )
     {

--- a/openstudiocore/src/openstudio_lib/InspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/InspectorView.cpp
@@ -845,7 +845,7 @@ NewPlenumDialog::NewPlenumDialog(QWidget * parent)
   {
     if( (! it->isPlenum()) && it->equipment().empty() && (! it->airLoopHVAC()) )
     {
-      zoneChooser->addItem(QString::fromStdString(it->name().get()),it->handle().toString());
+      zoneChooser->addItem(QString::fromStdString(it->name().get()),toQString(it->handle()));
     }
   }
 
@@ -1021,7 +1021,7 @@ void ThermalZoneInspectorView::onSupplyPlenumChooserChanged(int newIndex)
   OS_ASSERT(thermalZone);
 
   QString newPlenumString = m_plenumChooser->supplyPlenumChooser->itemData(newIndex).toString();
-  Handle newPlenumHandle(newPlenumString);
+  Handle newPlenumHandle(toUUID(newPlenumString));
 
   emit moveBranchForZoneSupplySelected(thermalZone.get(),newPlenumHandle);
 }
@@ -1034,7 +1034,7 @@ void ThermalZoneInspectorView::onReturnPlenumChooserChanged(int newIndex)
   OS_ASSERT(thermalZone);
 
   QString newPlenumString = m_plenumChooser->returnPlenumChooser->itemData(newIndex).toString();
-  Handle newPlenumHandle(newPlenumString);
+  Handle newPlenumHandle(toUUID(newPlenumString));
 
   emit moveBranchForZoneReturnSelected(thermalZone.get(),newPlenumHandle);
 }
@@ -1047,7 +1047,7 @@ void ThermalZoneInspectorView::onNewSupplyPlenumClicked()
   if( result == QDialog::Accepted )
   {
     QComboBox * cb = dialog.zoneChooser;
-    Handle newZoneHandle(cb->itemData(cb->currentIndex()).toString());
+    Handle newZoneHandle(toUUID(cb->itemData(cb->currentIndex()).toString()));
     if( ! newZoneHandle.isNull() )
     {
       OS_ASSERT(m_modelObject);
@@ -1068,7 +1068,7 @@ void ThermalZoneInspectorView::onNewReturnPlenumClicked()
   if( result == QDialog::Accepted )
   {
     QComboBox * cb = dialog.zoneChooser;
-    Handle newZoneHandle(cb->itemData(cb->currentIndex()).toString());
+    Handle newZoneHandle(toUUID(cb->itemData(cb->currentIndex()).toString()));
     if( ! newZoneHandle.isNull() )
     {
       OS_ASSERT(m_modelObject);
@@ -1159,11 +1159,11 @@ void ThermalZoneInspectorView::update()
     boost::optional<model::ThermalZone> t_plenumZone = it->thermalZone();
     if( t_plenumZone )
     {
-      supplyChooser->addItem(supplyPixmap,QString::fromStdString(t_plenumZone->name().get()),it->handle().toString());
+      supplyChooser->addItem(supplyPixmap,QString::fromStdString(t_plenumZone->name().get()),toQString(it->handle()));
     }
     else 
     {
-      supplyChooser->addItem(supplyPixmap,QString::fromStdString(it->name().get()),it->handle().toString());
+      supplyChooser->addItem(supplyPixmap,QString::fromStdString(it->name().get()),toQString(it->handle()));
     }
   }
   supplyChooser->addItem("Ducted Supply - No Plenum","");
@@ -1176,7 +1176,7 @@ void ThermalZoneInspectorView::update()
   }
   else
   {
-    supplyChooser->setCurrentIndex(supplyChooser->findData(thisZoneSupplyPlenums.front().handle().toString()));
+    supplyChooser->setCurrentIndex(supplyChooser->findData(toQString(thisZoneSupplyPlenums.front().handle())));
   }
   supplyChooser->blockSignals(false);
 
@@ -1213,11 +1213,11 @@ void ThermalZoneInspectorView::update()
     boost::optional<model::ThermalZone> t_plenumZone = it->thermalZone();
     if( t_plenumZone )
     {
-      returnChooser->addItem(returnPixmap,QString::fromStdString(t_plenumZone->name().get()),it->handle().toString());
+      returnChooser->addItem(returnPixmap,QString::fromStdString(t_plenumZone->name().get()), toQString(it->handle()));
     }
     else 
     {
-      returnChooser->addItem(returnPixmap,QString::fromStdString(it->name().get()),it->handle().toString());
+      returnChooser->addItem(returnPixmap,QString::fromStdString(it->name().get()), toQString(it->handle()));
     }
   }
   returnChooser->addItem("Ducted Return - No Plenum","");
@@ -1230,7 +1230,7 @@ void ThermalZoneInspectorView::update()
   }
   else
   {
-    returnChooser->setCurrentIndex(returnChooser->findData(thisZoneReturnPlenums.front().handle().toString()));
+    returnChooser->setCurrentIndex(returnChooser->findData(toQString(thisZoneReturnPlenums.front().handle())));
   }
   returnChooser->blockSignals(false);
 }

--- a/openstudiocore/src/openstudio_lib/LoopScene.cpp
+++ b/openstudiocore/src/openstudio_lib/LoopScene.cpp
@@ -74,7 +74,7 @@ void LoopScene::initDefault()
 
 void LoopScene::layout()
 {
-  if( m_dirty && m_loop.handle() != nullptr )
+  if( m_dirty && !m_loop.handle().isNull() )
   {
     QList<QGraphicsItem *> itemList = items();
     for( QList<QGraphicsItem *>::iterator it = itemList.begin(); 

--- a/openstudiocore/src/openstudio_lib/ModelObjectItem.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectItem.cpp
@@ -38,7 +38,7 @@ OSItemId modelObjectToItemId(const openstudio::model::ModelObject& modelObject, 
 {
   std::stringstream ss;
   ss << modelObject;
-  return OSItemId(modelObject.handle().toString(), modelToSourceId(modelObject.model()), isDefaulted, toQString(ss.str()));
+  return OSItemId(toQString(modelObject.handle()), modelToSourceId(modelObject.model()), isDefaulted, toQString(ss.str()));
 }
 
 QString modelToSourceId(const openstudio::model::Model& model)

--- a/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
@@ -68,7 +68,7 @@ void ModelObjectListController::objectAdded(std::shared_ptr<openstudio::detail::
     emit itemIds(ids);
 
     for (const OSItemId& id : ids){
-      if (id.itemId() == impl->handle().toString()){
+      if (id.itemId() == toQString(impl->handle())){
         emit selectedItemId(id);
         break;
       }

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -1599,20 +1599,20 @@ namespace openstudio {
   boost::optional<model::ModelObject> OSDocument::getModelObject(const OSItemId& itemId) const
   {
     if (fromModel(itemId)){
-      Handle handle(itemId.itemId());
+      Handle handle(toUUID(itemId.itemId()));
       return m_model.getModelObject<model::ModelObject>(handle);
     }
     else if (fromComponentLibrary(itemId)){
       if (itemId.sourceId() == modelToSourceId(m_compLibrary)){
-        Handle handle(itemId.itemId());
+        Handle handle(toUUID(itemId.itemId()));
         return m_compLibrary.getModelObject<model::ModelObject>(handle);
       }
       else if (itemId.sourceId() == modelToSourceId(m_hvacCompLibrary)){
-        Handle handle(itemId.itemId());
+        Handle handle(toUUID(itemId.itemId()));
         return m_hvacCompLibrary.getModelObject<model::ModelObject>(handle);
       }
       else if (itemId.sourceId() == modelToSourceId(m_combinedCompLibrary)){
-        Handle handle(itemId.itemId());
+        Handle handle(toUUID(itemId.itemId()));
         return m_combinedCompLibrary.getModelObject<model::ModelObject>(handle);
       }
     }

--- a/openstudiocore/src/openstudio_lib/RefrigerationController.cpp
+++ b/openstudiocore/src/openstudio_lib/RefrigerationController.cpp
@@ -69,25 +69,25 @@ void RefrigerationController::refreshRefrigerationSystemView(RefrigerationSystem
 
   if( system )
   {
-    systemView->setId(OSItemId(system->handle().toString(),QString(),false));
+    systemView->setId(OSItemId(toQString(system->handle()), QString(),false));
 
     if( boost::optional<model::RefrigerationSubcoolerLiquidSuction> subcooler = system->liquidSuctionHeatExchangerSubcooler() )
     {
-      systemView->refrigerationSHXView->setId(OSItemId(subcooler->handle().toString(),QString(),false));
+      systemView->refrigerationSHXView->setId(OSItemId(toQString(subcooler->handle()), QString(),false));
 
       systemView->refrigerationSHXView->setName(QString::fromStdString(subcooler->name().get()));
     }
 
     if( boost::optional<model::RefrigerationSubcoolerMechanical> subcooler = system->mechanicalSubcooler() )
     {
-      systemView->refrigerationSubCoolerView->setId(OSItemId(subcooler->handle().toString(),QString(),false));
+      systemView->refrigerationSubCoolerView->setId(OSItemId(toQString(subcooler->handle()), QString(),false));
 
       systemView->refrigerationSubCoolerView->setName(QString::fromStdString(subcooler->name().get()));
     }
 
     if( boost::optional<model::ModelObject> condenser = system->refrigerationCondenser() )
     {
-      systemView->refrigerationCondenserView->setCondenserId(OSItemId(condenser->handle().toString(),QString(),false));
+      systemView->refrigerationCondenserView->setCondenserId(OSItemId(toQString(condenser->handle()), QString(),false));
 
       systemView->refrigerationCondenserView->setCondenserName(QString::fromStdString(condenser->name().get()));
 
@@ -130,7 +130,7 @@ void RefrigerationController::refreshRefrigerationSystemView(RefrigerationSystem
     {
       auto detailView = new RefrigerationCompressorDetailView(); 
 
-      detailView->setId(OSItemId(it->handle().toString(),QString(),false));
+      detailView->setId(OSItemId(toQString(it->handle()), QString(),false));
 
       detailView->setLabel(QString::number(compressorIndex));
 
@@ -155,7 +155,7 @@ void RefrigerationController::refreshRefrigerationSystemView(RefrigerationSystem
     {
       auto detailView = new RefrigerationCaseDetailView();
 
-      detailView->setId(OSItemId(it->handle().toString(),QString(),false));
+      detailView->setId(OSItemId(toQString(it->handle()), QString(),false));
 
       detailView->setName(QString::fromStdString(it->name().get()));
 
@@ -178,7 +178,7 @@ void RefrigerationController::refreshRefrigerationSystemView(RefrigerationSystem
     {
       auto detailView = new RefrigerationCaseDetailView();
 
-      detailView->setId(OSItemId(it->handle().toString(),QString(),false));
+      detailView->setId(OSItemId(toQString(it->handle()), QString(),false));
 
       detailView->setName(QString::fromStdString(it->name().get()));
 
@@ -597,7 +597,7 @@ void RefrigerationController::removeSubCooler(const OSItemId & itemid)
 {
   if( boost::optional<model::Model> model = OSAppBase::instance()->currentModel() )
   {
-    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(Handle(itemid.itemId())))
+    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(toUUID(itemid.itemId())))
     {
       mo->remove();
 
@@ -659,7 +659,7 @@ void RefrigerationController::removeSubCoolerLiquidSuction(const OSItemId & item
 {
   if( boost::optional<model::Model> model = OSAppBase::instance()->currentModel() )
   {
-    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(Handle(itemid.itemId())))
+    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(toUUID(itemid.itemId())))
     {
       mo->remove();
 
@@ -700,7 +700,7 @@ void RefrigerationController::inspectOSItem(const OSItemId & itemid)
 
   OS_ASSERT(m_currentSystem);
 
-  boost::optional<model::ModelObject> mo = m_currentSystem->model().getModelObject<model::ModelObject>(Handle(itemid.itemId()));
+  boost::optional<model::ModelObject> mo = m_currentSystem->model().getModelObject<model::ModelObject>(toUUID(itemid.itemId()));
 
   doc->mainRightColumnController()->inspectModelObject(mo,false);
 }
@@ -709,7 +709,7 @@ void RefrigerationController::removeCompressor(const OSItemId & itemid)
 {
   if( boost::optional<model::Model> model = OSAppBase::instance()->currentModel() )
   {
-    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(Handle(itemid.itemId())))
+    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(toUUID(itemid.itemId())))
     {
       mo->remove();
 
@@ -722,7 +722,7 @@ void RefrigerationController::removeCondenser(const OSItemId & itemid)
 {
   if( boost::optional<model::Model> model = OSAppBase::instance()->currentModel() )
   {
-    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(Handle(itemid.itemId())))
+    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(toUUID(itemid.itemId())))
     {
       mo->remove();
 
@@ -737,7 +737,7 @@ void RefrigerationController::removeCase(const OSItemId & itemid)
 {
   if( boost::optional<model::Model> model = OSAppBase::instance()->currentModel() )
   {
-    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(Handle(itemid.itemId())))
+    if(boost::optional<model::ModelObject> mo = model->getModelObject<model::ModelObject>(toUUID(itemid.itemId())))
     {
       mo->remove();
 

--- a/openstudiocore/src/openstudio_lib/ScheduleDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ScheduleDialog.cpp
@@ -160,7 +160,7 @@ void ScheduleDialog::createLayout()
     for (const model::ScheduleType& scheduleType : scheduleTypes){
       QString name = toQString(model::ScheduleTypeRegistry::instance().getDefaultName(scheduleType));
       model::ScheduleTypeLimits tmp = model::ScheduleTypeRegistry::instance().getOrCreateScheduleTypeLimits(scheduleType, m_model);
-      m_scheduleTypeComboBox->addItem(name, tmp.handle().toString());
+      m_scheduleTypeComboBox->addItem(name, toQString(tmp.handle()));
     }
 
     hLayout->addWidget(m_scheduleTypeComboBox);
@@ -238,7 +238,7 @@ void ScheduleDialog::onCurrentIndexChanged(int index)
 {
   OS_ASSERT(index >= 0);
 
-  UUID handle = UUID(m_scheduleTypeComboBox->itemData(index).toString());
+  UUID handle = toUUID(m_scheduleTypeComboBox->itemData(index).toString());
   m_scheduleTypeLimits = m_model.getModelObject<model::ScheduleTypeLimits>(handle);
   OS_ASSERT(m_scheduleTypeLimits);
 

--- a/openstudiocore/src/openstudio_lib/SchedulesView.cpp
+++ b/openstudiocore/src/openstudio_lib/SchedulesView.cpp
@@ -1416,7 +1416,7 @@ NewProfileView::NewProfileView(const model::ScheduleRuleset & scheduleRuleset, S
 void NewProfileView::onAddClicked()
 {
   int currentIndex = m_scheduleRuleComboBox->currentIndex();
-  UUID handle = m_scheduleRuleComboBox->itemData(currentIndex).toUuid();
+  UUID handle = toUUID(m_scheduleRuleComboBox->itemData(currentIndex).toString());
 
   switch (m_type)
   {
@@ -1435,20 +1435,20 @@ void NewProfileView::populateComboBox(const model::ScheduleRuleset & scheduleRul
 {
   
 
-  m_scheduleRuleComboBox->addItem("<New Profile>", UUID());
+  m_scheduleRuleComboBox->addItem("<New Profile>", toQString(UUID()));
 
-  m_scheduleRuleComboBox->addItem("Default Day Schedule", scheduleRuleset.defaultDaySchedule().handle());
+  m_scheduleRuleComboBox->addItem("Default Day Schedule", toQString(scheduleRuleset.defaultDaySchedule().handle()));
 
   if (!scheduleRuleset.isSummerDesignDayScheduleDefaulted()){
-    m_scheduleRuleComboBox->addItem("Summer Design Day Schedule", scheduleRuleset.summerDesignDaySchedule().handle());
+    m_scheduleRuleComboBox->addItem("Summer Design Day Schedule", toQString(scheduleRuleset.summerDesignDaySchedule().handle()));
   }
 
   if (!scheduleRuleset.isWinterDesignDayScheduleDefaulted()){
-    m_scheduleRuleComboBox->addItem("Winter Design Day Schedule", scheduleRuleset.winterDesignDaySchedule().handle());
+    m_scheduleRuleComboBox->addItem("Winter Design Day Schedule", toQString(scheduleRuleset.winterDesignDaySchedule().handle()));
   }
 
   for (const auto& rule : scheduleRuleset.scheduleRules()){
-    m_scheduleRuleComboBox->addItem(toQString(rule.name().get()), rule.daySchedule().handle());
+    m_scheduleRuleComboBox->addItem(toQString(rule.name().get()), toQString(rule.daySchedule().handle()));
   }
 
   m_scheduleRuleComboBox->setCurrentIndex(0);

--- a/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
@@ -365,7 +365,7 @@ namespace openstudio {
 
   void SpaceTypesGridController::filterChanged(const QString & text)
   {
-    LOG(Debug, "Load filter changed: " << text);
+    LOG(Debug, "Load filter changed: " << toString(text));
 
     auto objectSelector = getObjectSelector();
     if (text == SHOWALLLOADS)

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
@@ -602,7 +602,7 @@ namespace openstudio {
 
   void SpacesSubtabGridView::loadTypeFilterChanged(const QString& text)
   {
-    LOG(Debug, "Load filter changed: " << text);
+    LOG(Debug, "Load filter changed: " << toString(text));
 
     auto objectSelector = this->m_gridController->getObjectSelector();
     if (text == ALL)

--- a/openstudiocore/src/openstudio_lib/UtilityBillFuelTypeListView.cpp
+++ b/openstudiocore/src/openstudio_lib/UtilityBillFuelTypeListView.cpp
@@ -73,7 +73,7 @@ void UtilityBillFuelTypeListController::objectAdded(std::shared_ptr<openstudio::
         emit itemIds(ids);
 
         for (const OSItemId& id : ids){
-          if (id.itemId() == impl->handle().toString()){
+          if (id.itemId() == toQString(impl->handle())){
             emit selectedItemId(id);
             break;
           }

--- a/openstudiocore/src/openstudio_lib/VRFController.cpp
+++ b/openstudiocore/src/openstudio_lib/VRFController.cpp
@@ -102,7 +102,7 @@ void VRFController::refreshNow()
 
     if( m_currentSystem )
     {
-      m_detailView->setId(OSItemId(m_currentSystem->handle().toString(),modelToSourceId(m_currentSystem->model()),false));
+      m_detailView->setId(OSItemId(toQString(m_currentSystem->handle()), modelToSourceId(m_currentSystem->model()),false));
 
       connect(m_detailView.data(), &VRFSystemView::inspectClicked, this, &VRFController::inspectOSItem);
 
@@ -112,7 +112,7 @@ void VRFController::refreshNow()
           ++it)
       {
         auto vrfTerminalView = new VRFTerminalView();
-        vrfTerminalView->setId(OSItemId(it->handle().toString(),modelToSourceId(it->model()),false));
+        vrfTerminalView->setId(OSItemId(toQString(it->handle()), modelToSourceId(it->model()),false));
         m_detailView->addVRFTerminalView(vrfTerminalView);
         connect(vrfTerminalView, &VRFTerminalView::componentDroppedOnZone, this, &VRFController::onVRFTerminalViewDrop);
         connect(vrfTerminalView, &VRFTerminalView::removeZoneClicked, this, &VRFController::onRemoveZoneClicked);
@@ -156,7 +156,7 @@ void VRFController::onVRFSystemViewDrop(const OSItemId & itemid)
     if( auto component = doc->getComponent(itemid) ) {
       if( auto terminal = component->primaryObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>() ) {
         // Ugly hack to avoid the component being treated as a resource.
-        component->componentData().setString(OS_ComponentDataFields::UUID,createUUID().toString().toStdString());
+        component->componentData().setString(OS_ComponentDataFields::UUID, toString(createUUID()));
         std::cout << component->componentData().getString(OS_ComponentDataFields::UUID) << std::endl;;
         if( auto componentData = m_currentSystem->model().insertComponent(component.get()) ) {
           terminal = componentData->primaryComponentObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>();
@@ -223,7 +223,7 @@ void VRFController::onVRFTerminalViewDrop(const OSItemId & terminalId, const OSI
         if( auto component = doc->getComponent(terminalId) ) {
           if( auto terminal = component->primaryObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>() ) {
             // Ugly hack to avoid the component being treated as a resource.
-            component->componentData().setString(OS_ComponentDataFields::UUID,createUUID().toString().toStdString());
+            component->componentData().setString(OS_ComponentDataFields::UUID, toString(createUUID()));
             if( auto componentData = m_currentSystem->model().insertComponent(component.get()) ) {
               terminal = componentData->primaryComponentObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>();
               OS_ASSERT(terminal);
@@ -306,7 +306,7 @@ void VRFController::zoomOutToSystemGridView()
 void VRFController::inspectOSItem(const OSItemId & itemid)
 {
   OS_ASSERT(m_currentSystem);
-  boost::optional<model::ModelObject> mo = m_currentSystem->model().getModelObject<model::ModelObject>(Handle(itemid.itemId()));
+  boost::optional<model::ModelObject> mo = m_currentSystem->model().getModelObject<model::ModelObject>(toUUID(itemid.itemId()));
 
   std::shared_ptr<OSDocument> doc = OSAppBase::instance()->currentDocument();
   OS_ASSERT(doc);
@@ -400,7 +400,7 @@ void VRFSystemListController::addSystem(const OSItemId & itemid)
     if( auto component = doc->getComponent(itemid) ) {
       if( auto system = component->primaryObject().optionalCast<model::AirConditionerVariableRefrigerantFlow>() ) {
         // Ugly hack to avoid the component being treated as a resource.
-        component->componentData().setString(OS_ComponentDataFields::UUID,createUUID().toString().toStdString());
+        component->componentData().setString(OS_ComponentDataFields::UUID, toString(createUUID()));
         if( auto componentData = model->insertComponent(component.get()) ) {
           system = componentData->primaryComponentObject().optionalCast<model::AirConditionerVariableRefrigerantFlow>();
           OS_ASSERT(system);

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -1290,10 +1290,10 @@ std::string VersionTranslator::update_0_9_1_to_0_9_2(const IdfFile& idf_0_9_1, c
       boost::optional<std::string> s;
 
       IdfObject newInletPortList(idd_0_9_2.getObject("OS:PortList").get());
-      newInletPortList.setString(0,createUUID().toString().toStdString());
+      newInletPortList.setString(0,toString(createUUID()));
 
       IdfObject newExhaustPortList(idd_0_9_2.getObject("OS:PortList").get());
-      newExhaustPortList.setString(0,createUUID().toString().toStdString());
+      newExhaustPortList.setString(0,toString(createUUID()));
 
       IdfObject newZoneHVACEquipmentList(idd_0_9_2.getObject("OS:ZoneHVAC:EquipmentList").get());
 
@@ -1424,7 +1424,7 @@ std::string VersionTranslator::update_0_9_1_to_0_9_2(const IdfFile& idf_0_9_1, c
                           connection.setUnsigned(3,2);
 
                           newFPTSecondaryInletConn = IdfObject(idd_0_9_2.getObject("OS:Connection").get());
-                          newFPTSecondaryInletConn->setString(0,createUUID().toString().toStdString());
+                          newFPTSecondaryInletConn->setString(0,toString(createUUID()));
 
                           newFPTSecondaryInletConn->setString(2,node.getString(0).get());
                           newFPTSecondaryInletConn->setUnsigned(3,3);
@@ -1525,7 +1525,7 @@ std::string VersionTranslator::update_0_9_5_to_0_9_6(const IdfFile& idf_0_9_5, c
     {
       IdfObject newSizingPlant(idd_0_9_6.getObject("OS:Sizing:Plant").get());
 
-      newSizingPlant.setString(0,createUUID().toString().toStdString());
+      newSizingPlant.setString(0,toString(createUUID()));
 
       newSizingPlant.setString(1,object.getString(0).get());
 
@@ -1746,7 +1746,7 @@ std::string VersionTranslator::update_0_11_1_to_0_11_2(const IdfFile& idf_0_11_1
     {
       alwaysOnSchedule = IdfObject(idd_0_11_2.getObject("OS:Schedule:Constant").get());
 
-      alwaysOnSchedule->setString(0,createUUID().toString().toStdString());
+      alwaysOnSchedule->setString(0,toString(createUUID()));
 
       alwaysOnSchedule->setString(1,"Always On Discrete");
 
@@ -1755,7 +1755,7 @@ std::string VersionTranslator::update_0_11_1_to_0_11_2(const IdfFile& idf_0_11_1
 
       IdfObject typeLimits(idd_0_11_2.getObject("OS:ScheduleTypeLimits").get());
 
-      typeLimits.setString(0,createUUID().toString().toStdString());
+      typeLimits.setString(0,toString(createUUID()));
 
       typeLimits.setString(1,"Always On Discrete Limits");
 
@@ -1790,7 +1790,7 @@ std::string VersionTranslator::update_0_11_1_to_0_11_2(const IdfFile& idf_0_11_1
 
       IdfObject newMechVentController(idd_0_11_2.getObject("OS:Controller:MechanicalVentilation").get());
 
-      newMechVentController.setString(0,createUUID().toString().toStdString());
+      newMechVentController.setString(0,toString(createUUID()));
 
       newMechVentController.setString(4,"ZoneSum");
 
@@ -1812,14 +1812,14 @@ std::string VersionTranslator::update_0_11_1_to_0_11_2(const IdfFile& idf_0_11_1
 
       IdfObject newAvailList(idd_0_11_2.getObject("OS:AvailabilityManagerAssignmentList").get());
 
-      newAvailList.setString(0,createUUID().toString().toStdString());
+      newAvailList.setString(0,toString(createUUID()));
 
       newAirLoopHVAC.setString(3,newAvailList.getString(0).get());
 
 
       IdfObject newAvailabilityManagerScheduled(idd_0_11_2.getObject("OS:AvailabilityManager:Scheduled").get());
 
-      newAvailabilityManagerScheduled.setString(0,createUUID().toString().toStdString());
+      newAvailabilityManagerScheduled.setString(0,toString(createUUID()));
 
       newAvailabilityManagerScheduled.setString(2,alwaysOnSchedule->getString(0).get());
 
@@ -1830,7 +1830,7 @@ std::string VersionTranslator::update_0_11_1_to_0_11_2(const IdfFile& idf_0_11_1
 
       IdfObject newAvailabilityManagerNightCycle(idd_0_11_2.getObject("OS:AvailabilityManager:NightCycle").get());
 
-      newAvailabilityManagerNightCycle.setString(0,createUUID().toString().toStdString());
+      newAvailabilityManagerNightCycle.setString(0,toString(createUUID()));
 
       eg = newAvailList.insertExtensibleGroup(1);
 
@@ -2941,10 +2941,10 @@ std::string VersionTranslator::update_1_9_4_to_1_9_5(const IdfFile& idf_1_9_4, c
           for( const auto & coil : coils ) {
             // waterInletConnection will be a handle to a connection object
             if( auto waterInletConnectionHandle = coil.getString(waterInletIndex) ) {
-              if( auto waterInletConnection = idf_1_9_4.getObject(Handle(QString::fromStdString(waterInletConnectionHandle.get()))) ) {
+              if( auto waterInletConnection = idf_1_9_4.getObject(toUUID(waterInletConnectionHandle.get()))) {
                 if( auto sourceHandle = waterInletConnection->getString(2) ) {
                   if( sourceHandle.get() == actuatorNodeHandle.get() ) {
-                    result = coil.handle().toString().toStdString();
+                    result = toString(coil.handle());
                     break;
                   }
                 }

--- a/openstudiocore/src/pat_app/DesignAlternativesTabController.cpp
+++ b/openstudiocore/src/pat_app/DesignAlternativesTabController.cpp
@@ -874,7 +874,7 @@ void AlternativeModelMeasureListController::addAlternativeModelMeasure()
   QJsonArray modelMeasures = this->modelMeasures();
 
   QJsonObject newMeasure;
-  newMeasure.insert("uuid", UUID::createUuid().toString());
+  newMeasure.insert("uuid", toQString(openstudio::createUUID()));
   newMeasure.insert("displayName", QString("New User Defined Measure"));
   newMeasure.insert("description", QString("New User Defined Measure Description"));
   newMeasure.insert("taxonomyTag", QString("Envelope.Form"));

--- a/openstudiocore/src/project/DakotaAlgorithmRecord.cpp
+++ b/openstudiocore/src/project/DakotaAlgorithmRecord.cpp
@@ -88,7 +88,7 @@ namespace detail {
 
     value = query.value(DakotaAlgorithmRecord::ColumnsType::jobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      m_jobUUID = openstudio::UUID(value.toString());
+      m_jobUUID = toUUID(value.toString());
     }
   }
 
@@ -185,7 +185,7 @@ namespace detail {
     }
 
     if (m_jobUUID) {
-      query.bindValue(DakotaAlgorithmRecord::ColumnsType::jobUUID, m_jobUUID->toString());
+      query.bindValue(DakotaAlgorithmRecord::ColumnsType::jobUUID, toQString(*m_jobUUID));
     }
     else {
       query.bindValue(DakotaAlgorithmRecord::ColumnsType::jobUUID, QVariant(QVariant::String));
@@ -223,7 +223,7 @@ namespace detail {
 
     value = query.value(DakotaAlgorithmRecord::ColumnsType::jobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      m_lastJobUUID = openstudio::UUID(value.toString());
+      m_lastJobUUID = toUUID(value.toString());
     }else{
       m_lastJobUUID.reset();
     }
@@ -260,7 +260,7 @@ namespace detail {
 
     value = query.value(DakotaAlgorithmRecord::ColumnsType::jobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      openstudio::UUID testUUID(value.toString());
+      openstudio::UUID testUUID(toUUID(value.toString()));
       result = result && m_lastJobUUID && (m_lastJobUUID.get() == testUUID);
     }else{
       result = result && !m_lastJobUUID;

--- a/openstudiocore/src/project/DataPointRecord.cpp
+++ b/openstudiocore/src/project/DataPointRecord.cpp
@@ -147,7 +147,7 @@ namespace detail {
 
     value = query.value(DataPointRecordColumns::topLevelJobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      m_topLevelJobUUID = openstudio::UUID(value.toString());
+      m_topLevelJobUUID = toUUID(value.toString());
     }
 
     value = query.value(DataPointRecordColumns::dakotaParametersFiles);
@@ -672,7 +672,7 @@ namespace detail {
       query.bindValue(DataPointRecordColumns::sqlOutputDataRecordId, QVariant(QVariant::Int));
     }
     if (m_topLevelJobUUID) {
-      query.bindValue(DataPointRecordColumns::topLevelJobUUID, m_topLevelJobUUID->toString());
+      query.bindValue(DataPointRecordColumns::topLevelJobUUID, toQString(*m_topLevelJobUUID));
     }
     else {
       query.bindValue(DataPointRecordColumns::topLevelJobUUID, QVariant(QVariant::String));
@@ -755,7 +755,7 @@ namespace detail {
 
     value = query.value(DataPointRecordColumns::topLevelJobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      m_lastTopLevelJobUUID = openstudio::UUID(value.toString());
+      m_lastTopLevelJobUUID = toUUID(value.toString());
     }else{
       m_lastTopLevelJobUUID.reset();
     }
@@ -834,7 +834,7 @@ namespace detail {
 
     value = query.value(DataPointRecordColumns::topLevelJobUUID);
     if (value.isValid() && !value.isNull() && !value.toString().isEmpty()) {
-      openstudio::UUID testUUID(value.toString());
+      openstudio::UUID testUUID(toUUID(value.toString()));
       result = result && m_lastTopLevelJobUUID && (m_lastTopLevelJobUUID.get() == testUUID);
     }else{
       result = result && !m_lastTopLevelJobUUID;

--- a/openstudiocore/src/project/FileReferenceRecord.cpp
+++ b/openstudiocore/src/project/FileReferenceRecord.cpp
@@ -549,7 +549,7 @@ boost::optional<FileReferenceRecord> FileReferenceRecord::getFileReferenceRecord
   QSqlQuery query(*(database.qSqlDatabase()));
   query.prepare(toQString("SELECT * FROM " + FileReferenceRecord::databaseTableName() + 
       " WHERE handle=:handle"));
-  query.bindValue(":handle",handle.toString());
+  query.bindValue(":handle", toQString(handle));
   assertExec(query);
   if (query.first()) {
     result = FileReferenceRecord(query, database);

--- a/openstudiocore/src/project/ObjectRecord.cpp
+++ b/openstudiocore/src/project/ObjectRecord.cpp
@@ -44,7 +44,7 @@ namespace detail {
       m_description(description),
       m_timestampCreate(DateTime::now()),
       m_timestampLast(m_timestampCreate),
-      m_uuidLast(this->handle().toString())
+      m_uuidLast(this->handle())
   {}
 
   ObjectRecord_Impl::ObjectRecord_Impl(const ProjectDatabase& projectDatabase,
@@ -57,7 +57,7 @@ namespace detail {
       m_description(description),
       m_timestampCreate(DateTime::now()),
       m_timestampLast(m_timestampCreate),
-      m_uuidLast(this->handle().toString())
+      m_uuidLast(this->handle())
   {}
 
   ObjectRecord_Impl::ObjectRecord_Impl(const ProjectDatabase& projectDatabase,

--- a/openstudiocore/src/project/ProjectDatabase.hpp
+++ b/openstudiocore/src/project/ProjectDatabase.hpp
@@ -249,7 +249,7 @@ class PROJECT_API ProjectDatabase {
 
     QSqlQuery query(*(this->qSqlDatabase()));
     query.prepare(toQString("SELECT * FROM " + T::ObjectRecordType::databaseTableName() + " WHERE handle=:handle"));
-    query.bindValue(":handle",handle.toString());
+    query.bindValue(":handle", toQString(handle));
     try {
       assertExec(query);
       if (query.first()) {

--- a/openstudiocore/src/runmanager/lib/Job_Impl.cpp
+++ b/openstudiocore/src/runmanager/lib/Job_Impl.cpp
@@ -1693,10 +1693,10 @@ namespace detail {
 
     if (t_other.get() == this)
     {
-      LOG(Info, "Updating job is current job, nothing to do: " << toString(uuid().toString())); 
+      LOG(Info, "Updating job is current job, nothing to do: " << toString(uuid())); 
       return;
     } else {
-      LOG(Info, "Updating job: " << toString(uuid().toString()));
+      LOG(Info, "Updating job: " << toString(uuid()));
     }
 
     QWriteLocker l(&m_mutex);

--- a/openstudiocore/src/shared_gui_components/LocalLibraryController.cpp
+++ b/openstudiocore/src/shared_gui_components/LocalLibraryController.cpp
@@ -560,7 +560,7 @@ QWidget * LibraryItemDelegate::view(QSharedPointer<OSListItem> dataSource)
     MeasureType measureType = libraryItem->m_bclMeasure.measureType();
 
     // NOTE: replaces needed to trim unwanted curly braces
-    QString measureUUID = libraryItem->m_bclMeasure.uuid().toString().replace("{", "").replace("}", "").toStdString().c_str();
+    QString measureUUID = toQString(libraryItem->m_bclMeasure.uuid()).replace("{", "").replace("}", "");
 
     std::vector<std::string> localUUIDs = (LocalBCL::instance().measureUids());
 

--- a/openstudiocore/src/shared_gui_components/MeasureDragData.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureDragData.cpp
@@ -59,7 +59,7 @@ MeasureDragData::MeasureDragData(const QByteArray & data)
   QDomElement idElement = measureDragDataElement.firstChildElement("ID");
   QString idString = idElement.text();
   
-  m_id = UUID(idString);
+  m_id = toUUID(idString);
 }
 
 MeasureDragData::MeasureDragData(const UUID & id)
@@ -105,7 +105,7 @@ QString MeasureDragData::toXml()
   QDomElement idElement = doc.createElement("ID");
   measureDragDataElement.appendChild(idElement);
 
-  QDomText idText = doc.createTextNode(m_id.toString());
+  QDomText idText = doc.createTextNode(toQString(m_id));
   idElement.appendChild(idText);
 
   return doc.toString();

--- a/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
@@ -361,7 +361,7 @@ namespace openstudio{
     }
 
     if (result.isEmpty()){
-      result = QString("A") + createUUID().toString();
+      result = QString("A") + openstudio::toQString(createUUID());
       result.replace('{',"").replace('}',"").replace('-',"");
     }else if (!startsWithLetter){
       result.prepend("A");

--- a/openstudiocore/src/utilities/bcl/BCLXML.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLXML.cpp
@@ -38,8 +38,8 @@ namespace openstudio{
   BCLXML::BCLXML(const BCLXMLType& bclXMLType)
     : m_bclXMLType(bclXMLType)
   {
-    m_uid = removeBraces(UUID::createUuid());
-    m_versionId = removeBraces(UUID::createUuid());
+    m_uid = removeBraces(openstudio::createUUID());
+    m_versionId = removeBraces(openstudio::createUUID());
     m_versionModified = DateTime::nowUTC().toISO8601();
   }
 
@@ -799,13 +799,13 @@ namespace openstudio{
 
   void BCLXML::changeUID()
   {
-    m_uid = removeBraces(UUID::createUuid());
+    m_uid = removeBraces(openstudio::createUUID());
     // DLM: should this call incrementVersionId() ?
   }
 
   void BCLXML::incrementVersionId()
   {
-    m_versionId = removeBraces(UUID::createUuid());
+    m_versionId = removeBraces(openstudio::createUUID());
     m_versionModified = DateTime::nowUTC().toISO8601();
   }
 

--- a/openstudiocore/src/utilities/cloud/OSServer.cpp
+++ b/openstudiocore/src/utilities/cloud/OSServer.cpp
@@ -1755,7 +1755,7 @@ namespace openstudio{
       for (const QJsonValue& val : array) {
         if (val.toObject().contains("_id")){
           QString id = val.toObject()["_id"].toString();
-          UUID uuid(id);
+          UUID uuid = toUUID(id);
           result.push_back(uuid);
         }else{
           success = false;

--- a/openstudiocore/src/utilities/core/Compare.hpp
+++ b/openstudiocore/src/utilities/core/Compare.hpp
@@ -237,23 +237,23 @@ struct IndexLess {
 
 template<class T,class U>
 bool uuidsEqual(const T& left,const U& right) {
-  return (!left.uuid().is_nil()) && (left.uuid() == right.uuid());
+  return (!left.uuid().isNull()) && (left.uuid() == right.uuid());
 }
 
 template<class T,class U>
 bool uuidsAndVersionsEqual(const T& left,const U& right) {
-  return (!left.uuid().is_nil()) && (left.uuid() == right.uuid()) &&
-      (!left.versionUUID().is_nil()) && (left.versionUUID() == right.versionUUID());
+  return (!left.uuid().isNull()) && (left.uuid() == right.uuid()) &&
+      (!left.versionUUID().isNull()) && (left.versionUUID() == right.versionUUID());
 }
 
 template<class T,class U>
 bool uuidEquals(const T& object, const U& uuid) {
-  return !uuid.is_nil() && (object.uuid() == uuid);
+  return !uuid.isNull() && (object.uuid() == uuid);
 }
 
 template<class T,class U>
 bool handleEquals(const T& object, const U& handle) {
-  return !handle.is_nil() && (object.handle() == handle);
+  return !handle.isNull() && (object.handle() == handle);
 }
 
 }; // openstudio

--- a/openstudiocore/src/utilities/core/Compare.hpp
+++ b/openstudiocore/src/utilities/core/Compare.hpp
@@ -237,23 +237,23 @@ struct IndexLess {
 
 template<class T,class U>
 bool uuidsEqual(const T& left,const U& right) {
-  return (!left.uuid().isNull()) && (left.uuid() == right.uuid());
+  return (!left.uuid().is_nil()) && (left.uuid() == right.uuid());
 }
 
 template<class T,class U>
 bool uuidsAndVersionsEqual(const T& left,const U& right) {
-  return (!left.uuid().isNull()) && (left.uuid() == right.uuid()) &&
-      (!left.versionUUID().isNull()) && (left.versionUUID() == right.versionUUID());
+  return (!left.uuid().is_nil()) && (left.uuid() == right.uuid()) &&
+      (!left.versionUUID().is_nil()) && (left.versionUUID() == right.versionUUID());
 }
 
 template<class T,class U>
 bool uuidEquals(const T& object, const U& uuid) {
-  return !uuid.isNull() && (object.uuid() == uuid);
+  return !uuid.is_nil() && (object.uuid() == uuid);
 }
 
 template<class T,class U>
 bool handleEquals(const T& object, const U& handle) {
-  return !handle.isNull() && (object.handle() == handle);
+  return !handle.is_nil() && (object.handle() == handle);
 }
 
 }; // openstudio

--- a/openstudiocore/src/utilities/core/UUID.cpp
+++ b/openstudiocore/src/utilities/core/UUID.cpp
@@ -20,7 +20,13 @@
 #include "UUID.hpp"
 #include "String.hpp"
 #include "Checksum.hpp"
+#include "StaticInitializer.hpp"
+
 #include <sstream>
+
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/thread/tss.hpp>
 
 #ifdef __APPLE__
 
@@ -29,6 +35,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <math.h>
+
 
 #endif  // __APPLE__
 
@@ -55,34 +62,111 @@ namespace openstudio {
     };
     
     RandomNumberInitializer _randomNumberInitializer;
-    
+
   }
-  
+
 #endif  // __APPLE__
+
+  namespace detail {
+    struct BoostGeneratorsInitializer : StaticInitializer<BoostGeneratorsInitializer>
+    {
+      static void initialize()
+      {
+        createUUID();
+        toUUID(std::string("00000000-0000-0000-0000-000000000000"));
+      }
+    };
+    struct MakeSureBoostGeneratorsInitializerIsInitialized
+    {
+      MakeSureBoostGeneratorsInitializerIsInitialized()
+      {}
+
+      BoostGeneratorsInitializer m_i;
+    };
+
+  }
+
+
+UUID::UUID()
+  : boost::uuids::uuid(boost::uuids::nil_uuid())
+{
+}
+
+UUID::UUID(const boost::uuids::uuid &t_other)
+  : boost::uuids::uuid(t_other)
+{
+}
+
+UUID UUID::random_generate()
+{
+  static boost::thread_specific_ptr<boost::uuids::random_generator> gen;
+
+  if (gen.get() == nullptr) {
+    gen.reset(new boost::uuids::random_generator);
+  }
+    
+  return UUID((*gen)());
+}
+
+UUID UUID::string_generate(const std::string &t_str)
+{
+  static boost::thread_specific_ptr<boost::uuids::string_generator> gen;
+
+  if (gen.get() == nullptr) {
+    gen.reset(new boost::uuids::string_generator);
+  }
+
+  return UUID((*gen)(t_str));
+}
+
 
 UUID createUUID() 
 {
-  return QUuid::createUuid();
+  return UUID::random_generate();
+}
+
+UUID toUUID(const QString &str)
+{
+  return toUUID(toString(str));
 }
   
 UUID toUUID(const std::string& str)
 {
-  UUID uuid;
-  try{
-    uuid = UUID(toQString(str));
-  }catch(...){
-    try {
-      uuid = UUID(toQString("{" + str + "}"));
-    }
-    catch(...) {}
+  try {
+    return UUID::string_generate(str);
+  } catch (...) {
+    return UUID();
   }
-  return uuid;
 }
+
+bool operator!= ( const UUID & lhs, const UUID & rhs ) {
+  return static_cast<const boost::uuids::uuid&>(lhs) != static_cast<const boost::uuids::uuid&>(rhs);
+}
+bool operator< ( const UUID & lhs, const UUID & rhs ) {
+  return static_cast<const boost::uuids::uuid&>(lhs) < static_cast<const boost::uuids::uuid&>(rhs);
+}
+bool operator== ( const UUID & lhs, const UUID & rhs ) {
+  return static_cast<const boost::uuids::uuid&>(lhs) == static_cast<const boost::uuids::uuid&>(rhs);
+}
+bool operator> ( const UUID & lhs, const UUID & rhs ) {
+  return static_cast<const boost::uuids::uuid&>(lhs) > static_cast<const boost::uuids::uuid&>(rhs);
+}
+
 
 std::string toString(const UUID& uuid)
 {
-  return toString(uuid.toString());
+  std::stringstream ss;
+  ss << '{';
+  boost::uuids::operator<<(ss, uuid);
+  ss << '}';
+  return ss.str();
 }
+
+QString toQString(const UUID& uuid)
+{
+  return toQString(toString(uuid));
+}
+
 
 std::string createUniqueName(const std::string& prefix) {
   std::stringstream ss;
@@ -94,7 +178,9 @@ std::string createUniqueName(const std::string& prefix) {
 }
 
 std::string removeBraces(const UUID& uuid) {
-  return uuid.toString().replace("{", "").replace("}", "").toStdString();
+  std::stringstream ss;
+  boost::uuids::operator<<(ss, uuid);
+  return ss.str();
 }
 
 std::ostream& operator<<(std::ostream& os,const UUID& uuid) {

--- a/openstudiocore/src/utilities/core/UUID.hpp
+++ b/openstudiocore/src/utilities/core/UUID.hpp
@@ -22,17 +22,79 @@
 
 #include "../UtilitiesAPI.hpp"
 
-#include <QUuid>
 #include <QMetaType>
 #include <boost/optional.hpp>
+#include <boost/uuid/uuid.hpp>
 #include <vector>
 #include <ostream>
 #include <string>
 
 namespace openstudio {
+       class UTILITIES_API UUID;
+
+       /// create a UUID
+       UTILITIES_API UUID createUUID();
+
+       /// create a UUID from a std::string, does not throw, may return a null UUID
+       UTILITIES_API UUID toUUID(const std::string& str);
+
+       /// create a UUID from a std::string, does not throw, may return a null UUID
+       UTILITIES_API UUID toUUID(const QString& str);
+
+       /// create a std::string from a UUID
+       UTILITIES_API std::string toString(const UUID& uuid);
+
+       /// create a QString from a UUID
+       UTILITIES_API QString toQString(const UUID& uuid);
+
+       /// create a unique name, prefix << " " << UUID.
+       UTILITIES_API std::string createUniqueName(const std::string& prefix);
+
+       /// create a std::string without curly brackets from a UUID
+       UTILITIES_API std::string removeBraces(const UUID& uuid);
+
+       UTILITIES_API std::ostream& operator<<(std::ostream& os, const UUID& uuid);
+
+       UTILITIES_API bool operator!= (const UUID & lhs, const UUID & rhs);
+       UTILITIES_API bool operator< (const UUID & lhs, const UUID & rhs);
+       UTILITIES_API bool operator== (const UUID & lhs, const UUID & rhs);
+       UTILITIES_API bool operator> (const UUID & lhs, const UUID & rhs);
 
   /// Universally Unique Identifier
-  typedef QUuid UUID;
+  class UTILITIES_API UUID : private boost::uuids::uuid
+  {
+    public:
+      UUID();
+      using boost::uuids::uuid::is_nil;
+
+      bool isNull() const {
+        return is_nil();
+      }
+
+      using boost::uuids::uuid::iterator;
+      using boost::uuids::uuid::const_iterator;
+      using boost::uuids::uuid::begin;
+      using boost::uuids::uuid::end;
+
+    private:
+      explicit UUID(const boost::uuids::uuid &);
+
+      UTILITIES_API friend UUID openstudio::createUUID();
+      UTILITIES_API friend UUID openstudio::toUUID(const std::string& str);
+      UTILITIES_API friend UUID openstudio::toUUID(const QString& str);
+      UTILITIES_API friend std::string openstudio::toString(const UUID& uuid);
+      UTILITIES_API friend QString openstudio::toQString(const UUID& uuid);
+      UTILITIES_API friend std::string openstudio::createUniqueName(const std::string& prefix);
+      UTILITIES_API friend std::string openstudio::removeBraces(const UUID& uuid);
+      UTILITIES_API friend bool openstudio::operator!= (const UUID & lhs, const UUID & rhs);
+      UTILITIES_API friend bool openstudio::operator< (const UUID & lhs, const UUID & rhs);
+      UTILITIES_API friend bool openstudio::operator== (const UUID & lhs, const UUID & rhs);
+      UTILITIES_API friend bool openstudio::operator> (const UUID & lhs, const UUID & rhs);
+
+      static UUID random_generate();
+      static UUID string_generate(const std::string &);
+
+  };
 
   /// optional UUID
   typedef boost::optional<UUID> OptionalUUID;
@@ -40,22 +102,6 @@ namespace openstudio {
   /// vector of UUID
   typedef std::vector<UUID> UUIDVector;
 
-  /// create a UUID
-  UTILITIES_API UUID createUUID();
-
-  /// create a UUID from a std::string, does not throw, may return a null UUID
-  UTILITIES_API UUID toUUID(const std::string& str);
-
-  /// create a std::string from a UUID
-  UTILITIES_API std::string toString(const UUID& uuid);
-
-  /// create a unique name, prefix << " " << UUID.
-  UTILITIES_API std::string createUniqueName(const std::string& prefix);
-
-  /// create a std::string without curly brackets from a UUID
-  UTILITIES_API std::string removeBraces(const UUID& uuid);
-
-  UTILITIES_API std::ostream& operator<<(std::ostream& os,const UUID& uuid);
 
 } // openstudio
 

--- a/openstudiocore/src/utilities/core/UUID.hpp
+++ b/openstudiocore/src/utilities/core/UUID.hpp
@@ -65,7 +65,6 @@ namespace openstudio {
   {
     public:
       UUID();
-      using boost::uuids::uuid::is_nil;
 
       bool isNull() const {
         return is_nil();

--- a/openstudiocore/src/utilities/core/UUID.i
+++ b/openstudiocore/src/utilities/core/UUID.i
@@ -12,16 +12,13 @@
 namespace openstudio{
 
   #ifdef SWIGRUBY
-    %rename("nil?") isNull();
+    %rename("nil?") is_nil();
   #endif
 
   class UUID {
   public:
-    bool operator!= ( const UUID & other ) const;
-    bool operator< ( const UUID & other ) const;
-    bool operator== ( const UUID & other ) const;
-    bool operator> ( const UUID & other ) const;
-    bool isNull () const;
+    bool is_nil() const;
+    bool isNull() const;
     ~UUID();
 
   protected:
@@ -41,7 +38,27 @@ namespace openstudio{
     }
     
     std::string __str__() const{
-      return openstudio::toString(self->toString());
+      return openstudio::toString(*self);
+    }
+
+    bool isNull() const {
+      return self->is_nil();
+    }
+
+    bool operator!= ( const UUID & other ) const {
+      return *self != other;
+    }
+
+    bool operator< ( const UUID & other ) const {
+      return *self < other;
+    }
+
+    bool operator== ( const UUID & other ) const {
+      return *self == other;
+    }
+
+    bool operator> ( const UUID & other ) const {
+      return *self > other;
     }
   };
 

--- a/openstudiocore/src/utilities/core/UUID.i
+++ b/openstudiocore/src/utilities/core/UUID.i
@@ -12,37 +12,32 @@
 namespace openstudio{
 
   #ifdef SWIGRUBY
-    %rename("nil?") is_nil();
+    %rename("nil?") isNull();
   #endif
 
   class UUID {
   public:
-    bool is_nil() const;
     bool isNull() const;
     ~UUID();
 
   protected:
      UUID();
   };
-  
+
   UUID toUUID(const std::string& str);
-  
+
   UUID createUUID();
-  
+
   std::string removeBraces(const UUID& uuid);
-  
+
   %extend UUID{
-  
+
     static UUID create(){
       return createUUID();
     }
-    
+
     std::string __str__() const{
       return openstudio::toString(*self);
-    }
-
-    bool isNull() const {
-      return self->is_nil();
     }
 
     bool operator!= ( const UUID & other ) const {

--- a/openstudiocore/src/utilities/core/test/UUID_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/UUID_GTest.cpp
@@ -58,7 +58,7 @@ TEST(UUID, Constuctors)
   EXPECT_TRUE(uuid == uuid3);
 
   // from bad string
-  UUID uuid4 = toUUID("Not a UUID");
+  UUID uuid4 = toUUID(std::string("Not a UUID"));
   EXPECT_TRUE(uuid4.isNull());
 }
 
@@ -80,7 +80,7 @@ TEST(UUID, UUID_QVariant)
 {
   UUID uuid = createUUID();
   QVariant variant = QVariant::fromValue(uuid);
-  EXPECT_EQ("QUuid", std::string(variant.typeName()));
+  EXPECT_EQ("openstudio::UUID", std::string(variant.typeName()));
   ASSERT_TRUE(variant.canConvert<UUID>());
   UUID uuid2 = variant.value<UUID>();
   EXPECT_TRUE(uuid == uuid2);

--- a/openstudiocore/src/utilities/data/Attribute.cpp
+++ b/openstudiocore/src/utilities/data/Attribute.cpp
@@ -810,12 +810,12 @@ namespace detail{
     QDomText text;
 
     childElement = doc.createElement(QString::fromStdString("UUID"));
-    text = doc.createTextNode(m_uuid.toString());
+    text = doc.createTextNode(openstudio::toQString(m_uuid));
     childElement.appendChild(text);
     element.appendChild(childElement);
 
     childElement = doc.createElement(QString::fromStdString("VersionUUID"));
-    text = doc.createTextNode(m_versionUUID.toString());
+    text = doc.createTextNode(openstudio::toQString(m_versionUUID));
     childElement.appendChild(text);
     element.appendChild(childElement);
 

--- a/openstudiocore/src/utilities/idf/Test/IdfObject_GTest.cpp
+++ b/openstudiocore/src/utilities/idf/Test/IdfObject_GTest.cpp
@@ -748,7 +748,7 @@ TEST_F(IdfFixture, Handle_QVariant)
 {
   Handle handle = createUUID();
   QVariant variant = QVariant::fromValue(handle);
-  EXPECT_EQ("QUuid", std::string(variant.typeName()));
+  EXPECT_EQ("openstudio::UUID", std::string(variant.typeName()));
   ASSERT_TRUE(variant.canConvert<Handle>());
   Handle handle2 = variant.value<Handle>();
   EXPECT_TRUE(handle == handle2);

--- a/openstudiocore/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
+++ b/openstudiocore/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
@@ -414,7 +414,7 @@ TEST_F(IdfFixture, WorkspaceObject_RestoreHandleInAddObjects)
   EXPECT_EQ(1u, ws1.objects().size());
   OptionalString h1String = w1->getString(0);
   ASSERT_TRUE(h1String);
-  Handle h1(toQString(*h1String));
+  Handle h1(toUUID(*h1String));
   EXPECT_FALSE(h1.isNull());
   EXPECT_EQ(h1, w1->handle());
 
@@ -424,7 +424,7 @@ TEST_F(IdfFixture, WorkspaceObject_RestoreHandleInAddObjects)
   WorkspaceObject w2 = ws2.objects()[0];
   OptionalString h2String = w2.getString(0);
   ASSERT_TRUE(h2String);
-  Handle h2(toQString(*h2String));
+  Handle h2(toUUID(*h2String));
   EXPECT_FALSE(h2.isNull());
   EXPECT_EQ(h2, w2.handle());
 }
@@ -438,7 +438,7 @@ TEST_F(IdfFixture, WorkspaceObject_RestoreHandleInAddObjects2)
   EXPECT_EQ(1u, ws1.objects().size());
   OptionalString h1String = w1->getString(0);
   ASSERT_TRUE(h1String);
-  Handle h1(toQString(*h1String));
+  Handle h1(toUUID(*h1String));
   EXPECT_FALSE(h1.isNull());
   EXPECT_EQ(h1, w1->handle());
 
@@ -447,7 +447,7 @@ TEST_F(IdfFixture, WorkspaceObject_RestoreHandleInAddObjects2)
   IdfObject i1 = idf1.objects()[0];
   OptionalString i1hString = i1.getString(0);
   ASSERT_TRUE(i1hString);
-  Handle ih(toQString(*i1hString));
+  Handle ih(toUUID(*i1hString));
   EXPECT_FALSE(ih.isNull());
   EXPECT_EQ(ih,i1.handle());
 
@@ -457,7 +457,7 @@ TEST_F(IdfFixture, WorkspaceObject_RestoreHandleInAddObjects2)
   WorkspaceObject w2 = ws2.objects()[0];
   OptionalString h2String = w2.getString(0);
   ASSERT_TRUE(h2String);
-  Handle h2(toQString(*h2String));
+  Handle h2(toUUID(*h2String));
   EXPECT_FALSE(h2.isNull());
   EXPECT_EQ(h2, w2.handle());
 }

--- a/openstudiocore/src/utilities/pch/PCH.hpp.gcc.in
+++ b/openstudiocore/src/utilities/pch/PCH.hpp.gcc.in
@@ -513,5 +513,4 @@
 #include <QString>
 #include <QTextStream>
 #include <QUrl>
-#include <QUuid>
 #include <QVariant>

--- a/openstudiocore/src/utilities/pch/PCH.hpp.msvc.in
+++ b/openstudiocore/src/utilities/pch/PCH.hpp.msvc.in
@@ -513,5 +513,4 @@
 #include <QString>
 #include <QTextStream>
 #include <QUrl>
-#include <QUuid>
 #include <QVariant>


### PR DESCRIPTION
@kbenne note: aparently boost::uuid has two problems

  1. Abhorent speed if you recreate the generator on each call
  2. default constructor makes no guarantee on value, nil generator
     needs to be used instead

We fix those issues by making our own UUID type that inherits
from boost::uuids::uuid and sets the default construction.

We also make global thread safe generators that can be called as
necessary. That code can be moved to C++11's thread_local at some point
in the future if you move to MSVC2015 as a requirement.

Important notes:

  * The built in QUUID::toString was leading to much duplicated and
    inefficient string/qstring/uuid conversions. This patch reduces that
  * We rename methods as necessary to get it looking as much like QUUID as
    possible.