### PR TITLE
Implement missing fields for EvaporativeCoolerDirectResarchSpecial

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -18679,7 +18679,7 @@ OS:EvaporativeCooler:Direct:ResearchSpecial,
        \required-field
        \units W/(m3/s)
        \note this field is used when the previous field is set to autosize. The pump power is scaled with Primary Air Design Air Flow Rate
-  A8;  \field Water Pump Power Modifier Curve Name
+  A8,  \field Water Pump Power Modifier Curve Name
        \note this curve modifies the pump power in the previous field by multiplying the design power by the result of this curve.
        \note x = ff = flow fraction on the primary air.  The flow fraction is the secondary air flow rate during current operation divided
        \note by Primary Air Design Flow Rate
@@ -18690,6 +18690,29 @@ OS:EvaporativeCooler:Direct:ResearchSpecial,
        \note Curve:ExponentialSkewNormal, Curve:Sigmoid, Curve:RectuangularHyperbola1,
        \note Curve:RectangularHyperbola2, Curve:ExponentialDecay, Curve:DoubleExponentialDecay,
        \note Table:OneIndependentVariable
+  N7,  \field Evaporative Operation Minimum Drybulb Temperature
+       \type real
+       \minimum -99.0
+       \note This numeric field defines the evaporative cooler air inlet node drybulb temperature minimum
+       \note limit in degrees Celsius. The evaporative cooler will be turned off when the evaporator cooler
+       \note air inlet node dry-bulb temperature falls below this limit. The typical minimum value is 16degC. Users
+       \note are allowed to specify their own limits. If this field is left blank, then there is no drybulb lower
+       \note temperature limit for evaporative cooler operation.
+  N8,  \field Evaporative Operation Maximum Limit Wetbulb Temperature
+       \type real
+       \note when outdoor wetbulb temperature rises above this limit the cooler shuts down.
+       \note This numeric field defines the evaporative cooler air inlet node wet-bulb temperature maximum
+       \note limit in degrees Celsius. The evaporative cooler will be turned off when the evaporative cooler
+       \note air inlet node wet-bulb temperature exceeds this limit. The typical maximum value is 24degC. Users
+       \note are allowed to specify their own limits. If this field is left blank, then there is no upper
+       \note wetbulb temperature limit for evaporative cooler operation.
+  N9;  \field Evaporative Operation Maximum Limit Drybulb Temperature
+       \type real
+       \note This numeric field defines the evaporative cooler air inlet node dry-bulb temperature maximum
+       \note limit in degrees Celsius. The evaporative cooler will be turned off when its air inlet node
+       \note drybulb temperature exceeds this limit. The typical maximum value is 26degC. Users
+       \note are allowed to specify their own limits. If this field is left blank, then there is no upper
+       \note temperature limit for evaporative cooler operation.
 
 OS:EvaporativeFluidCooler:SingleSpeed,
        \min-fields 10
@@ -27396,7 +27419,7 @@ OS:ElectricLoadCenter:Inverter:PVWatts,
       \memo It implements the PVWatts inverter performance curves.
   A1, \field Handle
        \type handle
-       \required-field 
+       \required-field
   A2, \field Name
       \required-field
       \reference InverterList

--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -559,6 +559,7 @@ set(${target_name}_test_src
   Test/ElectricEquipment_GTest.cpp
   Test/EMS_GTest.cpp
   Test/FuelCell_GTest.cpp
+  Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
   Test/ExteriorLights_GTest.cpp
   Test/ExteriorFuelEquipment_GTest.cpp
   Test/ExteriorWaterEquipment_GTest.cpp

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
@@ -148,22 +148,17 @@ boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectRe
   }
 
   // Evaporative Operation Minimum Drybulb Temperature (Optional Double)
-  if( (OptD = modelObject.evaporativeOperationMinimumDrybulbTemperature()) )
-  {
-    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature,OptD.get());
-  }
+  idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature,
+                      modelObject.evaporativeOperationMinimumDrybulbTemperature());
+
 
   // Evaporative Operation Maximum Limit Wetbulb Temperature (Optional Double)
-  if( (OptD = modelObject.evaporativeOperationMaximumLimitWetbulbTemperature()) )
-  {
-    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature,OptD.get());
-  }
- 
+  idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature,
+                      modelObject.evaporativeOperationMaximumLimitWetbulbTemperature());
+
   // Evaporative Operation Maximum Limit Drybulb Temperature (Optional Double)
-  if( (OptD = modelObject.evaporativeOperationMaximumLimitDrybulbTemperature()) )
-  {
-    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature,OptD.get());
-  } 
+  idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature,
+                      modelObject.evaporativeOperationMaximumLimitDrybulbTemperature());
 
   return boost::optional<IdfObject>(idfObject);
 }

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
@@ -147,16 +147,16 @@ boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectRe
     idfObject.setString(EvaporativeCooler_Direct_ResearchSpecialFields::WaterPumpPowerModifierCurveName,_curve->name().get());
   }
 
-  // Evaporative Operation Minimum Drybulb Temperature (Optional Double)
+  // Evaporative Operation Minimum Drybulb Temperature (Double)
   idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature,
                       modelObject.evaporativeOperationMinimumDrybulbTemperature());
 
 
-  // Evaporative Operation Maximum Limit Wetbulb Temperature (Optional Double)
+  // Evaporative Operation Maximum Limit Wetbulb Temperature (Double)
   idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature,
                       modelObject.evaporativeOperationMaximumLimitWetbulbTemperature());
 
-  // Evaporative Operation Maximum Limit Drybulb Temperature (Optional Double)
+  // Evaporative Operation Maximum Limit Drybulb Temperature (Double)
   idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature,
                       modelObject.evaporativeOperationMaximumLimitDrybulbTemperature());
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
@@ -148,21 +148,21 @@ boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectRe
   }
 
   // Evaporative Operation Minimum Drybulb Temperature (Optional Double)
-  if( OptD = modelObject.evaporativeOperationMinimumDrybulbTemperature() )
+  if( (OptD = modelObject.evaporativeOperationMinimumDrybulbTemperature()) )
   {
     idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature,OptD.get());
   }
 
   // Evaporative Operation Maximum Limit Wetbulb Temperature (Optional Double)
-  if( OptD = modelObject.evaporativeOperationMaximumLimitWetbulbTemperature() )
+  if( (OptD = modelObject.evaporativeOperationMaximumLimitWetbulbTemperature()) )
   {
     idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature,OptD.get());
   }
  
   // Evaporative Operation Maximum Limit Drybulb Temperature (Optional Double)
-  if( OptD = modelObject.evaporativeOperationMaximumLimitDryBulbTemperature() )
+  if( (OptD = modelObject.evaporativeOperationMaximumLimitDrybulbTemperature()) )
   {
-    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature,OptD.get());
+    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature,OptD.get());
   } 
 
   return boost::optional<IdfObject>(idfObject);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateEvaporativeCoolerDirectResearchSpecial.cpp
@@ -50,7 +50,7 @@ namespace energyplus {
 boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectResearchSpecial( EvaporativeCoolerDirectResearchSpecial & modelObject )
 {
   OptionalString s;
-  OptionalDouble d;
+  OptionalDouble OptD;
   OptionalModelObject temp;
   double value;
 
@@ -77,8 +77,8 @@ boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectRe
   // RecirculatingWaterPumpPowerConsumption
   if ( modelObject.isRecirculatingWaterPumpPowerConsumptionAutosized() ) {
     idfObject.setString(EvaporativeCooler_Direct_ResearchSpecialFields::RecirculatingWaterPumpDesignPower,"autosize");
-  } else if( (d = modelObject.recirculatingWaterPumpPowerConsumption()) ) {
-    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::RecirculatingWaterPumpDesignPower,d.get());
+  } else if( (OptD = modelObject.recirculatingWaterPumpPowerConsumption()) ) {
+    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::RecirculatingWaterPumpDesignPower,OptD.get());
   }
 
   // AirInletNodeName
@@ -146,6 +146,24 @@ boost::optional<IdfObject> ForwardTranslator::translateEvaporativeCoolerDirectRe
     OS_ASSERT(_curve);
     idfObject.setString(EvaporativeCooler_Direct_ResearchSpecialFields::WaterPumpPowerModifierCurveName,_curve->name().get());
   }
+
+  // Evaporative Operation Minimum Drybulb Temperature (Optional Double)
+  if( OptD = modelObject.evaporativeOperationMinimumDrybulbTemperature() )
+  {
+    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature,OptD.get());
+  }
+
+  // Evaporative Operation Maximum Limit Wetbulb Temperature (Optional Double)
+  if( OptD = modelObject.evaporativeOperationMaximumLimitWetbulbTemperature() )
+  {
+    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature,OptD.get());
+  }
+ 
+  // Evaporative Operation Maximum Limit Drybulb Temperature (Optional Double)
+  if( OptD = modelObject.evaporativeOperationMaximumLimitDryBulbTemperature() )
+  {
+    idfObject.setDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature,OptD.get());
+  } 
 
   return boost::optional<IdfObject>(idfObject);
 }

--- a/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
@@ -1,0 +1,80 @@
+/***********************************************************************************************************************
+ *  OpenStudio(R), Copyright (c) 2008-2017, Alliance for Sustainable Energy, LLC. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ *  following conditions are met:
+ *
+ *  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *  disclaimer.
+ *
+ *  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *  following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote
+ *  products derived from this software without specific prior written permission from the respective party.
+ *
+ *  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative
+ *  works may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without
+ *  specific prior written permission from Alliance for Sustainable Energy, LLC.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+#include "../ReverseTranslator.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/Schedule.hpp"
+
+#include "../../model/EvaporativeCoolerDirectResearchSpecial.hpp"
+
+#include <utilities/idd/IddEnums.hxx>
+#include <utilities/idd/EvaporativeCooler_Direct_ResearchSpecial_FieldEnums.hxx>
+
+#include <resources.hxx>
+
+#include <sstream>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+TEST_F(EnergyPlusFixture,ForwardTranslator_EvaporativeCoolerDirectResearchSpecial_LimitFields)
+{
+  Model m;
+
+  Schedule sch =  m.alwaysOnDiscreteSchedule();
+  EvaporativeCoolerDirectResearchSpecial e(m, sch);
+
+  ASSERT_TRUE(e.setEvaporativeOperationMinimumDrybulbTemperature(16));
+  ASSERT_TRUE(e.setEvaporativeOperationMaximumLimitWetbulbTemperature(24));
+  ASSERT_TRUE(e.setEvaporativeOperationMaximumLimitDrybulbTemperature(28));
+
+  ASSERT_EQ(16, e.evaporativeOperationMinimumDrybulbTemperature());
+  ASSERT_EQ(24, e.evaporativeOperationMaximumLimitWetbulbTemperature());
+  ASSERT_EQ(28, e.evaporativeOperationMaximumLimitDrybulbTemperature());
+
+  ForwardTranslator ft;
+  Workspace w = ft.translateModel(m);
+
+  WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::EvaporativeCooler_Direct_ResearchSpecial);
+  ASSERT_EQ(1u, idfObjs.size());
+
+  WorkspaceObject idfObj(idfObjs[0]);
+
+  ASSERT_EQ(16, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature).get());
+  ASSERT_EQ(24, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature).get());
+  ASSERT_EQ(28, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature).get());
+
+}
+
+

--- a/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
@@ -71,9 +71,12 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_EvaporativeCoolerDirectResearchSpecia
 
   WorkspaceObject idfObj(idfObjs[0]);
 
-  ASSERT_EQ(16, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature).get());
-  ASSERT_EQ(24, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature).get());
-  ASSERT_EQ(28, idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature).get());
+  ASSERT_EQ(e.evaporativeOperationMinimumDrybulbTemperature(),
+            idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature).get());
+  ASSERT_EQ(e.evaporativeOperationMaximumLimitWetbulbTemperature(),
+            idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature).get());
+  ASSERT_EQ(e.evaporativeOperationMaximumLimitDrybulbTemperature(),
+            idfObj.getDouble(EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature).get());
 
 }
 

--- a/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/EvaporativeCoolerDirectResearchSpecial_GTest.cpp
@@ -1,30 +1,31 @@
 /***********************************************************************************************************************
- *  OpenStudio(R), Copyright (c) 2008-2017, Alliance for Sustainable Energy, LLC. All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
- *  following conditions are met:
- *
- *  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
- *  disclaimer.
- *
- *  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- *  following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- *  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote
- *  products derived from this software without specific prior written permission from the respective party.
- *
- *  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative
- *  works may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without
- *  specific prior written permission from Alliance for Sustainable Energy, LLC.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR
- *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- *  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- **********************************************************************************************************************/
+*  OpenStudio(R), Copyright (c) 2008-2018, Alliance for Sustainable Energy, LLC. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
 
 #include <gtest/gtest.h>
 #include "EnergyPlusFixture.hpp"

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
@@ -356,13 +356,6 @@ namespace detail{
     return result;
   }
 
-  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitDrybulbTemperature() {
-    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature, "");
-    OS_ASSERT(result);
-  }
-
-
-
 
   boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::autosizedRecirculatingWaterPumpPowerConsumption() const {
     return getAutosizedValue("Recirculating Pump Power", "W");

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
@@ -327,12 +327,8 @@ namespace detail{
 
 
   // Evaporative Operation Minimum Drybulb Temperature
-  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMinimumDrybulbTemperature() const {
-    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature, true);
-  }
-
-  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const {
-    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature);
+  double EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMinimumDrybulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature).get();
   }
 
   bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature) {
@@ -340,18 +336,9 @@ namespace detail{
     return result;
   }
 
-  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMinimumDrybulbTemperature() {
-    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature, "");
-    OS_ASSERT(result);
-  }
-
   // Evaporative Operation Maximum Limit Wetbulb Temperature
-  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitWetbulbTemperature() const {
-    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature, true);
-  }
-
-  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const {
-    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature);
+  double EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitWetbulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature).get();
   }
 
   bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature) {
@@ -359,18 +346,9 @@ namespace detail{
     return result;
   }
 
-  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitWetbulbTemperature() {
-    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature, "");
-    OS_ASSERT(result);
-  }
-
   // Evaporative Operation Maximum Limit Drybulb Temperature
-  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitDrybulbTemperature() const {
-    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature, true);
-  }
-
-  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const {
-    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature);
+  double EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitDrybulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature).get();
   }
 
   bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature) {
@@ -432,6 +410,13 @@ EvaporativeCoolerDirectResearchSpecial::EvaporativeCoolerDirectResearchSpecial(c
   setBlowdownConcentrationRatio(0.0);
 
   setWaterPumpPowerSizingFactor(0.1);
+
+
+  // E+ suggested values
+  setEvaporativeOperationMinimumDrybulbTemperature(16);
+  setEvaporativeOperationMaximumLimitWetbulbTemperature(24);
+  setEvaporativeOperationMaximumLimitDrybulbTemperature(28);
+
 }
 
 Schedule EvaporativeCoolerDirectResearchSpecial::availabilitySchedule() const
@@ -566,65 +551,37 @@ bool EvaporativeCoolerDirectResearchSpecial::isPrimaryAirDesignFlowRateAutosized
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isPrimaryAirDesignFlowRateAutosized();
 }
 
-
-boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMinimumDrybulbTemperature() const
+// Evaporative Operation Minimum Drybulb Temperature
+double EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMinimumDrybulbTemperature() const
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMinimumDrybulbTemperature();
-}
-
-bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const {
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMinimumDrybulbTemperatureDefaulted();
 }
 
 bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature) {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMinimumDrybulbTemperature(evaporativeOperationMinimumDrybulbTemperature);
 }
 
-void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMinimumDrybulbTemperature()
-{
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMinimumDrybulbTemperature();
-}
-
-
-boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitWetbulbTemperature() const
+// Evaporative Operation Maximum Limit Wetbulb Temperature
+double EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitWetbulbTemperature() const
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMaximumLimitWetbulbTemperature();
 }
 
-bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const
-{
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted();
-}
 bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature)
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMaximumLimitWetbulbTemperature(evaporativeOperationMaximumLimitWetbulbTemperature);
 }
 
-void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMaximumLimitWetbulbTemperature()
-{
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMaximumLimitWetbulbTemperature();
-}
-
-
-boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitDrybulbTemperature() const
+// Evaporative Operation Maximum Limit Drybulb Temperature
+double EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitDrybulbTemperature() const
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMaximumLimitDrybulbTemperature();
-}
-bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const
-{
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted();
 }
 
 bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature)
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMaximumLimitDrybulbTemperature(evaporativeOperationMaximumLimitDrybulbTemperature);
 }
-
-void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMaximumLimitDrybulbTemperature()
-{
-  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMaximumLimitDrybulbTemperature();
-}
-
 
 EvaporativeCoolerDirectResearchSpecial::EvaporativeCoolerDirectResearchSpecial(
   std::shared_ptr<detail::EvaporativeCoolerDirectResearchSpecial_Impl> p)

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
@@ -365,21 +365,21 @@ namespace detail{
   }
 
   // Evaporative Operation Maximum Limit Drybulb Temperature
-  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitDryBulbTemperature() const {
-    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, true);
+  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitDrybulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature, true);
   }
 
-  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const {
-    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature);
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const {
+    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature);
   }
 
-  bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature) {
-    bool result = setDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, evaporativeOperationMaximumLimitDryBulbTemperature);
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature) {
+    bool result = setDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature, evaporativeOperationMaximumLimitDrybulbTemperature);
     return result;
   }
 
-  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitDryBulbTemperature() {
-    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, "");
+  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitDrybulbTemperature() {
+    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDrybulbTemperature, "");
     OS_ASSERT(result);
   }
 
@@ -565,6 +565,66 @@ bool EvaporativeCoolerDirectResearchSpecial::isPrimaryAirDesignFlowRateAutosized
 {
   return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isPrimaryAirDesignFlowRateAutosized();
 }
+
+
+boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMinimumDrybulbTemperature() const
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMinimumDrybulbTemperature();
+}
+
+bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const {
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMinimumDrybulbTemperatureDefaulted();
+}
+
+bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature) {
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMinimumDrybulbTemperature(evaporativeOperationMinimumDrybulbTemperature);
+}
+
+void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMinimumDrybulbTemperature()
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMinimumDrybulbTemperature();
+}
+
+
+boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitWetbulbTemperature() const
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMaximumLimitWetbulbTemperature();
+}
+
+bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted();
+}
+bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature)
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMaximumLimitWetbulbTemperature(evaporativeOperationMaximumLimitWetbulbTemperature);
+}
+
+void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMaximumLimitWetbulbTemperature()
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMaximumLimitWetbulbTemperature();
+}
+
+
+boost::optional<double> EvaporativeCoolerDirectResearchSpecial::evaporativeOperationMaximumLimitDrybulbTemperature() const
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->evaporativeOperationMaximumLimitDrybulbTemperature();
+}
+bool EvaporativeCoolerDirectResearchSpecial::isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted();
+}
+
+bool EvaporativeCoolerDirectResearchSpecial::setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature)
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->setEvaporativeOperationMaximumLimitDrybulbTemperature(evaporativeOperationMaximumLimitDrybulbTemperature);
+}
+
+void EvaporativeCoolerDirectResearchSpecial::resetEvaporativeOperationMaximumLimitDrybulbTemperature()
+{
+  return getImpl<detail::EvaporativeCoolerDirectResearchSpecial_Impl>()->resetEvaporativeOperationMaximumLimitDrybulbTemperature();
+}
+
 
 EvaporativeCoolerDirectResearchSpecial::EvaporativeCoolerDirectResearchSpecial(
   std::shared_ptr<detail::EvaporativeCoolerDirectResearchSpecial_Impl> p)

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.cpp
@@ -325,6 +325,67 @@ namespace detail{
     OS_ASSERT(result);
   }
 
+
+  // Evaporative Operation Minimum Drybulb Temperature
+  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMinimumDrybulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature, true);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const {
+    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature) {
+    bool result = setDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature, evaporativeOperationMinimumDrybulbTemperature);
+    return result;
+  }
+
+  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMinimumDrybulbTemperature() {
+    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMinimumDrybulbTemperature, "");
+    OS_ASSERT(result);
+  }
+
+  // Evaporative Operation Maximum Limit Wetbulb Temperature
+  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitWetbulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature, true);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const {
+    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature) {
+    bool result = setDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature, evaporativeOperationMaximumLimitWetbulbTemperature);
+    return result;
+  }
+
+  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitWetbulbTemperature() {
+    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitWetbulbTemperature, "");
+    OS_ASSERT(result);
+  }
+
+  // Evaporative Operation Maximum Limit Drybulb Temperature
+  boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::evaporativeOperationMaximumLimitDryBulbTemperature() const {
+    return getDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, true);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const {
+    return isEmpty(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature);
+  }
+
+  bool EvaporativeCoolerDirectResearchSpecial_Impl::setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature) {
+    bool result = setDouble(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, evaporativeOperationMaximumLimitDryBulbTemperature);
+    return result;
+  }
+
+  void EvaporativeCoolerDirectResearchSpecial_Impl::resetEvaporativeOperationMaximumLimitDryBulbTemperature() {
+    bool result = setString(OS_EvaporativeCooler_Direct_ResearchSpecialFields::EvaporativeOperationMaximumLimitDryBulbTemperature, "");
+    OS_ASSERT(result);
+  }
+
+
+
+
   boost::optional<double> EvaporativeCoolerDirectResearchSpecial_Impl::autosizedRecirculatingWaterPumpPowerConsumption() const {
     return getAutosizedValue("Recirculating Pump Power", "W");
   }

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
@@ -147,7 +147,7 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
   /** Check for defaulted **/
   bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
   /** Sets or resets the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
-  void setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature); 
+  bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature); 
   void resetEvaporativeOperationMinimumDrybulbTemperature();
 
   /** Returns the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
@@ -155,16 +155,16 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
   /** Check for defaulted **/
   bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
   /** Sets or resets the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
-  void setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
+  bool setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
   void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
 
-  /** Returns the value of the EvaporativeOperationMaximumLimitDryBulbTemperature field. **/
-  boost::optional<double> evaporativeOperationMaximumLimitDryBulbTemperature() const;
+  /** Returns the value of the EvaporativeOperationMaximumLimitDrybulbTemperature field. **/
+  boost::optional<double> evaporativeOperationMaximumLimitDrybulbTemperature() const;
   /** Check for defaulted **/
-  bool isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const;
-  /** Sets or resets the value of the EvaporativeOperationMaximumLimitDryBulbTemperature field. **/
-  void setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature);
-  void resetEvaporativeOperationMaximumLimitDryBulbTemperature();
+  bool isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const;
+  /** Sets or resets the value of the EvaporativeOperationMaximumLimitDrybulbTemperature field. **/
+  bool setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature);
+  void resetEvaporativeOperationMaximumLimitDrybulbTemperature();
   
 
 

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
@@ -140,6 +140,34 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
 
   void resetWaterPumpPowerModifierCurve();
 
+  /** Sets the minimum and maximum operation temperatures **/
+
+  /** Returns the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
+  boost::optional<double> evaporativeOperationMinimumDrybulbTemperature() const;
+  /** Check for defaulted **/
+  bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
+  /** Sets or resets the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
+  void setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature); 
+  void resetEvaporativeOperationMinimumDrybulbTemperature();
+
+  /** Returns the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
+  boost::optional<double> evaporativeOperationMaximumLimitWetbulbTemperature() const;
+  /** Check for defaulted **/
+  bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
+  /** Sets or resets the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
+  void setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
+  void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
+
+  /** Returns the value of the EvaporativeOperationMaximumLimitDryBulbTemperature field. **/
+  boost::optional<double> evaporativeOperationMaximumLimitDryBulbTemperature() const;
+  /** Check for defaulted **/
+  bool isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const;
+  /** Sets or resets the value of the EvaporativeOperationMaximumLimitDryBulbTemperature field. **/
+  void setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature);
+  void resetEvaporativeOperationMaximumLimitDryBulbTemperature();
+  
+
+
   boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;
 
   boost::optional<double> autosizedPrimaryAirDesignFlowRate() const ;

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
@@ -143,29 +143,20 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
   /** Sets the minimum and maximum operation temperatures **/
 
   /** Returns the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
-  boost::optional<double> evaporativeOperationMinimumDrybulbTemperature() const;
-  /** Check for defaulted **/
-  bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
+  double evaporativeOperationMinimumDrybulbTemperature() const;
   /** Sets or resets the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
-  bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature); 
-  void resetEvaporativeOperationMinimumDrybulbTemperature();
+  bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
 
   /** Returns the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
-  boost::optional<double> evaporativeOperationMaximumLimitWetbulbTemperature() const;
-  /** Check for defaulted **/
-  bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
-  /** Sets or resets the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
+  double evaporativeOperationMaximumLimitWetbulbTemperature() const;
+  /** Sets the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
   bool setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
-  void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
 
   /** Returns the value of the EvaporativeOperationMaximumLimitDrybulbTemperature field. **/
-  boost::optional<double> evaporativeOperationMaximumLimitDrybulbTemperature() const;
-  /** Check for defaulted **/
-  bool isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const;
-  /** Sets or resets the value of the EvaporativeOperationMaximumLimitDrybulbTemperature field. **/
+  double evaporativeOperationMaximumLimitDrybulbTemperature() const;
+  /** Sets the value of the EvaporativeOperationMaximumLimitDrybulbTemperature field. **/
   bool setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature);
-  void resetEvaporativeOperationMaximumLimitDrybulbTemperature();
-  
+
 
 
   boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial.hpp
@@ -144,7 +144,7 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
 
   /** Returns the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
   double evaporativeOperationMinimumDrybulbTemperature() const;
-  /** Sets or resets the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
+  /** Sets the value of the EvaporativeOperationMinimumDrybulbTemperature field. **/
   bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
 
   /** Returns the value of the EvaporativeOperationMaximumLimitWetbulbTemperature field. **/
@@ -158,12 +158,9 @@ class MODEL_API EvaporativeCoolerDirectResearchSpecial : public StraightComponen
   bool setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature);
 
 
-
   boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;
 
   boost::optional<double> autosizedPrimaryAirDesignFlowRate() const ;
-
-
 
   //@}
  protected:

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
@@ -134,18 +134,18 @@ namespace detail {
 
     boost::optional<double> evaporativeOperationMinimumDrybulbTemperature() const;
     bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
-    void setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
+    bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
     void resetEvaporativeOperationMinimumDrybulbTemperature();
 
     boost::optional<double> evaporativeOperationMaximumLimitWetbulbTemperature() const;
     bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
-    void setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
+    bool setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
     void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
 
-    boost::optional<double> evaporativeOperationMaximumLimitDryBulbTemperature() const;
-    bool isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const;
-    void setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature);
-    void resetEvaporativeOperationMaximumLimitDryBulbTemperature();
+    boost::optional<double> evaporativeOperationMaximumLimitDrybulbTemperature() const;
+    bool isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const;
+    bool setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature);
+    void resetEvaporativeOperationMaximumLimitDrybulbTemperature();
 
     boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;
 

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
@@ -132,20 +132,14 @@ namespace detail {
 
     bool isPrimaryAirDesignFlowRateAutosized() const;
 
-    boost::optional<double> evaporativeOperationMinimumDrybulbTemperature() const;
-    bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
+    double evaporativeOperationMinimumDrybulbTemperature() const;
     bool setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
-    void resetEvaporativeOperationMinimumDrybulbTemperature();
 
-    boost::optional<double> evaporativeOperationMaximumLimitWetbulbTemperature() const;
-    bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
+    double evaporativeOperationMaximumLimitWetbulbTemperature() const;
     bool setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
-    void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
 
-    boost::optional<double> evaporativeOperationMaximumLimitDrybulbTemperature() const;
-    bool isEvaporativeOperationMaximumLimitDrybulbTemperatureDefaulted() const;
+    double evaporativeOperationMaximumLimitDrybulbTemperature() const;
     bool setEvaporativeOperationMaximumLimitDrybulbTemperature(double evaporativeOperationMaximumLimitDrybulbTemperature);
-    void resetEvaporativeOperationMaximumLimitDrybulbTemperature();
 
     boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;
 

--- a/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
+++ b/openstudiocore/src/model/EvaporativeCoolerDirectResearchSpecial_Impl.hpp
@@ -132,6 +132,21 @@ namespace detail {
 
     bool isPrimaryAirDesignFlowRateAutosized() const;
 
+    boost::optional<double> evaporativeOperationMinimumDrybulbTemperature() const;
+    bool isEvaporativeOperationMinimumDrybulbTemperatureDefaulted() const;
+    void setEvaporativeOperationMinimumDrybulbTemperature(double evaporativeOperationMinimumDrybulbTemperature);
+    void resetEvaporativeOperationMinimumDrybulbTemperature();
+
+    boost::optional<double> evaporativeOperationMaximumLimitWetbulbTemperature() const;
+    bool isEvaporativeOperationMaximumLimitWetbulbTemperatureDefaulted() const;
+    void setEvaporativeOperationMaximumLimitWetbulbTemperature(double evaporativeOperationMaximumLimitWetbulbTemperature);
+    void resetEvaporativeOperationMaximumLimitWetbulbTemperature();
+
+    boost::optional<double> evaporativeOperationMaximumLimitDryBulbTemperature() const;
+    bool isEvaporativeOperationMaximumLimitDryBulbTemperatureDefaulted() const;
+    void setEvaporativeOperationMaximumLimitDryBulbTemperature(double evaporativeOperationMaximumLimitDryBulbTemperature);
+    void resetEvaporativeOperationMaximumLimitDryBulbTemperature();
+
     boost::optional<double> autosizedRecirculatingWaterPumpPowerConsumption() const ;
 
     boost::optional<double> autosizedPrimaryAirDesignFlowRate() const ;


### PR DESCRIPTION
Min  (Drybulb) and max (DB and WB) limit for operation based on temperature.

The ProposedEnergy+.idd already has them.
