### PR TITLE
Fix issue with AirConditionerVariableRefrigerantFlow::clone

### DIFF
--- a/openstudiocore/src/model/AirConditionerVariableRefrigerantFlow.cpp
+++ b/openstudiocore/src/model/AirConditionerVariableRefrigerantFlow.cpp
@@ -1538,6 +1538,136 @@ namespace detail {
     ModelObjectList modelObjectList(model);
     airConditionerClone.getImpl<detail::AirConditionerVariableRefrigerantFlow_Impl>()->setVRFModelObjectList(modelObjectList);
 
+    if( auto curve = coolingCapacityRatioModifierFunctionofLowTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingCapacityRatioModifierFunctionofLowTemperatureCurve(clone);
+    }
+
+    if( auto curve = coolingCapacityRatioBoundaryCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingCapacityRatioBoundaryCurve(clone);
+    }
+
+    if( auto curve = coolingCapacityRatioModifierFunctionofHighTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingCapacityRatioModifierFunctionofHighTemperatureCurve(clone);
+    }
+
+    if( auto curve = coolingEnergyInputRatioModifierFunctionofLowTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingEnergyInputRatioModifierFunctionofLowTemperatureCurve(clone);
+    }
+
+    if( auto curve = coolingEnergyInputRatioBoundaryCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingEnergyInputRatioBoundaryCurve(clone); 
+    }
+
+    if( auto curve = coolingEnergyInputRatioModifierFunctionofHighTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingEnergyInputRatioModifierFunctionofHighTemperatureCurve(clone);
+    }
+    
+    if( auto curve = coolingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve(clone);
+    }
+    
+    if( auto curve = coolingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve(clone);
+    }
+
+    if( auto curve = coolingCombinationRatioCorrectionFactorCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingCombinationRatioCorrectionFactorCurve(clone);
+    }
+
+    if( auto curve = coolingPartLoadFractionCorrelationCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setCoolingPartLoadFractionCorrelationCurve(clone);
+    }
+
+    if( auto curve = heatingCapacityRatioModifierFunctionofLowTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingCapacityRatioModifierFunctionofLowTemperatureCurve(clone);
+    }
+
+    if( auto curve = heatingCapacityRatioBoundaryCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingCapacityRatioBoundaryCurve(clone);
+    }
+
+    if( auto curve = heatingCapacityRatioModifierFunctionofHighTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingCapacityRatioModifierFunctionofHighTemperatureCurve(clone);
+    }
+
+    if( auto curve = heatingEnergyInputRatioModifierFunctionofLowTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingEnergyInputRatioModifierFunctionofLowTemperatureCurve(clone);
+    }
+
+    if( auto curve = heatingEnergyInputRatioBoundaryCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingEnergyInputRatioBoundaryCurve(clone);
+    }
+
+    if( auto curve = heatingEnergyInputRatioModifierFunctionofHighTemperatureCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingEnergyInputRatioModifierFunctionofHighTemperatureCurve(clone);
+    }
+
+    if( auto curve = heatingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve(clone);
+    }
+
+    if( auto curve = heatingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve(clone);
+    }
+
+    if( auto curve = heatingCombinationRatioCorrectionFactorCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingCombinationRatioCorrectionFactorCurve(clone);
+    }
+
+    if( auto curve = heatingPartLoadFractionCorrelationCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatingPartLoadFractionCorrelationCurve(clone);
+    }
+
+    if( auto curve = pipingCorrectionFactorforLengthinCoolingModeCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setPipingCorrectionFactorforLengthinCoolingModeCurve(clone);
+    }
+
+    if( auto curve = pipingCorrectionFactorforLengthinHeatingModeCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setPipingCorrectionFactorforLengthinHeatingModeCurve(clone);
+    }    
+
+    if( auto curve = heatRecoveryCoolingCapacityModifierCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatRecoveryCoolingCapacityModifierCurve(clone);
+    }
+
+    if( auto curve = heatRecoveryCoolingEnergyModifierCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatRecoveryCoolingEnergyModifierCurve(clone);
+    }
+
+    if( auto curve = heatRecoveryHeatingCapacityModifierCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatRecoveryHeatingCapacityModifierCurve(clone);
+    }
+
+    if( auto curve = heatRecoveryHeatingEnergyModifierCurve() ) {
+      auto clone = curve->clone(model).cast<Curve>();
+      airConditionerClone.setHeatRecoveryHeatingEnergyModifierCurve(clone);
+    }
+
     return airConditionerClone;
   }
 

--- a/openstudiocore/src/model/test/AirConditionerVariableRefrigerantFlow_GTest.cpp
+++ b/openstudiocore/src/model/test/AirConditionerVariableRefrigerantFlow_GTest.cpp
@@ -28,6 +28,8 @@
 #include "../PlantLoop.hpp"
 #include "../Node.hpp"
 #include "../Node_Impl.hpp"
+#include "../Curve.hpp"
+#include "../Curve_Impl.hpp"
 #include "../AirLoopHVACZoneSplitter.hpp"
 
 using namespace openstudio;
@@ -66,6 +68,29 @@ TEST_F(ModelFixture,AirConditionerVariableRefrigerantFlow)
 
   boost::optional<AirConditionerVariableRefrigerantFlow> vrfClone = vrf.clone(m2).optionalCast<AirConditionerVariableRefrigerantFlow>(); 
   ASSERT_TRUE(vrfClone);
+
+  ASSERT_TRUE(vrfClone->coolingCapacityRatioModifierFunctionofLowTemperatureCurve());
+  ASSERT_TRUE(vrfClone->coolingCapacityRatioBoundaryCurve());
+  ASSERT_TRUE(vrfClone->coolingCapacityRatioModifierFunctionofHighTemperatureCurve());
+  ASSERT_TRUE(vrfClone->coolingEnergyInputRatioModifierFunctionofLowTemperatureCurve());
+  ASSERT_TRUE(vrfClone->coolingEnergyInputRatioBoundaryCurve());
+  ASSERT_TRUE(vrfClone->coolingEnergyInputRatioModifierFunctionofHighTemperatureCurve());
+  ASSERT_TRUE(vrfClone->coolingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve());
+  ASSERT_TRUE(vrfClone->coolingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve());
+  ASSERT_TRUE(vrfClone->coolingCombinationRatioCorrectionFactorCurve());
+  ASSERT_TRUE(vrfClone->coolingPartLoadFractionCorrelationCurve());
+  ASSERT_TRUE(vrfClone->heatingCapacityRatioModifierFunctionofLowTemperatureCurve());
+  ASSERT_TRUE(vrfClone->heatingCapacityRatioBoundaryCurve());
+  ASSERT_TRUE(vrfClone->heatingCapacityRatioModifierFunctionofHighTemperatureCurve());
+  ASSERT_TRUE(vrfClone->heatingEnergyInputRatioModifierFunctionofLowTemperatureCurve());
+  ASSERT_TRUE(vrfClone->heatingEnergyInputRatioBoundaryCurve());
+  ASSERT_TRUE(vrfClone->heatingEnergyInputRatioModifierFunctionofHighTemperatureCurve());
+  ASSERT_TRUE(vrfClone->heatingEnergyInputRatioModifierFunctionofLowPartLoadRatioCurve());
+  ASSERT_TRUE(vrfClone->heatingEnergyInputRatioModifierFunctionofHighPartLoadRatioCurve());
+  ASSERT_TRUE(vrfClone->heatingCombinationRatioCorrectionFactorCurve());
+  ASSERT_TRUE(vrfClone->heatingPartLoadFractionCorrelationCurve());
+  ASSERT_TRUE(vrfClone->pipingCorrectionFactorforLengthinCoolingModeCurve());
+
 
   ASSERT_TRUE(vrfClone->terminals().empty()); 
 


### PR DESCRIPTION
The clone method was leaving behind the curves, and now it is fixed.

close #2226