### PR TITLE
Add new baseboard fields

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -14877,26 +14877,60 @@ OS:Coil:Heating:Water:Baseboard,
       \required-field
       \reference BaseboardHeatingCoil
       \reference ConnectionObject
-  N1, \field U-Factor Times Area Value
+  A3 , \field Heating Design Capacity Method
+       \type choice
+       \key HeatingDesignCapacity
+       \key CapacityPerFloorArea
+       \key FractionOfAutosizedHeatingCapacity
+       \required-field
+       \note Enter the method used to determine the heating design capacity.
+       \note HeatingDesignCapacity = > selected when the design heating capacity value or autosize
+       \note is specified. CapacityPerFloorArea = > selected when the design heating capacity is
+       \note determine from user specified heating capacity per floor area and zone floor area.
+       \note FractionOfAutosizedHeatingCapacity = > is selected when the design heating capacity is
+       \note determined from a user specified fraction and the auto-sized design heating capacity.
+  N1 , \field Heating Design Capacity
+       \type real
+       \units W
+       \minimum 0.0
+       \autosizable
+       \required-field
+       \ip-units W
+       \note Enter the design heating capacity.Required field when the heating design capacity method
+       \note HeatingDesignCapacity.
+  N2 , \field Heating Design Capacity Per Floor Area
+       \type real
+       \units W/m2
+       \minimum 0.0
+       \required-field
+       \note Enter the heating design capacity per zone floor area.Required field when the heating design
+       \note capacity method field is CapacityPerFloorArea.
+  N3 , \field Fraction of Autosized Heating Design Capacity
+       \type real
+       \minimum 0.0
+       \required-field
+       \note Enter the fraction of auto - sized heating design capacity.Required field when capacity the
+       \note heating design capacity method field is FractionOfAutosizedHeatingCapacity.
+  N4, \field U-Factor Times Area Value
       \type real
       \autosizable
       \units W/K
       \default autosize
-  N2, \field Maximum Water Flow Rate
+  N5, \field Maximum Water Flow Rate
       \type real
       \autosizable
       \units m3/s
       \ip-units gal/min
       \default Autosize
-  N3, \field Convergence Tolerance
+  N6, \field Convergence Tolerance
       \type real
       \minimum> 0.0
       \default 0.001       
-  A3, \field Water Inlet Node Name
+  A4, \field Water Inlet Node Name
       \type object-list
       \required-field
       \object-list ConnectionNames
-  A4; \field Water Outlet Node Name
+  A5; \field Water Outlet Node Name
       \type object-list
       \required-field
       \object-list ConnectionNames

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACBaseboardConvectiveWater.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACBaseboardConvectiveWater.cpp
@@ -97,6 +97,27 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACBaseboardConvecti
       }
     }
 
+    {
+      auto value = coilHeatBBConvWater.heatingDesignCapacityMethod();
+      idfObject.setString(ZoneHVAC_Baseboard_Convective_WaterFields::HeatingDesignCapacityMethod,value);
+    }
+
+    if( coilHeatBBConvWater.isHeatingDesignCapacityAutosized() ) {
+      idfObject.setString(ZoneHVAC_Baseboard_Convective_WaterFields::HeatingDesignCapacity,"Autosize");
+    } else if( auto value = coilHeatBBConvWater.heatingDesignCapacity() ) {
+      idfObject.setDouble(ZoneHVAC_Baseboard_Convective_WaterFields::HeatingDesignCapacity,value.get());
+    }
+
+    {
+      auto value = coilHeatBBConvWater.heatingDesignCapacityPerFloorArea();
+      idfObject.setDouble(ZoneHVAC_Baseboard_Convective_WaterFields::HeatingDesignCapacityPerFloorArea,value);
+    }
+
+    {
+      auto value = coilHeatBBConvWater.fractionofAutosizedHeatingDesignCapacity();
+      idfObject.setDouble(ZoneHVAC_Baseboard_Convective_WaterFields::FractionofAutosizedHeatingDesignCapacity,value);
+    }
+
     // UFactorTimesAreaValue
     if(coilHeatBBConvWater.isUFactorTimesAreaValueAutosized())
     {

--- a/openstudiocore/src/model/CoilHeatingWaterBaseboard.cpp
+++ b/openstudiocore/src/model/CoilHeatingWaterBaseboard.cpp
@@ -28,6 +28,7 @@
 
 #include <utilities/idd/OS_Coil_Heating_Water_Baseboard_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
+#include <utilities/idd/IddFactory.hxx>
 
 #include "../utilities/units/Unit.hpp"
 
@@ -107,6 +108,37 @@ namespace detail {
     return boost::none;
   }
 
+  std::string CoilHeatingWaterBaseboard_Impl::heatingDesignCapacityMethod() const {
+    boost::optional<std::string> value = getString(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacityMethod,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  boost::optional<double> CoilHeatingWaterBaseboard_Impl::heatingDesignCapacity() const {
+    return getDouble(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacity,true);
+  }
+
+  bool CoilHeatingWaterBaseboard_Impl::isHeatingDesignCapacityAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacity, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "autosize");
+    }
+    return result;
+  }
+
+  double CoilHeatingWaterBaseboard_Impl::heatingDesignCapacityPerFloorArea() const {
+    boost::optional<double> value = getDouble(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacityPerFloorArea,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  double CoilHeatingWaterBaseboard_Impl::fractionofAutosizedHeatingDesignCapacity() const {
+    boost::optional<double> value = getDouble(OS_Coil_Heating_Water_BaseboardFields::FractionofAutosizedHeatingDesignCapacity,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
   boost::optional<double> CoilHeatingWaterBaseboard_Impl::uFactorTimesAreaValue() const {
     return getDouble(OS_Coil_Heating_Water_BaseboardFields::UFactorTimesAreaValue,true);
   }
@@ -149,6 +181,34 @@ namespace detail {
 
    bool CoilHeatingWaterBaseboard_Impl::isConvergenceToleranceDefaulted() const {
     return isEmpty(OS_Coil_Heating_Water_BaseboardFields::ConvergenceTolerance);
+  }
+
+  bool CoilHeatingWaterBaseboard_Impl::setHeatingDesignCapacityMethod(std::string heatingDesignCapacityMethod) {
+    bool result = setString(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacityMethod, heatingDesignCapacityMethod);
+    return result;
+  }
+
+  bool CoilHeatingWaterBaseboard_Impl::setHeatingDesignCapacity(boost::optional<double> heatingDesignCapacity) {
+    bool result(false);
+    if (heatingDesignCapacity) {
+      result = setDouble(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacity, heatingDesignCapacity.get());
+    }
+    return result;
+  }
+
+  void CoilHeatingWaterBaseboard_Impl::autosizeHeatingDesignCapacity() {
+    bool result = setString(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacity, "autosize");
+    OS_ASSERT(result);
+  }
+
+  bool CoilHeatingWaterBaseboard_Impl::setHeatingDesignCapacityPerFloorArea(double heatingDesignCapacityPerFloorArea) {
+    bool result = setDouble(OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacityPerFloorArea, heatingDesignCapacityPerFloorArea);
+    return result;
+  }
+
+  bool CoilHeatingWaterBaseboard_Impl::setFractionofAutosizedHeatingDesignCapacity(double fractionofAutosizedHeatingDesignCapacity) {
+    bool result = setDouble(OS_Coil_Heating_Water_BaseboardFields::FractionofAutosizedHeatingDesignCapacity, fractionofAutosizedHeatingDesignCapacity);
+    return result;
   }
 
    void CoilHeatingWaterBaseboard_Impl::setUFactorTimesAreaValue(boost::optional<double> uFactorTimesAreaValue) {
@@ -225,6 +285,11 @@ CoilHeatingWaterBaseboard::CoilHeatingWaterBaseboard(const Model& model)
   : StraightComponent(CoilHeatingWaterBaseboard::iddObjectType(),model)
 {
   OS_ASSERT(getImpl<detail::CoilHeatingWaterBaseboard_Impl>());
+
+  setHeatingDesignCapacityMethod("HeatingDesignCapacity");
+  autosizeHeatingDesignCapacity();
+  setHeatingDesignCapacityPerFloorArea(0.0);
+  setFractionofAutosizedHeatingDesignCapacity(0.8);
 }
 unsigned CoilHeatingWaterBaseboard::inletPort()
 {
@@ -238,6 +303,31 @@ unsigned CoilHeatingWaterBaseboard::outletPort()
 
 IddObjectType CoilHeatingWaterBaseboard::iddObjectType() {
   return IddObjectType(IddObjectType::OS_Coil_Heating_Water_Baseboard);
+}
+
+std::vector<std::string> CoilHeatingWaterBaseboard::heatingDesignCapacityMethodValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_Coil_Heating_Water_BaseboardFields::HeatingDesignCapacityMethod);
+}
+
+std::string CoilHeatingWaterBaseboard::heatingDesignCapacityMethod() const {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->heatingDesignCapacityMethod();
+}
+
+boost::optional<double> CoilHeatingWaterBaseboard::heatingDesignCapacity() const {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->heatingDesignCapacity();
+}
+
+bool CoilHeatingWaterBaseboard::isHeatingDesignCapacityAutosized() const {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->isHeatingDesignCapacityAutosized();
+}
+
+double CoilHeatingWaterBaseboard::heatingDesignCapacityPerFloorArea() const {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->heatingDesignCapacityPerFloorArea();
+}
+
+double CoilHeatingWaterBaseboard::fractionofAutosizedHeatingDesignCapacity() const {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->fractionofAutosizedHeatingDesignCapacity();
 }
 
 boost::optional<double> CoilHeatingWaterBaseboard::uFactorTimesAreaValue() const {
@@ -270,6 +360,26 @@ double CoilHeatingWaterBaseboard::convergenceTolerance() const {
 
 bool CoilHeatingWaterBaseboard::isConvergenceToleranceDefaulted() const {
   return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->isConvergenceToleranceDefaulted();
+}
+
+bool CoilHeatingWaterBaseboard::setHeatingDesignCapacityMethod(std::string heatingDesignCapacityMethod) {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->setHeatingDesignCapacityMethod(heatingDesignCapacityMethod);
+}
+
+bool CoilHeatingWaterBaseboard::setHeatingDesignCapacity(double heatingDesignCapacity) {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->setHeatingDesignCapacity(heatingDesignCapacity);
+}
+
+void CoilHeatingWaterBaseboard::autosizeHeatingDesignCapacity() {
+  getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->autosizeHeatingDesignCapacity();
+}
+
+bool CoilHeatingWaterBaseboard::setHeatingDesignCapacityPerFloorArea(double heatingDesignCapacityPerFloorArea) {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->setHeatingDesignCapacityPerFloorArea(heatingDesignCapacityPerFloorArea);
+}
+
+bool CoilHeatingWaterBaseboard::setFractionofAutosizedHeatingDesignCapacity(double fractionofAutosizedHeatingDesignCapacity) {
+  return getImpl<detail::CoilHeatingWaterBaseboard_Impl>()->setFractionofAutosizedHeatingDesignCapacity(fractionofAutosizedHeatingDesignCapacity);
 }
 
 void CoilHeatingWaterBaseboard::setUFactorTimesAreaValue(double uFactorTimesAreaValue) {

--- a/openstudiocore/src/model/CoilHeatingWaterBaseboard.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterBaseboard.hpp
@@ -50,12 +50,24 @@ class MODEL_API CoilHeatingWaterBaseboard : public StraightComponent {
 
   static IddObjectType iddObjectType();
 
+  static std::vector<std::string> heatingDesignCapacityMethodValues();
+
   /** @name Getters */
   //@{
  
   unsigned inletPort();
 
   unsigned outletPort();
+
+  std::string heatingDesignCapacityMethod() const;
+
+  boost::optional<double> heatingDesignCapacity() const;
+
+  bool isHeatingDesignCapacityAutosized() const;
+
+  double heatingDesignCapacityPerFloorArea() const;
+
+  double fractionofAutosizedHeatingDesignCapacity() const;
 
   /** Returns the value of the UFactorTimesAreaValue field. **/
   boost::optional<double> uFactorTimesAreaValue() const;
@@ -81,6 +93,15 @@ class MODEL_API CoilHeatingWaterBaseboard : public StraightComponent {
   //@}
   /** @name Setters */
   //@{
+  bool setHeatingDesignCapacityMethod(std::string heatingDesignCapacityMethod);
+
+  bool setHeatingDesignCapacity(double heatingDesignCapacity);
+
+  void autosizeHeatingDesignCapacity();
+
+  bool setHeatingDesignCapacityPerFloorArea(double heatingDesignCapacityPerFloorArea);
+
+  bool setFractionofAutosizedHeatingDesignCapacity(double fractionofAutosizedHeatingDesignCapacity);
 
   void setUFactorTimesAreaValue(double uFactorTimesAreaValue);
 

--- a/openstudiocore/src/model/CoilHeatingWaterBaseboard_Impl.hpp
+++ b/openstudiocore/src/model/CoilHeatingWaterBaseboard_Impl.hpp
@@ -72,6 +72,16 @@ namespace detail {
     /** @name Getters */
     //@{
 
+    std::string heatingDesignCapacityMethod() const;
+
+    boost::optional<double> heatingDesignCapacity() const;
+
+    bool isHeatingDesignCapacityAutosized() const;
+
+    double heatingDesignCapacityPerFloorArea() const;
+
+    double fractionofAutosizedHeatingDesignCapacity() const;
+
     boost::optional<double> uFactorTimesAreaValue() const;
 
     bool isUFactorTimesAreaValueDefaulted() const;
@@ -91,6 +101,15 @@ namespace detail {
     //@}
     /** @name Setters */
     //@{
+    bool setHeatingDesignCapacityMethod(std::string heatingDesignCapacityMethod);
+
+    bool setHeatingDesignCapacity(boost::optional<double> heatingDesignCapacity);
+
+    void autosizeHeatingDesignCapacity();
+
+    bool setHeatingDesignCapacityPerFloorArea(double heatingDesignCapacityPerFloorArea);
+
+    bool setFractionofAutosizedHeatingDesignCapacity(double fractionofAutosizedHeatingDesignCapacity);
 
     void setUFactorTimesAreaValue(boost::optional<double> uFactorTimesAreaValue);
 

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -200,6 +200,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_1_9_5_to_1_10_0(const IdfFile& idf_1_9_5, const IddFileAndFactoryWrapper& idd_1_10_0);
   std::string update_1_10_1_to_1_10_2(const IdfFile& idf_1_10_1, const IddFileAndFactoryWrapper& idd_1_10_2);
   std::string update_1_10_5_to_1_10_6(const IdfFile& idf_1_10_5, const IddFileAndFactoryWrapper& idd_1_10_6);
+  std::string update_1_11_3_to_1_11_4(const IdfFile& idf_1_11_3, const IddFileAndFactoryWrapper& idd_1_11_4);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
std::string heatingDesignCapacityMethod() const;
boost::optional<double> heatingDesignCapacity() const;
bool isHeatingDesignCapacityAutosized() const;
double heatingDesignCapacityPerFloorArea() const;
double fractionofAutosizedHeatingDesignCapacity() const;

close #2233