### PR TITLE
Remove creation of ProgramControl object

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.cpp
@@ -335,9 +335,11 @@ Workspace ForwardTranslator::translateModelPrivate( model::Model & model, bool f
     translateAndMapModelObject(*simulationControl);
 
     // Add a ProgramControl object to force a single threaded simulation
-    IdfObject programControl(openstudio::IddObjectType::ProgramControl);
-    programControl.setInt(openstudio::ProgramControlFields::NumberofThreadsAllowed,1);
-    m_idfObjects.push_back(programControl);
+    //AP This code is no longer needed as multithreading has been disabled
+    //in E+ and this object is no longer forward translated anyway.
+    //IdfObject programControl(openstudio::IddObjectType::ProgramControl);
+    //programControl.setInt(openstudio::ProgramControlFields::NumberofThreadsAllowed,1);
+    //m_idfObjects.push_back(programControl);
 
     // ensure that sizing parameters control exists
     boost::optional<model::SizingParameters> sizingParameters = model.getOptionalUniqueModelObject<model::SizingParameters>();


### PR DESCRIPTION
Just trying to get rid of this fwd translation warning: [openstudio.energyplus.ForwardTranslator] <0> OS_ProgramControl is not currently translated.  Shouldn't be a problem to remove this code since it doesn't get translated to IDF anyway.