### PR TITLE
Fix for Issue #2383

### DIFF
--- a/openstudiocore/src/runmanager/lib/EnergyPlusPreProcessJob.cpp
+++ b/openstudiocore/src/runmanager/lib/EnergyPlusPreProcessJob.cpp
@@ -422,7 +422,9 @@ namespace detail {
         ofs << "    WaterSystems:Electricity,!- Variable or Meter 12 Name" << std::endl;
         ofs << "    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 12" << std::endl;
         ofs << "    Cogeneration:Electricity,!- Variable or Meter 13 Name" << std::endl;
-        ofs << "    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 13" << std::endl;
+        ofs << "    ValueWhenMaximumOrMinimum,            !- Aggregation Type for Variable or Meter 13" << std::endl;
+        ofs << "    Refrigeration:Electricity,!- Variable or Meter 14 Name" << std::endl;
+        ofs << "    ValueWhenMaximumOrMinimum;            !- Aggregation Type for Variable or Meter 14" << std::endl;
 
         ofs << "Output:Table:Monthly," << std::endl;
         ofs << "  Building Energy Performance - Natural Gas Peak Demand,  !- Name" << std::endl;


### PR DESCRIPTION
@macumber I think this is all there is to this. Adding missing meter that was on Electricity Consumption to Electricity Demand.

@asparke2 not sure if this will affect anything you use in OpenStudio standards. The OpenStudio results report doesn't need any changes, this should just show up now.