### PR TITLE
unit vent fanname

### DIFF
--- a/openstudiocore/resources/energyplus/ProposedEnergy+.idd
+++ b/openstudiocore/resources/energyplus/ProposedEnergy+.idd
@@ -23359,7 +23359,7 @@ ZoneHVAC:UnitVentilator,
    A12, \field Supply Air Fan Name
         \required-field
         \type object-list
-        \object-list FansCVandVAV
+        \object-list FansCVandOnOffandVAV
    A13, \field Coil Option
         \required-field
         \type choice
@@ -57811,4 +57811,3 @@ Output:PreprocessorMessage,
         \retaincase
    A12; \field Message Line 10
         \retaincase
-

--- a/openstudiocore/resources/energyplus/ProposedEnergy+.idd
+++ b/openstudiocore/resources/energyplus/ProposedEnergy+.idd
@@ -57811,3 +57811,4 @@ Output:PreprocessorMessage,
         \retaincase
    A12; \field Message Line 10
         \retaincase
+        


### PR DESCRIPTION
forward translator wasn't setting the name of a Fan:OnOff for ZoneHVAC:UnitVentilator. this *should* fix it.