### PR TITLE
Reverse translate name for ScheduleConstant

### DIFF
--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateScheduleConstant.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateScheduleConstant.cpp
@@ -52,6 +52,11 @@ OptionalModelObject ReverseTranslator::translateScheduleConstant( const Workspac
 
   ScheduleConstant scheduleConstant(m_model);
 
+  if (OptionalString os = workspaceObject.name()) {
+    scheduleConstant.setName(*os);
+  }
+
+  
   boost::optional<WorkspaceObject> target = workspaceObject.getTarget(Schedule_ConstantFields::ScheduleTypeLimitsName);
   if (target){
     OptionalModelObject scheduleTypeLimits = translateAndMapWorkspaceObject(*target);

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateThermostatSetpointDualSetpoint.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateThermostatSetpointDualSetpoint.cpp
@@ -48,6 +48,10 @@ OptionalModelObject result,temp;
 
   ThermostatSetpointDualSetpoint tsds(m_model);
 
+  if (OptionalString os = workspaceObject.name()) {
+    tsds.setName(*os);
+  }
+
   OptionalWorkspaceObject owo = workspaceObject.getTarget(ThermostatSetpoint_DualSetpointFields::HeatingSetpointTemperatureScheduleName);
   if(!owo)
   {


### PR DESCRIPTION
All in the title, was currently missing therefore any object would be named with a UUID.