### PR TITLE
fixing Propane/PropaneGas bug when translating to EnergyPlus

### DIFF
--- a/openstudiocore/resources/energyplus/ProposedEnergy+.idd
+++ b/openstudiocore/resources/energyplus/ProposedEnergy+.idd
@@ -29371,7 +29371,7 @@ Coil:Heating:Fuel,
        \type choice
        \key Gas
        \key NaturalGas
-       \key PropaneGas
+       \key Propane
        \key Diesel
        \key Gasoline
        \key FuelOil#1

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -14740,6 +14740,7 @@ OS:Coil:Heating:Gas,
   A8;  \field Fuel Type
        \type choice
        \key NaturalGas
+       \key Propane
        \key PropaneGas
        \key Diesel
        \key Gasoline

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -14738,6 +14738,7 @@ OS:Coil:Heating:Gas,
        \type real
        \units W
   A8;  \field Fuel Type
+       \note PropaneGas is deprecated in favor of Propane
        \type choice
        \key NaturalGas
        \key Propane

--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -495,6 +495,7 @@ set(${target_name}_test_src
 
   Test/AirWallMaterial_GTest.cpp
   Test/Building_GTest.cpp
+  Test/CoilHeatingGas_GTest.cpp
   Test/Construction_GTest.cpp
   Test/DaylightingControl_GTest.cpp
   Test/DaylightingDeviceShelf_GTest.cpp

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
@@ -73,7 +73,12 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingGas( CoilHeati
   ///////////////////////////////////////////////////////////////////////////
   // Field: Fuel Type
   ///////////////////////////////////////////////////////////////////////////
-  idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, modelObject.fuelType());
+  if (modelObject.fuelType() == "PropaneGas") {
+    idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, "Propane");
+  } else {
+    idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, modelObject.fuelType());
+  }
+  
   ///////////////////////////////////////////////////////////////////////////
 
   ///////////////////////////////////////////////////////////////////////////

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
@@ -74,6 +74,7 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingGas( CoilHeati
   // Field: Fuel Type
   ///////////////////////////////////////////////////////////////////////////
   if (modelObject.fuelType() == "PropaneGas") {
+    LOG(Warn, "'PropaneGas' is deprecated for Coil_Heating_FuelFields:FuelType, use 'Propane' instead.")
     idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, "Propane");
   } else {
     idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, modelObject.fuelType());

--- a/openstudiocore/src/energyplus/Test/CoilHeatingGas_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/CoilHeatingGas_GTest.cpp
@@ -1,0 +1,70 @@
+/***********************************************************************************************************************
+ *  OpenStudio(R), Copyright (c) 2008-2017, Alliance for Sustainable Energy, LLC. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ *  following conditions are met:
+ *
+ *  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *  disclaimer.
+ *
+ *  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *  following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote
+ *  products derived from this software without specific prior written permission from the respective party.
+ *
+ *  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative
+ *  works may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without
+ *  specific prior written permission from Alliance for Sustainable Energy, LLC.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/CoilHeatingGas.hpp"
+#include "../../model/CoilHeatingGas_Impl.hpp"
+#include "../../model/ScheduleConstant.hpp"
+#include "../../model/Schedule.hpp"
+
+#include <utilities/idd/Coil_Heating_Fuel_FieldEnums.hxx>
+#include <utilities/idd/IddEnums.hxx>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_CoilHeatingGas) {
+    Model model;
+    
+    ScheduleConstant scheduleConstant(model);
+    CoilHeatingGas coilHeatingGas(model, scheduleConstant);
+    coilHeatingGas.setGasBurnerEfficiency(0.6);
+    coilHeatingGas.setNominalCapacity(1535.0);
+    coilHeatingGas.setParasiticElectricLoad(48.0);
+    coilHeatingGas.setParasiticGasLoad(51.0);
+    coilHeatingGas.setFuelType("PropaneGas");
+    
+    ForwardTranslator forwardTranslator;
+    Workspace workspace = forwardTranslator.translateModel(model);
+    
+    WorkspaceObjectVector idfObjs(workspace.getObjectsByType(IddObjectType::Coil_Heating_Fuel));
+    EXPECT_EQ(1u, idfObjs.size());
+    WorkspaceObject coil(idfObjs[0]);
+    EXPECT_EQ("Propane", *coil.getString(Coil_Heating_FuelFields::FuelType));
+    EXPECT_DOUBLE_EQ(0.6, *coil.getDouble(Coil_Heating_FuelFields::BurnerEfficiency));
+    EXPECT_DOUBLE_EQ(1535.0, *coil.getDouble(Coil_Heating_FuelFields::NominalCapacity));
+    EXPECT_DOUBLE_EQ(48.0, *coil.getDouble(Coil_Heating_FuelFields::ParasiticElectricLoad));
+    EXPECT_DOUBLE_EQ(51.0, *coil.getDouble(Coil_Heating_FuelFields::ParasiticFuelLoad));
+
+}

--- a/openstudiocore/src/model/CoilHeatingGas.cpp
+++ b/openstudiocore/src/model/CoilHeatingGas.cpp
@@ -151,7 +151,7 @@ namespace detail{
   bool CoilHeatingGas_Impl::setFuelType(const std::string &fuelType)
   {
     if (fuelType == "PropaneGas") {
-        LOG(Warn, "The Fuel Type PropaneGas is deprecated in favor of Propane.");
+        LOG(Warn, "'PropaneGas' is deprecated for Coil_Heating_GasFields:FuelType, use 'Propane' instead");
     }
     return this->setString(OS_Coil_Heating_GasFields::FuelType, fuelType);
   }

--- a/openstudiocore/src/model/CoilHeatingGas.cpp
+++ b/openstudiocore/src/model/CoilHeatingGas.cpp
@@ -150,6 +150,9 @@ namespace detail{
 
   bool CoilHeatingGas_Impl::setFuelType(const std::string &fuelType)
   {
+    if (fuelType == "PropaneGas") {
+        LOG(Warn, "The Fuel Type PropaneGas is deprecated in favor of Propane.");
+    }
     return this->setString(OS_Coil_Heating_GasFields::FuelType, fuelType);
   }
 

--- a/openstudiocore/src/model/test/CoilHeatingGas_GTest.cpp
+++ b/openstudiocore/src/model/test/CoilHeatingGas_GTest.cpp
@@ -65,7 +65,10 @@ TEST_F(ModelFixture,CoilHeatingGas) {
   EXPECT_EQ(coilHeatingGas.availableSchedule(),schedule2);
 
   EXPECT_EQ(coilHeatingGas.fuelType(), "NaturalGas");
-  bool isOk = coilHeatingGas.setFuelType("PropaneGas");
+  bool isOk = coilHeatingGas.setFuelType("Propane");
+  EXPECT_TRUE(isOk);
+  EXPECT_EQ(coilHeatingGas.fuelType(), "Propane");
+  isOk = coilHeatingGas.setFuelType("PropaneGas");
   EXPECT_TRUE(isOk);
   EXPECT_EQ(coilHeatingGas.fuelType(), "PropaneGas");
   coilHeatingGas.resetFuelType();
@@ -75,7 +78,7 @@ TEST_F(ModelFixture,CoilHeatingGas) {
   EXPECT_NE(std::find(validFuelTypes.begin(), validFuelTypes.end(), "PropaneGas"), validFuelTypes.end());
   EXPECT_NE(std::find(validFuelTypes.begin(), validFuelTypes.end(), "NaturalGas"), validFuelTypes.end());
   EXPECT_NE(std::find(validFuelTypes.begin(), validFuelTypes.end(), "Diesel"), validFuelTypes.end());
-  EXPECT_EQ(validFuelTypes.size(), 8);
+  EXPECT_EQ(validFuelTypes.size(), 9);
 
 }
 


### PR DESCRIPTION
EnergyPlus recently had an idd change in `Coil:Heating:Fuel` for the fuel type to be `Propane` instead of `PropaneGas`. OpenStudio was still translating to `PropaneGas`. Now, it accepts either in the OS model (warning about the deprecation of `PropaneGas`) and forward translates to `Propane` in EnergyPlus.

Fixes https://github.com/NREL/OpenStudio-BEopt/issues/114

@shorowit