### PR TITLE
CooledBeamType returns a std::string, not an optional string. See #2192

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctConstantVolumeCooledBeam.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctConstantVolumeCooledBeam.cpp
@@ -91,11 +91,8 @@ boost::optional<IdfObject> ForwardTranslator::translateAirTerminalSingleDuctCons
   }
 
   // Field A3 Cooled Beam Type
-  if((s = modelObject.cooledBeamType()))
-  {
-    idfObject.setString(AirTerminal_SingleDuct_ConstantVolume_CooledBeamFields::CooledBeamType,s.get());
-  }
-
+  idfObject.setString(AirTerminal_SingleDuct_ConstantVolume_CooledBeamFields::CooledBeamType, modelObject.cooledBeamType());
+  
   // Field A4 Supply Air Inlet Node Name
   temp = modelObject.inletModelObject();
   if(temp)


### PR DESCRIPTION
@asparke2 