### PR TITLE
Plant Loop Availability Manager

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -19015,9 +19015,9 @@ OS:PlantLoop,
         \key UniformLoad
         \key UniformPLR
         \key SequentialUniformPLR
-  A16, \field Availability Manager List Name
+  A16, \field Availability Manager Name
        \type object-list
-       \object-list SystemAvailabilityManagerLists
+       \object-list SystemAvailabilityManagers
   A17, \field Plant Loop Demand Calculation Scheme
        \type choice
        \default SingleSetpoint

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
@@ -31,6 +31,8 @@
 #include "../../model/Model.hpp"
 #include "../../model/PlantLoop.hpp"
 #include "../../model/PlantLoop_Impl.hpp"
+#include "../../model/AvailabilityManager.hpp"
+#include "../../model/AvailabilityManager_Impl.hpp"
 #include "../../model/AirLoopHVACOutdoorAirSystem.hpp"
 #include "../../model/AirLoopHVACOutdoorAirSystem_Impl.hpp"
 #include "../../model/SizingPlant.hpp"
@@ -119,6 +121,7 @@
 #include <utilities/idd/Sizing_Plant_FieldEnums.hxx>
 #include <utilities/idd/AirTerminal_SingleDuct_ConstantVolume_CooledBeam_FieldEnums.hxx>
 #include <utilities/idd/ZoneHVAC_AirDistributionUnit_FieldEnums.hxx>
+#include <utilities/idd/AvailabilityManagerAssignmentList_FieldEnums.hxx>
 #include "../../utilities/core/Assert.hpp"
 
 using namespace openstudio::model;
@@ -445,6 +448,23 @@ boost::optional<IdfObject> ForwardTranslator::translatePlantLoop( PlantLoop & pl
   {
     auto scheme = plantLoop.loadDistributionScheme();
     idfObject.setString(PlantLoopFields::LoadDistributionScheme,scheme);
+  }
+
+  // AvailabilityManager
+  if (OptionalAvailabilityManager availMgr = plantLoop.availabilityManager()) {
+
+    // Availability Manager List
+    IdfObject availabilityManagerAssignmentListIdf(openstudio::IddObjectType::AvailabilityManagerAssignmentList);
+    availabilityManagerAssignmentListIdf.setName(plantLoop.name().get() + " Availability Manager List");
+    m_idfObjects.push_back(availabilityManagerAssignmentListIdf);
+    idfObject.setString(PlantLoopFields::AvailabilityManagerListName, availabilityManagerAssignmentListIdf.name().get());
+
+    // Availability Manager
+    OptionalIdfObject availMgrIdf = translateAndMapModelObject(availMgr.get());
+    OS_ASSERT(availMgrIdf);
+    IdfExtensibleGroup eg = availabilityManagerAssignmentListIdf.pushExtensibleGroup();
+    eg.setString(AvailabilityManagerAssignmentListExtensibleFields::AvailabilityManagerObjectType,availMgrIdf->iddObject().name());
+    eg.setString(AvailabilityManagerAssignmentListExtensibleFields::AvailabilityManagerName,availMgrIdf->name().get());
   }
 
   //  PlantLoopDemandCalculationScheme

--- a/openstudiocore/src/model/PlantLoop.cpp
+++ b/openstudiocore/src/model/PlantLoop.cpp
@@ -60,10 +60,13 @@
 #include "ScheduleTypeRegistry.hpp"
 #include "Schedule.hpp"
 #include "Schedule_Impl.hpp"
+#include "AvailabilityManager.hpp"
+#include "AvailabilityManager_Impl.hpp"
 #include "../utilities/core/Assert.hpp"
 #include <utilities/idd/OS_PlantLoop_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include <utilities/idd/IddFactory.hxx>
+#include <utilities/idd/OS_AvailabilityManagerAssignmentList_FieldEnums.hxx>
 
 namespace openstudio {
 
@@ -98,6 +101,10 @@ std::vector<openstudio::IdfObject> PlantLoop_Impl::remove()
 
   ModelObjectVector modelObjects;
   ModelObjectVector::iterator it;
+
+  if( auto t_availabilityManager = availabilityManager() ) {
+    t_availabilityManager->remove();
+  }
 
   modelObjects = supplyComponents();
   for(it = modelObjects.begin();
@@ -161,7 +168,15 @@ IddObjectType PlantLoop_Impl::iddObjectType() const {
 
 ModelObject PlantLoop_Impl::clone(Model model) const
 {
-  return Loop_Impl::clone(model);
+  PlantLoop plantLoopClone = Loop_Impl::clone(model).cast<PlantLoop>();
+  if( auto mo = availabilityManager() ) {
+    auto clone = mo->clone(model).cast<AvailabilityManager>();
+    plantLoopClone.setAvailabilityManager(clone);
+  } else {
+    plantLoopClone.setString(OS_PlantLoopFields::AvailabilityManagerName,"");
+  }
+
+  return plantLoopClone;
 }
 
 unsigned PlantLoop_Impl::supplyInletPort() const
@@ -492,6 +507,27 @@ bool PlantLoop_Impl::setLoadDistributionScheme(std::string scheme)
     scheme = "UniformLoad";
   }
   return setString(OS_PlantLoopFields::LoadDistributionScheme,scheme);
+}
+
+boost::optional<AvailabilityManager> PlantLoop_Impl::availabilityManager() const {
+  return getObject<ModelObject>().getModelObjectTarget<AvailabilityManager>(OS_PlantLoopFields::AvailabilityManagerName);
+}
+
+bool PlantLoop_Impl::setAvailabilityManager(const AvailabilityManager & availabilityManager) {
+  auto type = availabilityManager.iddObjectType();
+  if( type == IddObjectType::OS_AvailabilityManager_NightCycle ||
+      type == IddObjectType::OS_AvailabilityManager_HybridVentilation ||
+      type == IddObjectType::OS_AvailabilityManager_NightVentilation ||
+      type == IddObjectType::OS_AvailabilityManager_OptimumStart ||
+      type == IddObjectType::OS_AvailabilityManager_DifferentialThermostat) {
+    return setPointer(OS_PlantLoopFields::AvailabilityManagerName, availabilityManager.handle());
+  }
+  return false;
+}
+
+void PlantLoop_Impl::resetAvailabilityManager() {
+  bool result = setString(OS_PlantLoopFields::AvailabilityManagerName, "");
+  OS_ASSERT(result);
 }
 
 double PlantLoop_Impl::maximumLoopTemperature()
@@ -863,7 +899,6 @@ PlantLoop::PlantLoop(Model& model)
   setLoopTemperatureSetpointNode(supplyOutletNode);
 
   setString(OS_PlantLoopFields::DemandSideConnectorListName,"");
-  setString(OS_PlantLoopFields::AvailabilityManagerListName,"");
   setString(OS_PlantLoopFields::PlantLoopDemandCalculationScheme,"");
   setString(OS_PlantLoopFields::CommonPipeSimulation,"");
   setString(OS_PlantLoopFields::PressureSimulationType,"");
@@ -872,6 +907,21 @@ PlantLoop::PlantLoop(Model& model)
 PlantLoop::PlantLoop(std::shared_ptr<detail::PlantLoop_Impl> impl)
   : Loop(impl)
 {}
+
+boost::optional<AvailabilityManager> PlantLoop::availabilityManager() const
+{
+  return getImpl<detail::PlantLoop_Impl>()->availabilityManager();
+}
+
+bool PlantLoop::setAvailabilityManager(const AvailabilityManager& availabilityManager)
+{
+  return getImpl<detail::PlantLoop_Impl>()->setAvailabilityManager(availabilityManager);
+}
+
+void PlantLoop::resetAvailabilityManager()
+{
+  return getImpl<detail::PlantLoop_Impl>()->resetAvailabilityManager();
+}
 
 std::vector<IdfObject> PlantLoop::remove()
 {

--- a/openstudiocore/src/model/PlantLoop.hpp
+++ b/openstudiocore/src/model/PlantLoop.hpp
@@ -49,6 +49,7 @@ class PlantEquipmentOperationScheme;
 class PlantEquipmentOperationHeatingLoad;
 class PlantEquipmentOperationCoolingLoad;
 class Schedule;
+class AvailabilityManager;
 
 /** PlantLoop is an interface to the EnergyPlus IDD object
  *  named "PlantLoop"
@@ -88,6 +89,12 @@ class MODEL_API PlantLoop : public Loop {
   std::string loadDistributionScheme();
 
   bool setLoadDistributionScheme(std::string scheme);
+
+  boost::optional<AvailabilityManager> availabilityManager() const;
+
+  bool setAvailabilityManager(const AvailabilityManager& availabilityManager);
+
+  void resetAvailabilityManager();
 
   std::string fluidType();
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -43,6 +43,8 @@ class SizingPlant;
 class PlantEquipmentOperationScheme;
 class PlantEquipmentOperationHeatingLoad;
 class PlantEquipmentOperationCoolingLoad;
+class AvailabilityManager;
+
 
 namespace detail {
 
@@ -66,6 +68,12 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
   std::string loadDistributionScheme();
 
   bool setLoadDistributionScheme(std::string scheme);
+
+  boost::optional<AvailabilityManager> availabilityManager() const;
+
+  bool setAvailabilityManager(const AvailabilityManager & availabilityManager);
+
+  void resetAvailabilityManager();
 
   std::string fluidType();
 

--- a/openstudiocore/src/model/test/PlantLoop_GTest.cpp
+++ b/openstudiocore/src/model/test/PlantLoop_GTest.cpp
@@ -451,7 +451,4 @@ TEST_F(ModelFixture, PlantLoop_AvailabilityManager) {
   EXPECT_TRUE(plant2.availabilityManager());
   plant.resetAvailabilityManager();
   EXPECT_FALSE(plant.availabilityManager());
-
-
 }
-

--- a/openstudiocore/src/model/test/PlantLoop_GTest.cpp
+++ b/openstudiocore/src/model/test/PlantLoop_GTest.cpp
@@ -29,6 +29,7 @@
 #include <gtest/gtest.h>
 #include "ModelFixture.hpp"
 #include "../PlantLoop.hpp"
+#include "../PlantLoop_Impl.hpp"
 #include "../Node.hpp"
 #include "../Node_Impl.hpp"
 #include "../Loop.hpp"
@@ -56,6 +57,8 @@
 #include "../PlantEquipmentOperationHeatingLoad_Impl.hpp"
 #include "../PlantEquipmentOperationOutdoorDryBulb.hpp"
 #include "../PlantEquipmentOperationOutdoorDryBulb_Impl.hpp"
+#include "../AvailabilityManagerDifferentialThermostat.hpp"
+#include "../AvailabilityManagerDifferentialThermostat_Impl.hpp"
 
 #include <utilities/idd/IddEnums.hxx>
 
@@ -430,5 +433,25 @@ TEST_F(ModelFixture, PlantLoop_OperationSchemes)
     EXPECT_EQ(plantEquipmentOperationOutdoorDryBulb,dryBulb.get());
   }
   
+}
+
+TEST_F(ModelFixture, PlantLoop_AvailabilityManager) {
+  Model m;
+  PlantLoop plant(m);
+  AvailabilityManagerDifferentialThermostat availMgr(m);
+
+  EXPECT_FALSE(plant.availabilityManager());
+  EXPECT_TRUE(plant.setAvailabilityManager(availMgr));
+  OptionalAvailabilityManager availMgr2 = plant.availabilityManager();
+  EXPECT_TRUE(availMgr2);
+  if (availMgr2) {
+    EXPECT_EQ(availMgr2.get(), availMgr);
+  }
+  PlantLoop plant2 = plant.clone(m).cast<PlantLoop>();
+  EXPECT_TRUE(plant2.availabilityManager());
+  plant.resetAvailabilityManager();
+  EXPECT_FALSE(plant.availabilityManager());
+
+
 }
 


### PR DESCRIPTION
Previously there was no way to attribute an availability manager to a plant loop. This made it to where the availability manager wasn't forward translating because it had no parent object. Fixes #2623.

@shorowit @macumber 