### PR TITLE
Plant loop fluid concentration

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -18937,6 +18937,11 @@ OS:PlantLoop,
        \key Steam
        \key PropyleneGlycol
        \key EthyleneGlycol
+  N1,  \field Glycol Concentration
+       \type integer
+       \minimum 0
+       \maximum 100
+       \note Only used with either "PropyleneGlycol" or "EthyleneGlycol"
   A4, \field User Defined Fluid Type
        \note This field is not used.
        \type alpha
@@ -18953,27 +18958,27 @@ OS:PlantLoop,
        \type object-list
        \required-field
        \object-list Node
-  N1, \field Maximum Loop Temperature
+  N2, \field Maximum Loop Temperature
        \type real
        \units C
        \default 100.0
-  N2, \field Minimum Loop Temperature
+  N3, \field Minimum Loop Temperature
        \type real
        \units C
        \default 0.0
-  N3, \field Maximum Loop Flow Rate
+  N4, \field Maximum Loop Flow Rate
        \type real
        \autosizable
        \units m3/s
        \ip-units gal/min
        \minimum 0
        \default autosize
-  N4, \field Minimum Loop Flow Rate
+  N5, \field Minimum Loop Flow Rate
        \type real
        \units m3/s
        \ip-units gal/min
        \default 0.0
-  N5, \field Plant Loop Volume
+  N6, \field Plant Loop Volume
        \type real
        \autocalculatable
        \units m3
@@ -19052,14 +19057,9 @@ OS:PlantLoop,
   A22, \field Primary Plant Equipment Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
-  A23, \field Component Setpoint Operation Scheme Schedule
+  A23; \field Component Setpoint Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
-  N6;  \field Glycol Concentration
-       \type integer
-       \minimum 0
-       \maximum 100
-       \note Only used with either "PropyleneGlycol" or "EthyleneGlycol"
 
 OS:PlantEquipmentOperation:CoolingLoad,
     \extensible:3

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -18985,34 +18985,34 @@ OS:PlantLoop,
        \ip-units gal
        \minimum 0
        \default autocalculate
-  A8, \field Plant Side Inlet Node Name
+  A9, \field Plant Side Inlet Node Name
        \type object-list
        \required-field
        \object-list ConnectionNames
-  A9, \field Plant Side Outlet Node Name
+  A10, \field Plant Side Outlet Node Name
        \type object-list
        \required-field
        \object-list ConnectionNames
-  A10, \field Plant Side Branch List Name
+  A11, \field Plant Side Branch List Name
        \type object-list
        \required-field
        \object-list BranchLists
-  A11, \field Demand Side Inlet Node Name
+  A12, \field Demand Side Inlet Node Name
        \type object-list
        \required-field
        \object-list ConnectionNames
-  A12, \field Demand Side Outlet Node Name
+  A13, \field Demand Side Outlet Node Name
        \type object-list
        \required-field
        \object-list ConnectionNames
-  A13, \field Demand Side Branch List Name
+  A14, \field Demand Side Branch List Name
        \type object-list
        \required-field
        \object-list BranchLists
-  A14, \field Demand Side Connector List Name
+  A15, \field Demand Side Connector List Name
        \type object-list
        \object-list ConnectorLists
-  A15, \field Load Distribution Scheme
+  A16, \field Load Distribution Scheme
        \type choice
        \required-field
         \key Optimal
@@ -19020,15 +19020,15 @@ OS:PlantLoop,
         \key UniformLoad
         \key UniformPLR
         \key SequentialUniformPLR
-  A16, \field Availability Manager Name
+  A17, \field Availability Manager Name
        \type object-list
        \object-list SystemAvailabilityManagers
-  A17, \field Plant Loop Demand Calculation Scheme
+  A18, \field Plant Loop Demand Calculation Scheme
        \type choice
        \default SingleSetpoint
        \key SingleSetpoint
        \key DualSetpointDeadband
-  A18, \field Common Pipe Simulation
+  A19, \field Common Pipe Simulation
        \note Specifies a primary-secondary loop configuration. The plant side is the
        \note primary loop, and the demand side is the secondary loop.
        \note A secondary supply pump is required on the demand side.
@@ -19042,22 +19042,22 @@ OS:PlantLoop,
        \key CommonPipe
        \key TwoWayCommonPipe
        \key None
-  A19, \field Pressure Simulation Type
+  A20, \field Pressure Simulation Type
        \type choice
        \default None
        \key PumpPowerCorrection
        \key LoopFlowCorrection
        \key None
-  A20, \field Plant Equipment Operation Heating Load Schedule
+  A21, \field Plant Equipment Operation Heating Load Schedule
        \type object-list
        \object-list ScheduleNames
-  A21, \field Plant Equipment Operation Cooling Load Schedule
+  A22, \field Plant Equipment Operation Cooling Load Schedule
        \type object-list
        \object-list ScheduleNames
-  A22, \field Primary Plant Equipment Operation Scheme Schedule
+  A23, \field Primary Plant Equipment Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
-  A23; \field Component Setpoint Operation Scheme Schedule
+  A24; \field Component Setpoint Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
 

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -18935,11 +18935,11 @@ OS:PlantLoop,
        \default Water
        \key Water
        \key Steam
-       \key UserDefinedFluidType
+       \key PropyleneGlycol
+       \key EthyleneGlycol
   A4, \field User Defined Fluid Type
-       \note This field is only required when Fluid Type is UserDefinedFluidType
-       \type object-list
-       \object-list FluidAndGlycolNames
+       \note This field is not used.
+       \type alpha
   A5, \field Plant Equipment Operation Heating Load
        \type object-list
        \object-list ControlSchemeList
@@ -19052,9 +19052,14 @@ OS:PlantLoop,
   A22, \field Primary Plant Equipment Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
-  A23; \field Component Setpoint Operation Scheme Schedule
+  A23, \field Component Setpoint Operation Scheme Schedule
        \type object-list
        \object-list ScheduleNames
+  N6;  \field Glycol Concentration
+       \type integer
+       \minimum 0
+       \maximum 100
+       \note Only used with either "PropyleneGlycol" or "EthyleneGlycol"
 
 OS:PlantEquipmentOperation:CoolingLoad,
     \extensible:3

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
@@ -119,6 +119,7 @@
 #include <utilities/idd/Sizing_Plant_FieldEnums.hxx>
 #include <utilities/idd/AirTerminal_SingleDuct_ConstantVolume_CooledBeam_FieldEnums.hxx>
 #include <utilities/idd/ZoneHVAC_AirDistributionUnit_FieldEnums.hxx>
+#include <utilities/idd/FluidProperties_Name_FieldEnums.hxx>
 #include "../../utilities/core/Assert.hpp"
 
 using namespace openstudio::model;
@@ -395,7 +396,22 @@ boost::optional<IdfObject> ForwardTranslator::translatePlantLoop( PlantLoop & pl
 
   if( (s = plantLoop.fluidType()) )
   {
-    idfObject.setString(PlantLoopFields::FluidType,s.get());
+    if (istringEqual(s.get(),"PropyleneGlycol") or istringEqual(s.get(),"EthyleneGlycol")) {
+      idfObject.setString(PlantLoopFields::FluidType,"UserDefinedFluidType");
+      boost::optional<int> gc = plantLoop.glycolConcentration();
+      if ( gc ) {
+        boost::optional<IdfObject> fluidProperties = createFluidProperties(s.get(), gc.get());
+        if (fluidProperties) {
+          boost::optional<std::string> fluidPropertiesName = fluidProperties->getString(FluidProperties_NameFields::FluidName,true);
+          if (fluidPropertiesName) {
+            idfObject.setString(PlantLoopFields::UserDefinedFluidType,fluidPropertiesName.get());
+          }
+        }
+      }
+
+    } else {
+      idfObject.setString(PlantLoopFields::FluidType,s.get());
+    }
   }
 
   // Loop Temperature Setpoint Node Name

--- a/openstudiocore/src/model/PlantLoop.cpp
+++ b/openstudiocore/src/model/PlantLoop.cpp
@@ -594,9 +594,31 @@ std::string PlantLoop_Impl::fluidType()
   return getString(OS_PlantLoopFields::FluidType,true).get();
 }
 
-void PlantLoop_Impl::setFluidType( const std::string & value )
+bool PlantLoop_Impl::setFluidType( const std::string & value )
 {
-  setString(OS_PlantLoopFields::FluidType,value);
+  if ((value != "PropyleneGlycol") && (value != "EthyleneGlycol")) {
+    this->resetGlycolConcentration();
+  }
+  return setString(OS_PlantLoopFields::FluidType,value);
+}
+
+boost::optional<int> PlantLoop_Impl::glycolConcentration() const {
+  return getInt(OS_PlantLoopFields::GlycolConcentration,true);
+}
+
+bool PlantLoop_Impl::setGlycolConcentration(int glycolConcentration) {
+  std::string currentFluidType = this->fluidType();
+  if ((currentFluidType == "PropyleneGlycol") || (currentFluidType == "EthyleneGlycol")) {
+    return setInt(OS_PlantLoopFields::GlycolConcentration, glycolConcentration);
+  } else {
+    LOG(Error, "Plant Loop Fluid Type must be PropyleneGlycol or EthyleneGlycol, not " + currentFluidType + ", to set a glycol concentration.");
+    return false;
+  }
+}
+
+void PlantLoop_Impl::resetGlycolConcentration() {
+  bool result = setString(OS_PlantLoopFields::GlycolConcentration, "");
+  OS_ASSERT(result);
 }
 
 Node PlantLoop_Impl::loopTemperatureSetpointNode()
@@ -1063,9 +1085,27 @@ std::string PlantLoop::fluidType()
   return getImpl<detail::PlantLoop_Impl>()->fluidType();
 }
 
-void PlantLoop::setFluidType( const std::string & value )
+bool PlantLoop::setFluidType( const std::string & value )
 {
-  getImpl<detail::PlantLoop_Impl>()->setFluidType( value );
+  return getImpl<detail::PlantLoop_Impl>()->setFluidType( value );
+}
+
+std::vector<std::string> PlantLoop::fluidTypeValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_PlantLoopFields::FluidType);
+
+}
+
+boost::optional<int> PlantLoop::glycolConcentration() const {
+  return getImpl<detail::PlantLoop_Impl>()->glycolConcentration();
+}
+
+bool PlantLoop::setGlycolConcentration(int glycolConcentration) {
+  return getImpl<detail::PlantLoop_Impl>()->setGlycolConcentration(glycolConcentration);
+}
+
+void PlantLoop::resetGlycolConcentration() {
+  getImpl<detail::PlantLoop_Impl>()->resetGlycolConcentration();
 }
 
 Node PlantLoop::loopTemperatureSetpointNode()

--- a/openstudiocore/src/model/PlantLoop.cpp
+++ b/openstudiocore/src/model/PlantLoop.cpp
@@ -632,29 +632,15 @@ std::string PlantLoop_Impl::fluidType()
 
 bool PlantLoop_Impl::setFluidType( const std::string & value )
 {
-  if (!(istringEqual(value,"PropyleneGlycol") || istringEqual(value,"EthyleneGlycol"))) {
-    this->resetGlycolConcentration();
-  }
   return setString(OS_PlantLoopFields::FluidType,value);
 }
 
-boost::optional<int> PlantLoop_Impl::glycolConcentration() const {
-  return getInt(OS_PlantLoopFields::GlycolConcentration,true);
+int PlantLoop_Impl::glycolConcentration() const {
+  return getInt(OS_PlantLoopFields::GlycolConcentration,true).get();
 }
 
-bool PlantLoop_Impl::setGlycolConcentration(int glycolConcentration) {
-  std::string currentFluidType = this->fluidType();
-  if (istringEqual(currentFluidType,"PropyleneGlycol") || istringEqual(currentFluidType,"EthyleneGlycol")) {
-    return setInt(OS_PlantLoopFields::GlycolConcentration, glycolConcentration);
-  } else {
-    LOG(Error, "Plant Loop Fluid Type must be PropyleneGlycol or EthyleneGlycol, not " + currentFluidType + ", to set a glycol concentration.");
-    return false;
-  }
-}
-
-void PlantLoop_Impl::resetGlycolConcentration() {
-  bool result = setString(OS_PlantLoopFields::GlycolConcentration, "");
-  OS_ASSERT(result);
+void PlantLoop_Impl::setGlycolConcentration(int glycolConcentration) {
+  setInt(OS_PlantLoopFields::GlycolConcentration, glycolConcentration);
 }
 
 Node PlantLoop_Impl::loopTemperatureSetpointNode()
@@ -1146,16 +1132,12 @@ std::vector<std::string> PlantLoop::fluidTypeValues() {
 
 }
 
-boost::optional<int> PlantLoop::glycolConcentration() const {
+int PlantLoop::glycolConcentration() const {
   return getImpl<detail::PlantLoop_Impl>()->glycolConcentration();
 }
 
-bool PlantLoop::setGlycolConcentration(int glycolConcentration) {
-  return getImpl<detail::PlantLoop_Impl>()->setGlycolConcentration(glycolConcentration);
-}
-
-void PlantLoop::resetGlycolConcentration() {
-  getImpl<detail::PlantLoop_Impl>()->resetGlycolConcentration();
+void PlantLoop::setGlycolConcentration(int glycolConcentration) {
+  getImpl<detail::PlantLoop_Impl>()->setGlycolConcentration(glycolConcentration);
 }
 
 Node PlantLoop::loopTemperatureSetpointNode()

--- a/openstudiocore/src/model/PlantLoop.cpp
+++ b/openstudiocore/src/model/PlantLoop.cpp
@@ -596,7 +596,7 @@ std::string PlantLoop_Impl::fluidType()
 
 bool PlantLoop_Impl::setFluidType( const std::string & value )
 {
-  if ((value != "PropyleneGlycol") && (value != "EthyleneGlycol")) {
+  if (!(istringEqual(value,"PropyleneGlycol") || istringEqual(value,"EthyleneGlycol"))) {
     this->resetGlycolConcentration();
   }
   return setString(OS_PlantLoopFields::FluidType,value);
@@ -608,7 +608,7 @@ boost::optional<int> PlantLoop_Impl::glycolConcentration() const {
 
 bool PlantLoop_Impl::setGlycolConcentration(int glycolConcentration) {
   std::string currentFluidType = this->fluidType();
-  if ((currentFluidType == "PropyleneGlycol") || (currentFluidType == "EthyleneGlycol")) {
+  if (istringEqual(currentFluidType,"PropyleneGlycol") || istringEqual(currentFluidType,"EthyleneGlycol")) {
     return setInt(OS_PlantLoopFields::GlycolConcentration, glycolConcentration);
   } else {
     LOG(Error, "Plant Loop Fluid Type must be PropyleneGlycol or EthyleneGlycol, not " + currentFluidType + ", to set a glycol concentration.");

--- a/openstudiocore/src/model/PlantLoop.hpp
+++ b/openstudiocore/src/model/PlantLoop.hpp
@@ -69,6 +69,8 @@ class MODEL_API PlantLoop : public Loop {
 
   static std::vector<std::string> loadDistributionSchemeValues();
 
+  static std::vector<std::string> fluidTypeValues();
+
   /** Prior to OS 1.11.0 the options where
       Optimal, Sequential, and Uniform.
       E+ changed the available options to.
@@ -91,7 +93,13 @@ class MODEL_API PlantLoop : public Loop {
 
   std::string fluidType();
 
-  void setFluidType( const std::string & value );
+  bool setFluidType( const std::string & value );
+
+  bool setGlycolConcentration(int glycolConcentration);
+
+  void resetGlycolConcentration();
+
+  boost::optional<int> glycolConcentration() const;
 
   Node loopTemperatureSetpointNode();
 

--- a/openstudiocore/src/model/PlantLoop.hpp
+++ b/openstudiocore/src/model/PlantLoop.hpp
@@ -102,11 +102,9 @@ class MODEL_API PlantLoop : public Loop {
 
   bool setFluidType( const std::string & value );
 
-  bool setGlycolConcentration(int glycolConcentration);
+  void setGlycolConcentration(int glycolConcentration);
 
-  void resetGlycolConcentration();
-
-  boost::optional<int> glycolConcentration() const;
+  int glycolConcentration() const;
 
   Node loopTemperatureSetpointNode();
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -69,7 +69,13 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   std::string fluidType();
 
-  void setFluidType( const std::string & value );
+  bool setFluidType( const std::string & value );
+
+  bool setGlycolConcentration(int glycolConcentration);
+
+  void resetGlycolConcentration();
+
+  boost::optional<int> glycolConcentration() const;
 
   double maximumLoopTemperature();
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -79,11 +79,9 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   bool setFluidType( const std::string & value );
 
-  bool setGlycolConcentration(int glycolConcentration);
+  void setGlycolConcentration(int glycolConcentration);
 
-  void resetGlycolConcentration();
-
-  boost::optional<int> glycolConcentration() const;
+  int glycolConcentration() const;
 
   double maximumLoopTemperature();
 

--- a/openstudiocore/src/model/test/PlantLoop_GTest.cpp
+++ b/openstudiocore/src/model/test/PlantLoop_GTest.cpp
@@ -432,3 +432,18 @@ TEST_F(ModelFixture, PlantLoop_OperationSchemes)
   
 }
 
+TEST_F(ModelFixture, PlantLoop_GlycolConcentration) {
+  Model m;
+  PlantLoop plant(m);
+
+  EXPECT_FALSE(plant.setGlycolConcentration(5));
+  EXPECT_TRUE(plant.setFluidType("PropyleneGlycol"));
+  EXPECT_EQ(plant.fluidType(), "PropyleneGlycol");
+  EXPECT_TRUE(plant.setGlycolConcentration(50));
+  boost::optional<int> glycolConcentration = plant.glycolConcentration();
+  EXPECT_TRUE(glycolConcentration);
+  if (glycolConcentration) {
+    EXPECT_EQ(glycolConcentration.get(), 50);
+  }
+
+}

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -778,6 +778,7 @@
     <rule IddField="Availability Manager List Name" Access="HIDDEN"/>
     <rule IddField="Plant Loop Demand Calculation Scheme" Access="HIDDEN"/>
     <rule IddField="Pressure Simulation Type" Access="HIDDEN"/>
+    <rule IddField="User Defined Fluid Type" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_InternalMass">
     <rule IddField="Space or SpaceType Name" Access="HIDDEN"/>

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -768,6 +768,9 @@
   </POLICY>
   <POLICY IddObjectType="OS_PlantLoop">
     <rule IddField="Plant Equipment Operation Scheme Name" Access="HIDDEN"/>
+    <rule IddField="Plant Equipment Operation Heating Load" Access="HIDDEN"/>
+    <rule IddField="Plant Equipment Operation Cooling Load" Access="HIDDEN"/>
+    <rule IddField="Primary Plant Equipment Operation Scheme" Access="HIDDEN"/>
     <rule IddField="Plant Side Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Plant Side Outlet Node Name" Access="HIDDEN"/>
     <rule IddField="Plant Side Branch List Name" Access="HIDDEN"/>

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -3491,6 +3491,8 @@ std::string VersionTranslator::update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, c
       ss << object;
     }
   }
+
+  return ss.str();
 }
 
 

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -115,9 +115,9 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("1.11.4")] = &VersionTranslator::update_1_11_3_to_1_11_4;
   m_updateMethods[VersionString("1.11.5")] = &VersionTranslator::update_1_11_4_to_1_11_5;
   m_updateMethods[VersionString("1.12.1")] = &VersionTranslator::update_1_12_0_to_1_12_1;
-  m_updateMethods[VersionString("1.13.4")] = &VersionTranslator::update_1_12_3_to_1_12_4;
+  m_updateMethods[VersionString("1.12.4")] = &VersionTranslator::update_1_12_3_to_1_12_4;
   m_updateMethods[VersionString("2.1.1")] = &VersionTranslator::update_2_1_0_to_2_1_1;
-  m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::defaultUpdate;
+  m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::update_2_1_1_to_2_1_2;
 
 
   // List of previous versions that may be updated to this one.
@@ -3456,6 +3456,41 @@ std::string VersionTranslator::update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, c
   }
 
   return ss.str();
+}
+
+std::string VersionTranslator::update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2) {
+  std::stringstream ss;
+
+  ss << idf_2_1_1.header() << std::endl << std::endl;
+  IdfFile targetIdf(idd_2_1_2.iddFile());
+  ss << targetIdf.versionObject().get();
+
+  for (const IdfObject& object : idf_2_1_1.objects()) {
+    auto iddname = object.iddObject().name();
+
+    if (iddname == "OS:PlantLoop") {
+      auto iddObject = idd_2_1_2.getObject("OS:PlantLoop");
+      IdfObject newObject(iddObject.get());
+
+      size_t newi = 0;
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( i == 3u ) {
+          newObject.setDouble(newi,50.0);
+          ++newi;
+        } else {
+          if( auto s = object.getString(i) ) {
+            newObject.setString(newi,s.get());
+          }
+        }
+        ++newi;
+      }
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+    } else {
+      ss << object;
+    }
+  }
 }
 
 

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -218,6 +218,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_1_12_0_to_1_12_1(const IdfFile& idf_1_12_0, const IddFileAndFactoryWrapper& idd_1_12_1);
   std::string update_1_12_3_to_1_12_4(const IdfFile& idf_1_12_3, const IddFileAndFactoryWrapper& idd_1_12_4);
   std::string update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, const IddFileAndFactoryWrapper& idd_2_1_1);
+  std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
This permits the use of PropyleneGlycol and EthyleneGlycol as the fluid type of a `PlantLoop`. It also opens up the ability to set the glycol concentration. The `FluidProperties:Name` and `FluidProperties:GlycolConcentration` idf objects are created on forward translation.

Part of https://github.com/NREL/OpenStudio-BEopt/issues/66
@shorowit 
