### PR TITLE
Add proper Python3 support 

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -676,6 +676,7 @@ endif()
 
 if(BUILD_PYTHON_BINDINGS)
   # need python
+  # TODO: add support for 3.x
   find_package(PythonInterp 2.7 REQUIRED)
   find_package(PythonLibs 2.7 REQUIRED)
   include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})

--- a/openstudiocore/ProjectMacros.cmake
+++ b/openstudiocore/ProjectMacros.cmake
@@ -23,7 +23,7 @@ macro(FIND_QT_STATIC_LIB NAMES P)
     #message("LOOKING FOR ${NAMES} in ${P}")
     find_library(QT_STATIC_LIB NAMES ${NAMES} PATHS ${P} NO_DEFAULT_PATH)
   endif()
-  
+
   if(QT_STATIC_LIB)
     list(APPEND QT_STATIC_LIBS ${QT_STATIC_LIB})
   else()
@@ -520,18 +520,33 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if(BUILD_DOCUMENTATION)
       set(PYTHON_AUTODOC -features autodoc=1)
     endif()
-    
+
+
+    # Add the -py3 flag if the version used is Python 3
+    set(SWIG_PYTHON_3_FLAG "")
+    if (PYTHON_VERSION_MAJOR) 
+      if (PYTHON_VERSION_MAJOR EQUAL 3)
+        set(SWIG_PYTHON_3_FLAG -py3)
+        message(STATUS "${MODULE} - Building SWIG Bindings for Python 3")
+      else()
+        message(STATUS "${MODULE} - Building SWIG Bindings for Python 2")
+      endif()
+    else()
+      message(STATUS "${MODULE} - Couldnt determine version of Python - Building SWIG Bindings for Python 2")
+    endif()
+
     add_custom_command(
       OUTPUT "${SWIG_WRAPPER_FULL_PATH}" 
       COMMAND "${SWIG_EXECUTABLE}"
-               "-python" "-c++" ${PYTHON_AUTODOC}
-               -outdir ${PYTHON_GENERATED_SRC_DIR} "-I${CMAKE_SOURCE_DIR}/src" "-I${CMAKE_BINARY_DIR}/src"
-               -module "${MODULE}"
-               -o "${SWIG_WRAPPER_FULL_PATH}"
-               "${SWIG_DEFINES}" ${SWIG_COMMON} ${KEY_I_FILE}
+              "-python" ${SWIG_PYTHON_3_FLAG} "-c++" ${PYTHON_AUTODOC} 
+              -outdir ${PYTHON_GENERATED_SRC_DIR} "-I${CMAKE_SOURCE_DIR}/src" "-I${CMAKE_BINARY_DIR}/src"
+              -module "${MODULE}"
+              -o "${SWIG_WRAPPER_FULL_PATH}"
+              "${SWIG_DEFINES}" ${SWIG_COMMON} ${KEY_I_FILE}
       DEPENDS ${this_depends}
     )
 
+    
     set_source_files_properties(${SWIG_WRAPPER_FULL_PATH} PROPERTIES GENERATED TRUE)
     set_source_files_properties(${PYTHON_GENERATED_SRC} PROPERTIES GENERATED TRUE)
 

--- a/openstudiocore/python/openstudio.py
+++ b/openstudiocore/python/openstudio.py
@@ -1,34 +1,38 @@
 # imports all of the openstudio libraries into a friendly namespace
 
-from openstudioutilitiescore import *
-from openstudioutilitieseconomics import *
-from openstudioutilitiestime import *
-from openstudioutilitiesdata import *
-from openstudioutilitiesplot import *
-from openstudioutilitiesgeometry import *
-from openstudioutilitiessql import *
-from openstudioutilitiesbcl import *
-from openstudioutilitiesunits import *
-from openstudioutilitiesidd import *
-from openstudioutilitiesidf import *
-from openstudioutilitiesfiletypes import *
-from openstudioutilities import *
+import .openstudioairflow as airflow
+import .openstudioanalysis as analysis
+import .openstudioanalysisdriver as analysisdriver
+import .openstudioenergyplus as energyplus
+import .openstudiogbxml as gbxml
+import .openstudioisomodel as isomodel
+import .openstudiolib as lib
+import .openstudiomeasure as measure
+import .openstudiomodel as model
+# import openstudiomodelcore as modelcore
+import .openstudiomodeleditor as modeleditor
+# import openstudiomodelgenerators as modelgenerators
+# import openstudiomodelgeometry as modelgeometry
+# import openstudiomodelhvac as modelhvac
+# import openstudiomodelrefrigeration as modelrefrigeration
+# import openstudiomodelresources as modelresources
+# import openstudiomodelsimulation as modelsimulation
+import .openstudioosversion as osversion
+import .openstudioradiance as radiance
+import .openstudiosdd as sdd
 
-import openstudioenergyplus as energyplus
+from .openstudioutilities import *
+from .openstudioutilitiesbcl import *
+from .openstudioutilitiescore import *
+from .openstudioutilitiesdata import *
+from .openstudioutilitieseconomics import *
+from .openstudioutilitiesgeometry import *
+from .openstudioutilitiesidd import *
+from .openstudioutilitiesidf import *
+# from .openstudioutilitiesfiletypes import *
+# from .openstudioutilitiesplot import *
+from .openstudioutilitiessql import *
+from .openstudioutilitiestime import *
+from .openstudioutilitiesunits import *
 
-import openstudiomodel as model
-
-import openstudioradiance as radiance
-
-import openstudiogbxml as gbxml
-
-import openstudioosversion as osversion
-
-import openstudiomeasure as measure
-import openstudiorunmanager as runmanager
-import openstudioproject as project
-import openstudioanalysisdriver as analysisdriver
-import openstudiomodeleditor as modeleditor
-import openstudioanalysis as analysis
-import openstudiolib as lib
 

--- a/openstudiocore/src/model/Model.i
+++ b/openstudiocore/src/model/Model.i
@@ -5,13 +5,13 @@
   %module openstudiomodel
 
   %pythoncode %{
-    from openstudiomodelcore import *
-    from openstudiomodelsimulation import *
-    from openstudiomodelresources import *
-    from openstudiomodelgeometry import *
-    from openstudiomodelhvac import *
-    from openstudiomodelrefrigeration import *
-    from openstudiomodelgenerators import *
+    from .openstudiomodelcore import *
+    from .openstudiomodelsimulation import *
+    from .openstudiomodelresources import *
+    from .openstudiomodelgeometry import *
+    from .openstudiomodelhvac import *
+    from .openstudiomodelrefrigeration import *
+    from .openstudiomodelgenerators import *
   %}
 
 #endif


### PR DESCRIPTION
Especially the problem with relative imports that are no longer working in Python 3.

I'm basically adding a check on the python major version, if it's python3, pass `-py3` flag to SWIG. 

Also changed a few files where python imports are explicitly defined.

This is building on my machine currently, so I can't tell whether it worked 100% or not.

