### PR TITLE
Removing Ruleset from measure and measure test templates

### DIFF
--- a/openstudiocore/src/utilities/bcl/templates/EnergyPlusMeasure/measure.rb
+++ b/openstudiocore/src/utilities/bcl/templates/EnergyPlusMeasure/measure.rb
@@ -2,7 +2,7 @@
 # http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
 
 # start the measure
-class EnergyPlusMeasureName < OpenStudio::Ruleset::WorkspaceUserScript
+class EnergyPlusMeasureName < OpenStudio::Measure::EnergyPlusMeasure
 
   # human readable name
   def name
@@ -21,10 +21,10 @@ class EnergyPlusMeasureName < OpenStudio::Ruleset::WorkspaceUserScript
 
   # define the arguments that the user will input
   def arguments(workspace)
-    args = OpenStudio::Ruleset::OSArgumentVector.new
+    args = OpenStudio::Measure::OSArgumentVector.new
 
     # the name of the zone to add to the model
-    zone_name = OpenStudio::Ruleset::OSArgument.makeStringArgument("zone_name", true)
+    zone_name = OpenStudio::Measure::OSArgument.makeStringArgument("zone_name", true)
     zone_name.setDisplayName("New zone name")
     zone_name.setDescription("This name will be used as the name of the new zone.")
     args << zone_name

--- a/openstudiocore/src/utilities/bcl/templates/EnergyPlusMeasure/tests/energyplus_measure_test.rb
+++ b/openstudiocore/src/utilities/bcl/templates/EnergyPlusMeasure/tests/energyplus_measure_test.rb
@@ -1,5 +1,5 @@
 require 'openstudio'
-require 'openstudio/ruleset/ShowRunnerOutput'
+require 'openstudio/measure/ShowRunnerOutput'
 require 'minitest/autorun'
 
 require_relative '../measure.rb'
@@ -30,8 +30,9 @@ class EnergyPlusMeasureName_Test < MiniTest::Unit::TestCase
     # create an instance of the measure
     measure = EnergyPlusMeasureName.new
 
-    # create an instance of a runner
-    runner = OpenStudio::Ruleset::OSRunner.new
+    # create runner with empty OSW
+    osw = OpenStudio::WorkflowJSON.new
+    runner = OpenStudio::Measure::OSRunner.new(osw)
 
     # make an empty workspace
     workspace = OpenStudio::Workspace.new("Draft".to_StrictnessLevel, "EnergyPlus".to_IddFileType)
@@ -41,7 +42,7 @@ class EnergyPlusMeasureName_Test < MiniTest::Unit::TestCase
 
     # get arguments
     arguments = measure.arguments(workspace)
-    argument_map = OpenStudio::Ruleset.convertOSArgumentVectorToMap(arguments)
+    argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
 
     # set argument values to bad value
     zone_name = arguments[0].clone
@@ -62,8 +63,9 @@ class EnergyPlusMeasureName_Test < MiniTest::Unit::TestCase
     # create an instance of the measure
     measure = EnergyPlusMeasureName.new
 
-    # create an instance of a runner
-    runner = OpenStudio::Ruleset::OSRunner.new
+    # create runner with empty OSW
+    osw = OpenStudio::WorkflowJSON.new
+    runner = OpenStudio::Measure::OSRunner.new(osw)
 
     # make an empty workspace
     workspace = OpenStudio::Workspace.new("Draft".to_StrictnessLevel, "EnergyPlus".to_IddFileType)
@@ -73,7 +75,7 @@ class EnergyPlusMeasureName_Test < MiniTest::Unit::TestCase
 
     # get arguments
     arguments = measure.arguments(workspace)
-    argument_map = OpenStudio::Ruleset.convertOSArgumentVectorToMap(arguments)
+    argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
 
     # set argument values to good values
     zone_name = arguments[0].clone

--- a/openstudiocore/src/utilities/bcl/templates/ModelMeasure/measure.rb
+++ b/openstudiocore/src/utilities/bcl/templates/ModelMeasure/measure.rb
@@ -2,7 +2,7 @@
 # http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
 
 # start the measure
-class ModelMeasureName < OpenStudio::Ruleset::ModelUserScript
+class ModelMeasureName < OpenStudio::Measure::ModelMeasure
 
   # human readable name
   def name
@@ -21,10 +21,10 @@ class ModelMeasureName < OpenStudio::Ruleset::ModelUserScript
 
   # define the arguments that the user will input
   def arguments(model)
-    args = OpenStudio::Ruleset::OSArgumentVector.new
+    args = OpenStudio::Measure::OSArgumentVector.new
 
     # the name of the space to add to the model
-    space_name = OpenStudio::Ruleset::OSArgument.makeStringArgument("space_name", true)
+    space_name = OpenStudio::Measure::OSArgument.makeStringArgument("space_name", true)
     space_name.setDisplayName("New space name")
     space_name.setDescription("This name will be used as the name of the new space.")
     args << space_name

--- a/openstudiocore/src/utilities/bcl/templates/ModelMeasure/tests/model_measure_test.rb
+++ b/openstudiocore/src/utilities/bcl/templates/ModelMeasure/tests/model_measure_test.rb
@@ -1,5 +1,5 @@
 require 'openstudio'
-require 'openstudio/ruleset/ShowRunnerOutput'
+require 'openstudio/measure/ShowRunnerOutput'
 require 'minitest/autorun'
 require_relative '../measure.rb'
 require 'fileutils'
@@ -29,15 +29,16 @@ class ModelMeasureName_Test < MiniTest::Unit::TestCase
     # create an instance of the measure
     measure = ModelMeasureName.new
 
-    # create an instance of a runner
-    runner = OpenStudio::Ruleset::OSRunner.new
+    # create runner with empty OSW
+    osw = OpenStudio::WorkflowJSON.new
+    runner = OpenStudio::Measure::OSRunner.new(osw)
 
     # make an empty model
     model = OpenStudio::Model::Model.new
 
     # get arguments
     arguments = measure.arguments(model)
-    argument_map = OpenStudio::Ruleset.convertOSArgumentVectorToMap(arguments)
+    argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
 
     # create hash of argument values
     args_hash = {}
@@ -67,8 +68,9 @@ class ModelMeasureName_Test < MiniTest::Unit::TestCase
     # create an instance of the measure
     measure = ModelMeasureName.new
 
-    # create an instance of a runner
-    runner = OpenStudio::Ruleset::OSRunner.new
+    # create runner with empty OSW
+    osw = OpenStudio::WorkflowJSON.new
+    runner = OpenStudio::Measure::OSRunner.new(osw)
 
     # load the test model
     translator = OpenStudio::OSVersion::VersionTranslator.new
@@ -82,7 +84,7 @@ class ModelMeasureName_Test < MiniTest::Unit::TestCase
 
     # get arguments
     arguments = measure.arguments(model)
-    argument_map = OpenStudio::Ruleset.convertOSArgumentVectorToMap(arguments)
+    argument_map = OpenStudio::Measure.convertOSArgumentVectorToMap(arguments)
 
     # create hash of argument values.
     # If the argument has a default that you want to use, you don't need it in the hash

--- a/openstudiocore/src/utilities/bcl/templates/ReportingMeasure/measure.rb
+++ b/openstudiocore/src/utilities/bcl/templates/ReportingMeasure/measure.rb
@@ -4,7 +4,7 @@
 require 'erb'
 
 #start the measure
-class ReportingMeasureName < OpenStudio::Ruleset::ReportingUserScript
+class ReportingMeasureName < OpenStudio::Measure::ReportingMeasure
 
   # human readable name
   def name
@@ -23,7 +23,7 @@ class ReportingMeasureName < OpenStudio::Ruleset::ReportingUserScript
 
   # define the arguments that the user will input
   def arguments()
-    args = OpenStudio::Ruleset::OSArgumentVector.new
+    args = OpenStudio::Measure::OSArgumentVector.new
 
     # this measure does not require any user arguments, return an empty list
 


### PR DESCRIPTION
Fixes issue #2656 had to create workflow on the fly to create runner.
Also removed 1x path for reporting measure test. Note: Measure made
based on these templates should not be back versioned in measure.xml to
1.x version of OpenStudio.