### PR TITLE
Fix 2379

### DIFF
--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -529,6 +529,7 @@ set(${target_name}_test_src
   Test/SurfacePropertyConvectionCoefficients.cpp
   Test/TableMultiVariableLookup_GTest.cpp
   Test/ThermalZone_GTest.cpp
+  Test/ThermostatSetpointDualSetpoint_GTest.cpp
   Test/WindowPropertyFrameAndDivider_GTest.cpp
   Test/ZoneHVACLowTemperatureRadiantConstFlow_GTest.cpp
   Test/ZoneHVACLowTempRadiantElectric_GTest.cpp

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingGas.cpp
@@ -65,7 +65,7 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingGas( CoilHeati
                         sched.name().get() );
   }
   catch (std::exception& e) {
-    LOG(Error,"Could not translate " << modelObject.briefDescription() << ", because " 
+    LOG(Error,"Could not translate " << modelObject.briefDescription() << ", because "
         << e.what() << ".");
     return boost::none;
   }
@@ -79,7 +79,7 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingGas( CoilHeati
   } else {
     idfObject.setString(openstudio::Coil_Heating_FuelFields::FuelType, modelObject.fuelType());
   }
-  
+
   ///////////////////////////////////////////////////////////////////////////
 
   ///////////////////////////////////////////////////////////////////////////
@@ -132,12 +132,12 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingGas( CoilHeati
 
   m_idfObjects.push_back(idfObject);
 
-  // Part Load Fraction Correlation Curve 
+  // Part Load Fraction Correlation Curve
   if( boost::optional<model::Curve> curve = modelObject.partLoadFractionCorrelationCurve() )
   {
     if( boost::optional<IdfObject> _curve = translateAndMapModelObject(curve.get()) )
     {
-      idfObject.setString(Coil_Heating_FuelFields::PartLoadFractionCorrelationCurveName,_curve->name().get()); 
+      idfObject.setString(Coil_Heating_FuelFields::PartLoadFractionCorrelationCurveName,_curve->name().get());
     }
   }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -253,7 +253,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
     for (Surface& surface : surfaces){
       translateAndMapModelObject(surface);
     }
-    
+
     // translate internal mass
     InternalMassVector internalMasses = spaces[0].internalMass();
     std::sort(internalMasses.begin(), internalMasses.end(), WorkspaceObjectNameLess());
@@ -347,7 +347,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
           primaryReferencePoint.setString(Daylighting_ReferencePointFields::ZoneName, refThermalZone->nameString());
         }
       }
-      
+
       primaryReferencePoint.setDouble(
           Daylighting_ReferencePointFields::XCoordinateofReferencePoint,
           primaryDaylightingControl->positionXCoordinate());
@@ -357,7 +357,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
       primaryReferencePoint.setDouble(
           Daylighting_ReferencePointFields::ZCoordinateofReferencePoint,
           primaryDaylightingControl->positionZCoordinate());
-      
+
       std::string fractionofZoneControlledbyFirstReferencePoint;
       if (istringEqual("None", primaryDaylightingControl->lightingControlType())){
         fractionofZoneControlledbyFirstReferencePoint = "0.0";
@@ -366,7 +366,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         ss << modelObject.fractionofZoneControlledbyPrimaryDaylightingControl();
         fractionofZoneControlledbyFirstReferencePoint = ss.str();
       }
-      
+
       std::string illuminanceSetpointatFirstReferencePoint;
       if (!primaryDaylightingControl->isIlluminanceSetpointDefaulted()){
         std::stringstream ss;
@@ -404,7 +404,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         secondaryReferencePoint.setDouble(
             Daylighting_ReferencePointFields::ZCoordinateofReferencePoint,
             secondaryDaylightingControl->positionZCoordinate());
-        
+
         std::string fractionofZoneControlledbySecondReferencePoint;
         if (istringEqual("None", secondaryDaylightingControl->lightingControlType())){
           fractionofZoneControlledbySecondReferencePoint = "0.0";
@@ -418,7 +418,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         if (!secondaryDaylightingControl->isIlluminanceSetpointDefaulted()){
           std::stringstream ss;
           ss << secondaryDaylightingControl->illuminanceSetpoint();
-          illuminanceSetpointatSecondReferencePoint = ss.str();      
+          illuminanceSetpointatSecondReferencePoint = ss.str();
         }
 
         std::vector<std::string> secondGroup;
@@ -458,7 +458,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         LOG(Warn, "Rotation of " << primaryDaylightingControl->phiRotationAroundZAxis() << " degrees about Z axis not mapped for OS:Daylighting:Control " << primaryDaylightingControl->name().get());
       }
 
-      // glare 
+      // glare
       double glareAngle = -openstudio::radToDeg(primaryDaylightingControl->thetaRotationAroundYAxis());
       daylightingControlObject.setDouble(
           Daylighting_ControlsFields::GlareCalculationAzimuthAngleofViewDirectionClockwisefromZoneyAxis,
@@ -469,11 +469,11 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
           Daylighting_ControlsFields::MaximumAllowableDiscomfortGlareIndex,
           *d);
       }
-      
+
       daylightingControlObject.setString(
         Daylighting_ControlsFields::GlareCalculationDaylightingReferencePointName,
         primaryReferencePoint.nameString());
-      
+
 
       if (!primaryDaylightingControl->isMinimumInputPowerFractionforContinuousDimmingControlDefaulted()){
         daylightingControlObject.setDouble(
@@ -498,17 +498,17 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             Daylighting_ControlsFields::ProbabilityLightingwillbeResetWhenNeededinManualSteppedControl,
             primaryDaylightingControl->probabilityLightingwillbeResetWhenNeededinManualSteppedControl());
       }
-      
+
     }
 
     // translate illuminance map
     boost::optional<IlluminanceMap> illuminanceMap = modelObject.illuminanceMap();
     if (illuminanceMap){
 
-      
+
       if (!primaryDaylightingControl){
         LOG(Warn, "Daylighting:Controls object is required to trigger daylighting calculations in EnergyPlus, adding a minimal one to Zone " << modelObject.name().get());
-        
+
         IdfObject referencePoint(openstudio::IddObjectType::Daylighting_ReferencePoint);
         referencePoint.setName(modelObject.nameString() + " Daylighting Reference Point");
         m_idfObjects.push_back(referencePoint);
@@ -527,7 +527,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         group.push_back(""); // illuminance setpoint
         daylightingControlObject.pushExtensibleGroup(group);
       }
-      
+
 
       IdfObject illuminanceMapObject(openstudio::IddObjectType::Output_IlluminanceMap);
       m_idfObjects.push_back(illuminanceMapObject);
@@ -541,11 +541,11 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
       illuminanceMapObject.setDouble(Output_IlluminanceMapFields::XMinimumCoordinate, illuminanceMap->originXCoordinate());
       illuminanceMapObject.setDouble(Output_IlluminanceMapFields::XMaximumCoordinate, illuminanceMap->originXCoordinate() + illuminanceMap->xLength());
       illuminanceMapObject.setInt(Output_IlluminanceMapFields::NumberofXGridPoints, illuminanceMap->numberofXGridPoints());
-      
+
       illuminanceMapObject.setDouble(Output_IlluminanceMapFields::YMinimumCoordinate, illuminanceMap->originYCoordinate());
       illuminanceMapObject.setDouble(Output_IlluminanceMapFields::YMaximumCoordinate, illuminanceMap->originYCoordinate() + illuminanceMap->yLength());
       illuminanceMapObject.setInt(Output_IlluminanceMapFields::NumberofYGridPoints, illuminanceMap->numberofYGridPoints());
-      
+
       if (illuminanceMap->psiRotationAroundXAxis() != 0.0){
         LOG(Warn, "Rotation of " << illuminanceMap->psiRotationAroundXAxis() << " degrees about X axis not mapped for OS:IlluminanceMap " << illuminanceMap->name().get());
       }
@@ -640,11 +640,12 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
           }
         };
 
-        // Only translate ThermostatSetpointDualSetpoint if there are schedules attached
+        // Only translate ThermostatSetpointDualSetpoint if there is at least one schedule attached
+        // The translation to SingleHeating, SingleCooling, or DualSetpoint as appropriate is handled in ForwardTranslateThermostatSetpointDualSetpoint
         if( auto dualSetpoint = thermostat->optionalCast<ThermostatSetpointDualSetpoint>() ) {
-          if( dualSetpoint->heatingSetpointTemperatureSchedule() && dualSetpoint->coolingSetpointTemperatureSchedule() ) {
+          if( dualSetpoint->heatingSetpointTemperatureSchedule() || dualSetpoint->coolingSetpointTemperatureSchedule() ) {
             createZoneControlThermostat();
-          }  
+          }
         } else {
           createZoneControlThermostat();
         }
@@ -672,7 +673,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
 
     idealLoadsAirSystem.setString(HVACTemplate_Zone_IdealLoadsAirSystemFields::ZoneName,modelObject.name().get());
 
-    m_idfObjects.push_back(idealLoadsAirSystem); 
+    m_idfObjects.push_back(idealLoadsAirSystem);
   }
 
   // ZoneVentilationDesignFlowRate does not go on equipment connections or associated list
@@ -734,8 +735,8 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
     }
 
     // ZoneHVAC_EquipmentList
-    
-    ZoneHVACEquipmentList equipmentList = modelObject.getImpl<model::detail::ThermalZone_Impl>()->zoneHVACEquipmentList(); 
+
+    ZoneHVACEquipmentList equipmentList = modelObject.getImpl<model::detail::ThermalZone_Impl>()->zoneHVACEquipmentList();
 
     boost::optional<IdfObject> _equipmentList = translateAndMapModelObject(equipmentList);
 
@@ -747,7 +748,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
     }
   }
 
-  // SizingZone 
+  // SizingZone
 
   if( (zoneEquipment.size() > 0) || modelObject.useIdealAirLoads() )
   {
@@ -815,7 +816,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
               outdoorAirFlowRate = 0;
               //outdoorAirFlowAirChangesperHour = 0;
             }
-          
+
           }else{
             // sum
           }
@@ -859,7 +860,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             IdfObject zoneVentilation(IddObjectType::ZoneVentilation_DesignFlowRate);
             zoneVentilation.setName(modelObject.name().get() + " Ventilation per Floor Area");
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ZoneorZoneListName, modelObject.name().get());
-            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get()); 
+            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get());
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Area");
             zoneVentilation.setDouble(ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, outdoorAirFlowperFloorArea);
             m_idfObjects.push_back(zoneVentilation);
@@ -869,7 +870,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             IdfObject zoneVentilation(IddObjectType::ZoneVentilation_DesignFlowRate);
             zoneVentilation.setName(modelObject.name().get() + " Ventilation Rate");
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ZoneorZoneListName, modelObject.name().get());
-            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get()); 
+            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get());
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Zone");
             zoneVentilation.setDouble(ZoneVentilation_DesignFlowRateFields::DesignFlowRate, outdoorAirFlowRate);
             m_idfObjects.push_back(zoneVentilation);
@@ -879,7 +880,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             IdfObject zoneVentilation(IddObjectType::ZoneVentilation_DesignFlowRate);
             zoneVentilation.setName(modelObject.name().get() + " Ventilation Air Changes per Hour");
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ZoneorZoneListName, modelObject.name().get());
-            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get()); 
+            zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::ScheduleName, this->alwaysOnSchedule().name().get());
             zoneVentilation.setString(ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "AirChanges/Hour");
             zoneVentilation.setDouble(ZoneVentilation_DesignFlowRateFields::AirChangesperHour, outdoorAirFlowAirChangesperHour);
             m_idfObjects.push_back(zoneVentilation);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
@@ -46,6 +46,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
 {
   OptionalSchedule heat_sch = modelObject.getHeatingSchedule();
   OptionalSchedule cool_sch = modelObject.getCoolingSchedule();
+  boost::optional<IdfObject> result;
 
   // Two schedules = DualSetpoint
   if (heat_sch.is_initialized() && cool_sch.is_initialized()) {
@@ -67,7 +68,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
     translateAndMapModelObject(*cool_sch);
     thermostat.setString(ThermostatSetpoint_DualSetpointFields::CoolingSetpointTemperatureScheduleName,cool_sch->name().get());
 
-    return boost::optional<IdfObject>(thermostat);
+    result = thermostat;
 
   // Heating only
   } else if ( heat_sch.is_initialized() && !cool_sch.is_initialized() ) {
@@ -85,7 +86,8 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
     translateAndMapModelObject(*heat_sch);
     thermostat.setString(ThermostatSetpoint_SingleHeatingFields::SetpointTemperatureScheduleName, heat_sch->name().get());
 
-    return boost::optional<IdfObject>(thermostat);
+    result = thermostat;
+
 
   // Cooling only
   } else if ( !heat_sch.is_initialized() && cool_sch.is_initialized()) {
@@ -103,11 +105,12 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
     translateAndMapModelObject(*cool_sch);
     thermostat.setString(ThermostatSetpoint_SingleCoolingFields::SetpointTemperatureScheduleName, cool_sch->name().get());
 
-    return boost::optional<IdfObject>(thermostat);
+    result = thermostat;
 
   }
   // No other cases, in ForwardTranslateThermalZone, we have checked that there is at least one schedule
 
+  return result;
 
 }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
@@ -50,6 +50,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
   // Two schedules = DualSetpoint
   if (heat_sch.is_initialized() && cool_sch.is_initialized()) {
     IdfObject thermostat(openstudio::IddObjectType::ThermostatSetpoint_DualSetpoint);
+    m_idfObjects.push_back(thermostat);
 
     // Name
     OptionalString s = modelObject.name();
@@ -71,6 +72,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
   // Heating only
   } else if ( heat_sch.is_initialized() && !cool_sch.is_initialized() ) {
     IdfObject thermostat(openstudio::IddObjectType::ThermostatSetpoint_SingleHeating);
+    m_idfObjects.push_back(thermostat);
 
     // Name
     OptionalString s = modelObject.name();
@@ -88,6 +90,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
   // Cooling only
   } else if ( !heat_sch.is_initialized() && cool_sch.is_initialized()) {
     IdfObject thermostat(openstudio::IddObjectType::ThermostatSetpoint_SingleCooling);
+    m_idfObjects.push_back(thermostat);
 
     // Name
     OptionalString s = modelObject.name();

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermostatSetpointDualSetpoint.cpp
@@ -81,7 +81,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
 
     // (Heating) Setpoint Temperature Schedule Name
     translateAndMapModelObject(*heat_sch);
-    thermostat.setString(ThermostatSetpoint_SingleHeating_Fields::SetpointTemperatureScheduleName, heat_sch->name().get());
+    thermostat.setString(ThermostatSetpoint_SingleHeatingFields::SetpointTemperatureScheduleName, heat_sch->name().get());
 
     return boost::optional<IdfObject>(thermostat);
 
@@ -98,7 +98,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermostatSetpointDualSet
 
     // (Cooling) Setpoint Temperature Schedule Name
     translateAndMapModelObject(*cool_sch);
-    thermostat.setString(ThermostatSetpoint_SingleCooling_Fields::SetpointTemperatureScheduleName, cool_sch->name().get());
+    thermostat.setString(ThermostatSetpoint_SingleCoolingFields::SetpointTemperatureScheduleName, cool_sch->name().get());
 
     return boost::optional<IdfObject>(thermostat);
 

--- a/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
@@ -97,7 +97,10 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Two_Schedules)
   thermostat.setCoolingSetpointTemperatureSchedule(cool_sch);
 
   // Assign to zone
-  zone.setThermostatSetpointDualSetpoint(thermostat)
+  zone.setThermostatSetpointDualSetpoint(thermostat);
+
+  // You also need an equipment, or ideal Loads, or tstat's not translated
+  zone.setUseIdealAirLoads(true);
 
   ForwardTranslator ft;
   Workspace workspace = ft.translateModel(m);
@@ -116,8 +119,10 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Two_Schedules)
   IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
   ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
   IdfExtensibleGroup eg = idf_zone_control.extensibleGroups()[0];
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(),
+            idf_tstat.iddObject().name());
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(),
+            idf_tstat.name().get());
 
 }
 
@@ -151,7 +156,10 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Heat_Only)
   thermostat.setHeatingSetpointTemperatureSchedule(heat_sch);
 
   // Assign to zone
-  zone.setThermostatSetpointDualSetpoint(thermostat)
+  zone.setThermostatSetpointDualSetpoint(thermostat);
+
+  // You also need an equipment, or ideal Loads, or tstat's not translated
+  zone.setUseIdealAirLoads(true);
 
   ForwardTranslator ft;
   Workspace workspace = ft.translateModel(m);
@@ -167,9 +175,11 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Heat_Only)
 
   IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
   ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
-  eg = idf_zone_control.extensibleGroups()[0];
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+  IdfExtensibleGroup eg = idf_zone_control.extensibleGroups()[0];
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(),
+            idf_tstat.iddObject().name() );
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(),
+            idf_tstat.name().get() );
 
 }
 
@@ -205,6 +215,9 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Cool_Only)
   // Assign to zone
   zone.setThermostatSetpointDualSetpoint(thermostat);
 
+  // You also need an equipment, or ideal Loads, or tstat's not translated
+  zone.setUseIdealAirLoads(true);
+
   ForwardTranslator ft;
   Workspace workspace = ft.translateModel(m);
 
@@ -219,7 +232,10 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Cool_Only)
 
   IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
   ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
-  eg = idf_zone_control.extensibleGroups()[0];
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
-  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+
+  IdfExtensibleGroup eg = idf_zone_control.extensibleGroups()[0];
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(),
+            idf_tstat.iddObject().name() );
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(),
+            idf_tstat.name().get() );
 }

--- a/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
@@ -1,0 +1,230 @@
+/***********************************************************************************************************************
+ *  OpenStudio(R), Copyright (c) 2008-2017, Alliance for Sustainable Energy, LLC. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ *  following conditions are met:
+ *
+ *  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *  disclaimer.
+ *
+ *  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *  following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote
+ *  products derived from this software without specific prior written permission from the respective party.
+ *
+ *  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative
+ *  works may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without
+ *  specific prior written permission from Alliance for Sustainable Energy, LLC.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+#include "../ReverseTranslator.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/Space.hpp"
+#include "../../model/Space_Impl.hpp"
+#include "../../model/Surface.hpp"
+#include "../../model/Surface_Impl.hpp"
+#include "../../model/ThermalZone.hpp"
+#include "../../model/ThermalZone_Impl.hpp"
+
+#include "../../model/ThermostatSetpointDualSetpoint.hpp"
+#include "../../model/ThermostatSetpointDualSetpoint_Impl.hpp"
+
+#include "../../model/ScheduleRuleset.hpp"
+#include "../../model/ScheduleRuleset_Impl.hpp"
+
+#include <utilities/idd/ThermostatSetpoint_DualSetpoint_FieldEnums.hxx>
+#include <utilities/idd/ThermostatSetpoint_SingleHeating_FieldEnums.hxx>
+#include <utilities/idd/ThermostatSetpoint_SingleCooling_FieldEnums.hxx>
+#include <utilities/idd/ZoneControl_Thermostat_FieldEnums.hxx>
+#include <utilities/idd/IddEnums.hxx>
+
+#include <resources.hxx>
+
+#include <sstream>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+/** Case when you defined both a heating and cooling schedule for the thermostat.
+ * Should end up as a ThermostatSetpoint:DualSetpoint in the IDF
+ **/
+TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Two_Schedules)
+{
+  Model m;
+
+  Point3dVector points;
+  points.push_back(Point3d(0, 0, 0));
+  points.push_back(Point3d(0, 1, 0));
+  points.push_back(Point3d(1, 1, 0));
+  points.push_back(Point3d(1, 0, 0));
+
+  ThermalZone zone(m);
+
+  Space space1(m);
+  space1.setThermalZone(zone);
+
+  Surface surface1(points, model);
+  surface1.setSpace(space1);
+
+  Surface surface2(points, model);
+  surface2.setSpace(space2);
+
+  // Create a thermostat
+  ThermostatSetpointDualSetpoint thermostat(m);
+
+  // Add Heating Setpoint Schedule
+  ScheduleRuleset heat_sch = ScheduleRuleset(m, 18.0);
+  thermostat.setHeatingSetpointTemperatureSchedule(heat_sch);
+
+  // Add Cooling Setpoint Schedule
+  ScheduleRuleset cool_sch = ScheduleRuleset(m, 26.0);
+  thermostat.setCoolingSetpointTemperatureSchedule(cool_sch);
+
+  // Assign to zone
+  zone.setThermostatSetpointDualSetpoint(thermostat)
+
+  ForwardTranslator ft;
+  Workspace workspace = ft.translateModel(m);
+
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::Zone).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_DualSetpoint).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat).size());
+
+  IdfObject idf_tstat = workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_DualSetpoint)[0];
+
+  ASSERT_EQ(idf_tstat.getString(ThermostatSetpoint_DualSetpointFields::HeatingSetpointTemperatureScheduleName).get(),
+            heat_sch.name());
+  ASSERT_EQ(idf_tstat.getString(ThermostatSetpoint_DualSetpointFields::CoolingSetpointTemperatureScheduleName).get(),
+            cool_sch.name());
+
+  IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
+  ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
+  eg = idf_zone_control.extensibleGroups()[0];
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+
+}
+
+
+/** Case where you defined only a heating schedule for the thermostat.
+ * Should end up as a ThermostatSetpoint:SingleHeating in the IDF
+ **/
+TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Heat_Only)
+{
+  Model m;
+
+  Point3dVector points;
+  points.push_back(Point3d(0, 0, 0));
+  points.push_back(Point3d(0, 1, 0));
+  points.push_back(Point3d(1, 1, 0));
+  points.push_back(Point3d(1, 0, 0));
+
+  ThermalZone zone(m);
+
+  Space space1(m);
+  space1.setThermalZone(zone);
+
+  Surface surface1(points, model);
+  surface1.setSpace(space1);
+
+  Surface surface2(points, model);
+  surface2.setSpace(space2);
+
+  // Create a thermostat
+  ThermostatSetpointDualSetpoint thermostat(m);
+
+  // Add Heating Setpoint Schedule
+  ScheduleRuleset heat_sch = ScheduleRuleset(m, 18.0);
+  thermostat.setHeatingSetpointTemperatureSchedule(heat_sch);
+
+  // Assign to zone
+  zone.setThermostatSetpointDualSetpoint(thermostat)
+
+  ForwardTranslator ft;
+  Workspace workspace = ft.translateModel(m);
+
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::Zone).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_SingleHeating).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat).size());
+
+  IdfObject idf_tstat = workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_SingleHeating)[0];
+
+  ASSERT_EQ(idf_tstat.getString(ThermostatSetpoint_SingleHeatingFields::SetpointTemperatureScheduleName).get(),
+            heat_sch.name());
+
+  IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
+  ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
+  eg = idf_zone_control.extensibleGroups()[0];
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+
+}
+
+
+/** Case where you defined only a cooling schedule for the thermostat.
+ * Should end up as a ThermostatSetpoint:SingleCooling in the IDF
+ **/
+TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Cool_Only)
+{
+  Model m;
+
+  Point3dVector points;
+  points.push_back(Point3d(0, 0, 0));
+  points.push_back(Point3d(0, 1, 0));
+  points.push_back(Point3d(1, 1, 0));
+  points.push_back(Point3d(1, 0, 0));
+
+  ThermalZone zone(m);
+
+  Space space1(m);
+  space1.setThermalZone(zone);
+
+  Surface surface1(points, model);
+  surface1.setSpace(space1);
+
+  Surface surface2(points, model);
+  surface2.setSpace(space2);
+
+  // Create a thermostat
+  ThermostatSetpointDualSetpoint thermostat(m);
+
+  // Add Cooling Setpoint Schedule
+  ScheduleRuleset cool_sch = ScheduleRuleset(m, 26.0);
+  thermostat.setCoolingSetpointTemperatureSchedule(cool_sch);
+
+  // Assign to zone
+  zone.setThermostatSetpointDualSetpoint(thermostat)
+
+  ForwardTranslator ft;
+  Workspace workspace = ft.translateModel(m);
+
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::Zone).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_SingleCooling).size());
+  EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat).size());
+
+  IdfObject idf_tstat = workspace.getObjectsByType(IddObjectType::ThermostatSetpoint_SingleCooling)[0];
+
+  ASSERT_EQ(idf_tstat.getString(ThermostatSetpoint_SingleCoolingFields::SetpointTemperatureScheduleName).get(),
+            cool_sch.name());
+
+  IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
+  ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
+  eg = idf_zone_control.extensibleGroups()[0];
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
+  ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
+}

--- a/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ThermostatSetpointDualSetpoint_GTest.cpp
@@ -46,6 +46,10 @@
 #include "../../model/ScheduleRuleset.hpp"
 #include "../../model/ScheduleRuleset_Impl.hpp"
 
+#include "../../utilities/idf/IdfObject.hpp"
+#include "../../utilities/idf/IdfExtensibleGroup.hpp"
+
+
 #include <utilities/idd/ThermostatSetpoint_DualSetpoint_FieldEnums.hxx>
 #include <utilities/idd/ThermostatSetpoint_SingleHeating_FieldEnums.hxx>
 #include <utilities/idd/ThermostatSetpoint_SingleCooling_FieldEnums.hxx>
@@ -78,11 +82,8 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Two_Schedules)
   Space space1(m);
   space1.setThermalZone(zone);
 
-  Surface surface1(points, model);
+  Surface surface1(points, m);
   surface1.setSpace(space1);
-
-  Surface surface2(points, model);
-  surface2.setSpace(space2);
 
   // Create a thermostat
   ThermostatSetpointDualSetpoint thermostat(m);
@@ -114,7 +115,7 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Two_Schedules)
 
   IdfObject idf_zone_control = workspace.getObjectsByType(IddObjectType::ZoneControl_Thermostat)[0];
   ASSERT_EQ(1u, idf_zone_control.extensibleGroups().size());
-  eg = idf_zone_control.extensibleGroups()[0];
+  IdfExtensibleGroup eg = idf_zone_control.extensibleGroups()[0];
   ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlObjectType).get(), idf_tstat.iddObject().name());
   ASSERT_EQ(eg.getString(ZoneControl_ThermostatExtensibleFields::ControlName).get(), idf_tstat.name().get());
 
@@ -139,11 +140,8 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Heat_Only)
   Space space1(m);
   space1.setThermalZone(zone);
 
-  Surface surface1(points, model);
+  Surface surface1(points, m);
   surface1.setSpace(space1);
-
-  Surface surface2(points, model);
-  surface2.setSpace(space2);
 
   // Create a thermostat
   ThermostatSetpointDualSetpoint thermostat(m);
@@ -194,11 +192,8 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Cool_Only)
   Space space1(m);
   space1.setThermalZone(zone);
 
-  Surface surface1(points, model);
+  Surface surface1(points, m);
   surface1.setSpace(space1);
-
-  Surface surface2(points, model);
-  surface2.setSpace(space2);
 
   // Create a thermostat
   ThermostatSetpointDualSetpoint thermostat(m);
@@ -208,7 +203,7 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_Thermostat_Cool_Only)
   thermostat.setCoolingSetpointTemperatureSchedule(cool_sch);
 
   // Assign to zone
-  zone.setThermostatSetpointDualSetpoint(thermostat)
+  zone.setThermostatSetpointDualSetpoint(thermostat);
 
   ForwardTranslator ft;
   Workspace workspace = ft.translateModel(m);

--- a/openstudiocore/src/energyplus/Test/ZoneHVACLowTemperatureRadiantConstFlow_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ZoneHVACLowTemperatureRadiantConstFlow_GTest.cpp
@@ -67,7 +67,7 @@ using namespace openstudio::energyplus;
 using namespace openstudio::model;
 using namespace openstudio;
 
-TEST_F(EnergyPlusFixture,ZoneHVACLowTempRadiantConstFlow_Set_Flow_Fractions) 
+TEST_F(EnergyPlusFixture,ZoneHVACLowTempRadiantConstFlow_Set_Flow_Fractions)
 {
   //make the example model
   Model model = model::exampleModel();
@@ -85,7 +85,7 @@ TEST_F(EnergyPlusFixture,ZoneHVACLowTempRadiantConstFlow_Set_Flow_Fractions)
     ScheduleConstant heatingLowWaterTempSched(model);
     ScheduleConstant heatingHighControlTempSched(model);
     ScheduleConstant heatingLowControlTempSched(model);
-  
+
     availabilitySched.setValue(1.0);
     coolingHighWaterTempSched.setValue(15.0);
     coolingLowWaterTempSched.setValue(10.0);
@@ -104,14 +104,14 @@ TEST_F(EnergyPlusFixture,ZoneHVACLowTempRadiantConstFlow_Set_Flow_Fractions)
     //set the coils
     testRad.setHeatingCoil(testHC);
     testRad.setCoolingCoil(testCC);
-    
+
     //add it to the thermal zone
     testRad.addToThermalZone(thermalZone);
 
     //attach to ceilings
     testRad.setRadiantSurfaceType("Ceilings");
 
-    //test that "surfaces" method returns 0 since no 
+    //test that "surfaces" method returns 0 since no
     //ceilings have an internal source construction
     EXPECT_EQ(0,testRad.surfaces().size());
 
@@ -147,6 +147,6 @@ TEST_F(EnergyPlusFixture,ZoneHVACLowTempRadiantConstFlow_Set_Flow_Fractions)
     }
   }
 
-} 
+}
 
 


### PR DESCRIPTION
Fix #2379.

Modified the forward translator to handle zone thermostats with Heating Schedule and/or cooling schedules in the underlying OS_ThermostatSetpoint_DualSetpoint

* If only a Heating Schedule is specified, IDF has a `ThermostatSetpoint:SingleHeating`
* If only a Cooling Schedule is specified, IDF has a `ThermostatSetpoint:SingleCooling`
* If both Schedules are specified, IDF has a `ThermostatSetpoint:DualSetpoint`

I added a completely new Forward Translator Gtest for this as well.

Review assignee: @kbenne (original assignee in #2379)