### PR TITLE
Fix #2215 make ZoneVentilationDesignFlowRate behave like SpaceInfiltrationDesignFlowRate (switch the flow rate calc method automatically)

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.7.0)
 cmake_policy(SET CMP0048 NEW)
 
+# Use ccache is available, has to be before "project()"
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  # Support Unix Makefiles and Ninja
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+
 project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
 include(CPackComponent)
+include(CheckCXXCompilerFlag)
 
 if( POLICY CMP0022 )
   cmake_policy(SET CMP0022 NEW)
@@ -314,6 +323,19 @@ if(MSVC)
   # ignore warnings about the stl being insecure
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 
+endif()
+
+# Add Color Output if Using Ninja
+macro(AddCXXFlagIfSupported flag test)
+   CHECK_CXX_COMPILER_FLAG(${flag} ${test})
+   if( ${${test}} )
+      message("adding ${flag}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+   endif()
+endmacro()
+
+if("Ninja" STREQUAL ${CMAKE_GENERATOR})
+   AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
 endif()
 ###############################################################################
 
@@ -649,6 +671,14 @@ endif()
 
 # SWIG
 
+# Xcode/Ninja generators undefined MAKE
+if(CMAKE_GENERATOR MATCHES "Make")
+  set(MAKE "$(MAKE)")
+else()
+  set(MAKE make)
+endif()
+
+
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
@@ -656,8 +686,8 @@ if(UNIX)
     URL_MD5 7fff46c84b8c630ede5b0f0827e3d90a
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
+    BUILD_COMMAND ${MAKE}
+    INSTALL_COMMAND ${MAKE} install
     BUILD_IN_SOURCE 1
   )
   set(SWIG_EXECUTABLE ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)

--- a/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
+++ b/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
@@ -542,11 +542,9 @@ ZoneVentilationDesignFlowRate::ZoneVentilationDesignFlowRate(const Model& model)
     setSchedule(schedule);
   }
 
-  setDesignFlowRateCalculationMethod("AirChanges/Hour");
-  setDesignFlowRate(0.0);
-  setFlowRateperZoneFloorArea(0.0);
-  setFlowRateperPerson(0.0);
+  // This automatically switches the Calculation Method to "AirChanges/Hour"
   setAirChangesperHour(5.0);
+
   setVentilationType("Natural");
   setFanPressureRise(0.0);
   setFanTotalEfficiency(1.0);

--- a/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
+++ b/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
@@ -270,17 +270,19 @@ namespace detail {
     bool result = true;
     if (designFlowRate < 0){
       result = false;
-    }else{
-      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Zone");
-      OS_ASSERT(result);
+    } else {
+      // This is the only case where it could really fail, if the user passed NaN/Inf
       result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, designFlowRate);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
-      OS_ASSERT(result);
+      if (result) {
+        result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Zone");
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+        OS_ASSERT(result);
+      }
     }
     return result;
   }
@@ -289,17 +291,18 @@ namespace detail {
     bool result = true;
     if (flowRateperZoneFloorArea < 0){
       result = false;
-    }else{
-      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Area");
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
-      OS_ASSERT(result);
+    } else {
       result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, flowRateperZoneFloorArea);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
-      OS_ASSERT(result);
+      if (result) {
+        result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Area");
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+        OS_ASSERT(result);
+      }
     }
     return result;
   }
@@ -308,17 +311,18 @@ namespace detail {
     bool result = true;
     if (flowRateperPerson < 0){
       result = false;
-    }else{
-      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Person");
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
-      OS_ASSERT(result);
+    } else {
       result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, flowRateperPerson);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
-      OS_ASSERT(result);
+      if (result) {
+        result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Person");
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+        OS_ASSERT(result);
+      }
     }
     return result;
   }
@@ -327,17 +331,18 @@ namespace detail {
     bool result = true;
     if (airChangesperHour < 0){
       result = false;
-    }else{
-      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "AirChanges/Hour");
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
-      OS_ASSERT(result);
-      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
-      OS_ASSERT(result);
+    } else {
       result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, airChangesperHour);
-      OS_ASSERT(result);
+      if (result) {
+        result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "AirChanges/Hour");
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+        OS_ASSERT(result);
+        result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+        OS_ASSERT(result);
+      }
     }
     return result;
   }

--- a/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
+++ b/openstudiocore/src/model/ZoneVentilationDesignFlowRate.cpp
@@ -28,6 +28,7 @@
 
 #include "ZoneVentilationDesignFlowRate.hpp"
 #include "ZoneVentilationDesignFlowRate_Impl.hpp"
+
 #include "Schedule.hpp"
 #include "Schedule_Impl.hpp"
 #include "ThermalZone.hpp"
@@ -37,6 +38,7 @@
 #include "ZoneHVACEquipmentList_Impl.hpp"
 #include "ScheduleTypeLimits.hpp"
 #include "ScheduleTypeRegistry.hpp"
+
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include <utilities/idd/OS_ZoneVentilation_DesignFlowRate_FieldEnums.hxx>
@@ -259,27 +261,84 @@ namespace detail {
   }
 
   bool ZoneVentilationDesignFlowRate_Impl::setDesignFlowRateCalculationMethod(std::string designFlowRateCalculationMethod) {
+    LOG(Warn, "ZoneVentilationDesignFlowRate::setDesignFlowRateCalculationMethod has been deprecated and will be removed in a future release, the design flow rate calculation method is set during the call to setDesignFlowRate, setFlowRateperZoneFloorArea, setAirChangesperHour, etc");
     bool result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, designFlowRateCalculationMethod);
     return result;
   }
 
   bool ZoneVentilationDesignFlowRate_Impl::setDesignFlowRate(double designFlowRate) {
-    bool result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, designFlowRate);
+    bool result = true;
+    if (designFlowRate < 0){
+      result = false;
+    }else{
+      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Zone");
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, designFlowRate);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+      OS_ASSERT(result);
+    }
     return result;
   }
 
   bool ZoneVentilationDesignFlowRate_Impl::setFlowRateperZoneFloorArea(double flowRateperZoneFloorArea) {
-    bool result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, flowRateperZoneFloorArea);
+    bool result = true;
+    if (flowRateperZoneFloorArea < 0){
+      result = false;
+    }else{
+      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Area");
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, flowRateperZoneFloorArea);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+      OS_ASSERT(result);
+    }
     return result;
   }
 
   bool ZoneVentilationDesignFlowRate_Impl::setFlowRateperPerson(double flowRateperPerson) {
-    bool result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, flowRateperPerson);
+    bool result = true;
+    if (flowRateperPerson < 0){
+      result = false;
+    }else{
+      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "Flow/Person");
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, flowRateperPerson);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, 0.0);
+      OS_ASSERT(result);
+    }
     return result;
   }
 
   bool ZoneVentilationDesignFlowRate_Impl::setAirChangesperHour(double airChangesperHour) {
-    bool result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, airChangesperHour);
+    bool result = true;
+    if (airChangesperHour < 0){
+      result = false;
+    }else{
+      result = setString(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRateCalculationMethod, "AirChanges/Hour");
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::DesignFlowRate, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperZoneFloorArea, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::FlowRateperPerson, 0.0);
+      OS_ASSERT(result);
+      result = setDouble(OS_ZoneVentilation_DesignFlowRateFields::AirChangesperHour, airChangesperHour);
+      OS_ASSERT(result);
+    }
     return result;
   }
 

--- a/openstudiocore/src/model/ZoneVentilationDesignFlowRate.hpp
+++ b/openstudiocore/src/model/ZoneVentilationDesignFlowRate.hpp
@@ -31,6 +31,7 @@
 
 #include "ModelAPI.hpp"
 #include "ZoneHVACComponent.hpp"
+#include "../utilities/core/Deprecated.hpp"
 
 namespace openstudio {
 
@@ -119,7 +120,10 @@ class MODEL_API ZoneVentilationDesignFlowRate : public ZoneHVACComponent {
 
   bool setSchedule(Schedule& schedule);
 
-  bool setDesignFlowRateCalculationMethod(std::string designFlowRateCalculationMethod);
+  /** \deprecated ZoneVentilationDesignFlowRate::setDesignFlowRateCalculationMethod has been deprecated and will be removed in a future release, \n
+   *  the design flow rate calculation method is set during the call to setDesignFlowRate, setFlowRateperZoneFloorArea, setAirChangesperHour, etc
+   **/
+  OS_DEPRECATED bool setDesignFlowRateCalculationMethod(std::string designFlowRateCalculationMethod);
 
   bool setDesignFlowRate(double designFlowRate);
 

--- a/openstudiocore/src/model/test/ZoneVentilationDesignFlowRate_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneVentilationDesignFlowRate_GTest.cpp
@@ -40,13 +40,56 @@ TEST_F(ModelFixture,ZoneVentilationDesignFlowRate)
 {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-  ASSERT_EXIT ( 
-  {  
-     Model m; 
-     ZoneVentilationDesignFlowRate zv(m); 
+  ASSERT_EXIT (
+  {
+     Model m;
+     ZoneVentilationDesignFlowRate zv(m);
 
-     exit(0); 
+     exit(0);
   } ,
     ::testing::ExitedWithCode(0), "" );
 }
+
+/** Tests that the designFlowRateCalculationMethod is set appropriately and the other inputs cleared
+ * when using the setXXX methods for flow rates
+ */
+TEST_F(ModelFixture,ZoneVentilationDesignFlowRate_setFlow)
+{
+  Model m;
+
+  ZoneVentilationDesignFlowRate zv(m);
+
+  // Flow/Zone
+  ASSERT_TRUE(zv.setDesignFlowRate(12.05));
+  EXPECT_DOUBLE_EQ(12.05, zv.designFlowRate());
+  ASSERT_EQ("Flow/Zone", zv.designFlowRateCalculationMethod());
+  ASSERT_FALSE(zv.flowRateperZoneFloorArea());
+  ASSERT_FALSE(zv.flowRateperPerson());
+  ASSERT_FALSE(zv.airChangesperHour());
+
+  // Flow/Area
+  ASSERT_TRUE(zv.setFlowRateperZoneFloorArea(10.05));
+  EXPECT_DOUBLE_EQ(10.05, zv.flowRateperZoneFloorArea());
+  ASSERT_EQ("Flow/Area", zv.designFlowRateCalculationMethod());
+  ASSERT_FALSE(zv.designFlowRate());
+  ASSERT_FALSE(zv.flowRateperPerson());
+  ASSERT_FALSE(zv.airChangesperHour());
+
+  // Flow/Person
+  ASSERT_TRUE(zv.setFlowRateperPerson(15.5));
+  EXPECT_DOUBLE_EQ(15.5, zv.flowRateperPerson());
+  ASSERT_EQ("Flow/Person", zv.designFlowRateCalculationMethod());
+  ASSERT_FALSE(zv.designFlowRate());
+  ASSERT_FALSE(zv.flowRateperZoneFloorArea());
+  ASSERT_FALSE(zv.airChangesperHour());
+
+  // AirChanges/Hour
+  ASSERT_TRUE(zv.setFlowRateperZoneFloorArea(1.05));
+  EXPECT_DOUBLE_EQ(1.05, zv.airChangesperHour());
+  ASSERT_EQ("AirChanges/Hour", zv.designFlowRateCalculationMethod());
+  ASSERT_FALSE(zv.designFlowRate());
+  ASSERT_FALSE(zv.flowRateperZoneFloorArea());
+  ASSERT_FALSE(zv.flowRateperPerson());
+}
+
 

--- a/openstudiocore/src/model/test/ZoneVentilationDesignFlowRate_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneVentilationDesignFlowRate_GTest.cpp
@@ -84,7 +84,7 @@ TEST_F(ModelFixture,ZoneVentilationDesignFlowRate_setFlow)
   ASSERT_FALSE(zv.airChangesperHour());
 
   // AirChanges/Hour
-  ASSERT_TRUE(zv.setFlowRateperZoneFloorArea(1.05));
+  ASSERT_TRUE(zv.setAirChangesperHour(1.05));
   EXPECT_DOUBLE_EQ(1.05, zv.airChangesperHour());
   ASSERT_EQ("AirChanges/Hour", zv.designFlowRateCalculationMethod());
   ASSERT_FALSE(zv.designFlowRate());


### PR DESCRIPTION
Fix #2215 (also tested #833 and got it closed by David)

Deprecated the `ZoneVentilationDesignFlowRate::setDesignFlowRateCalculationMethod`, and make it behave like SpaceInfiltrationDesignFlowRate:

if you call setAirChangesperHour(double), it will automatically set the CalculationMethod to "AirChanges/Hour" and put all of other fields as 0.0  (fyi, in SpaceInfiltration, the others are actually optional, and have a default value... )


review assignee: @asparke2 (original #2215 assigned)
