### PR TITLE
Ninja ccache

### DIFF
--- a/developer/msvc/Visualizers/concat_natvis.py
+++ b/developer/msvc/Visualizers/concat_natvis.py
@@ -1,0 +1,59 @@
+"""
+This small snippet will open all the *.natvis files and concat them into a
+single one to be able to use them in Visual Studio Code (for Mac for eg)
+vscode-cpptools expects only one visualizerFile currently
+"""
+
+import xml.etree.ElementTree as ET
+import glob as gb
+
+OUT_FILENAME = 'all_concat.natvis'
+
+
+def concat_all_natvis_files():
+    """
+    Main function
+    """
+    natvis_files = gb.glob('*.natvis')
+    if OUT_FILENAME in natvis_files:
+        natvis_files.remove(OUT_FILENAME)
+
+    # In order to avoid the ns0 prefix the default namespace should be set
+    schema = 'http://schemas.microsoft.com/vstudio/debugger/natvis/2010'
+    # before reading the XML data.
+    ET.register_namespace('', schema)
+
+    # Open the file first found
+    print("Opening first: {}".format(natvis_files[0]))
+    tree = ET.parse(natvis_files[0])
+    root = tree.getroot()
+
+    ori_n_child = len(root)
+    total_n_child = ori_n_child
+
+    # Loop on the rest
+    for fname in natvis_files[1:]:
+        tree2 = ET.parse(fname)
+        root2 = tree2.getroot()
+        n_child = len(root2)
+        print("Parsing '{}', {} children".format(fname, n_child))
+        total_n_child += n_child
+        # Append each child or root2 to the first root
+        for child in root2.iter():
+            root.append(child)
+
+    final_n_child = len(root)
+    if final_n_child == total_n_child:
+        print("\nOK: Started with {}, Ended with {} children as "
+              "expected".format(ori_n_child, final_n_child))
+    else:
+        print("\nProblem: Started with {}, Ended with {} children, "
+              "expected {}".format(ori_n_child, final_n_child, total_n_child))
+
+    print("\nSaving to {}".format(OUT_FILENAME))
+    tree.write(OUT_FILENAME, encoding='utf-8', xml_declaration=True)
+
+
+# If run from a terminal
+if __name__ == '__main__':
+    concat_all_natvis_files()

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -13,6 +13,7 @@ project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
 include(CPackComponent)
+include(CheckCXXCompilerFlag)
 
 if( POLICY CMP0022 )
   cmake_policy(SET CMP0022 NEW)
@@ -322,6 +323,19 @@ if(MSVC)
   # ignore warnings about the stl being insecure
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 
+endif()
+
+# Add Color Output if Using Ninja
+macro(AddCXXFlagIfSupported flag test)
+   CHECK_CXX_COMPILER_FLAG(${flag} ${test})
+   if( ${${test}} )
+      message("adding ${flag}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+   endif()
+endmacro()
+
+if("Ninja" STREQUAL ${CMAKE_GENERATOR})
+   AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
 endif()
 ###############################################################################
 

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -335,9 +335,20 @@ macro(AddCXXFlagIfSupported flag test)
 endmacro()
 
 if("Ninja" STREQUAL ${CMAKE_GENERATOR})
-   AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
+  # Clang
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
+  endif()
+
+  # g++
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # For some reason it doesn't say its supported, but it works...
+    # AddCXXFlagIfSupported(-fdiagnostics-color COMPILER_SUPPORTS_fdiagnostics-color)
+    message("Forcing -fdiagnostics-color=always")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  endif()
 endif()
-###############################################################################
+##############################################################################
 
 
 ###############################################################################

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.7.0)
 cmake_policy(SET CMP0048 NEW)
 
+# Use ccache is available, has to be before "project()"
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  # Support Unix Makefiles and Ninja
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+
 project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
@@ -649,6 +657,14 @@ endif()
 
 # SWIG
 
+# Xcode/Ninja generators undefined MAKE
+if(CMAKE_GENERATOR MATCHES "Make")
+  set(MAKE "$(MAKE)")
+else()
+  set(MAKE make)
+endif()
+
+
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
@@ -656,8 +672,8 @@ if(UNIX)
     URL_MD5 7fff46c84b8c630ede5b0f0827e3d90a
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
+    BUILD_COMMAND ${MAKE}
+    INSTALL_COMMAND ${MAKE} install
     BUILD_IN_SOURCE 1
   )
   set(SWIG_EXECUTABLE ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)


### PR DESCRIPTION
Enables usage of [ccache](24a0608839d046bb2c8c239c778b7c6fc56935c0) and the [Ninja Generator](https://ninja-build.org/), and add color output when building with Ninja.

This has been speeding up my build time quite a lot, probably most of it is due to ccache. The first build is a bit slower (builds the cache), but when rebuilding or even switching branches (unless you have an IDD change of course...) it goes much much faster.