### PR TITLE
Fix 2749 2275 plant op logic

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.7.0)
 cmake_policy(SET CMP0048 NEW)
 
+# Use ccache is available, has to be before "project()"
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  # Support Unix Makefiles and Ninja
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+
 project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
 include(CPackComponent)
+include(CheckCXXCompilerFlag)
 
 if( POLICY CMP0022 )
   cmake_policy(SET CMP0022 NEW)
@@ -315,7 +324,31 @@ if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 
 endif()
-###############################################################################
+
+# Add Color Output if Using Ninja
+macro(AddCXXFlagIfSupported flag test)
+   CHECK_CXX_COMPILER_FLAG(${flag} ${test})
+   if( ${${test}} )
+      message("adding ${flag}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+   endif()
+endmacro()
+
+if("Ninja" STREQUAL ${CMAKE_GENERATOR})
+  # Clang
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
+  endif()
+
+  # g++
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # For some reason it doesn't say its supported, but it works...
+    # AddCXXFlagIfSupported(-fdiagnostics-color COMPILER_SUPPORTS_fdiagnostics-color)
+    message("Forcing -fdiagnostics-color=always")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  endif()
+endif()
+##############################################################################
 
 
 ###############################################################################
@@ -649,6 +682,14 @@ endif()
 
 # SWIG
 
+# Xcode/Ninja generators undefined MAKE
+if(CMAKE_GENERATOR MATCHES "Make")
+  set(MAKE "$(MAKE)")
+else()
+  set(MAKE make)
+endif()
+
+
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
@@ -656,8 +697,8 @@ if(UNIX)
     URL_MD5 7fff46c84b8c630ede5b0f0827e3d90a
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
+    BUILD_COMMAND ${MAKE}
+    INSTALL_COMMAND ${MAKE} install
     BUILD_IN_SOURCE 1
   )
   set(SWIG_EXECUTABLE ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)

--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -516,6 +516,8 @@ set(${target_name}_test_src
   Test/Luminaire_GTest.cpp
   Test/Meter_GTest.cpp
   Test/People_GTest.cpp
+  Test/PlantEquipmentOperationSchemes_GTest.cpp
+
   Test/RunPeriodControlDaylightSavingTime_GTest.cpp
   Test/ScheduleInterval_GTest.cpp
   Test/ScheduleRuleset_GTest.cpp

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
@@ -381,7 +381,7 @@ ComponentType componentType(const HVACComponent & component)
             return plantLoopType(_p.get());
 
           } else {
-            // It isn't connected to a source side, and has zero capacity => it's NONE
+            // It isn't connected to a source side, and has zero capacity => it's a buffer tank => NONE
             return ComponentType::NONE;
           } // End if has source loop
 
@@ -410,7 +410,7 @@ ComponentType componentType(const HVACComponent & component)
               // Here we go check what's on the supply side of the secondary plantLoop
               return plantLoopType(_p.get());
             } else {
-              // It isn't connected to a source side, and has zero capacity => it's NONE
+              // It isn't connected to a source side, and has zero capacity => it's a buffer tank => NONE
               return ComponentType::NONE;
             }
           }

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
@@ -70,6 +70,8 @@
 #include "../../model/SetpointManager_Impl.hpp"
 #include "../../model/Schedule.hpp"
 #include "../../model/Schedule_Impl.hpp"
+#include "../../model/ThermalStorageChilledWaterStratified.hpp"
+#include "../../model/ThermalStorageChilledWaterStratified_Impl.hpp"
 #include "../../model/WaterHeaterMixed.hpp"
 #include "../../model/WaterHeaterMixed_Impl.hpp"
 #include "../../model/WaterHeaterStratified.hpp"
@@ -197,6 +199,12 @@ boost::optional<double> flowrate(const HVACComponent & component)
     {
       auto chiller = component.cast<ChillerAbsorption>();
       result = chiller.designChilledWaterFlowRate();
+      break;
+    }
+    case openstudio::IddObjectType::OS_ThermalStorage_ChilledWater_Stratified :
+    {
+      ThermalStorageChilledWaterStratified ts = component.cast<ThermalStorageChilledWaterStratified>();
+      result = ts.useSideDesignFlowRate();
       break;
     }
     case openstudio::IddObjectType::OS_ThermalStorage_Ice_Detailed :
@@ -436,8 +444,13 @@ ComponentType componentType(const HVACComponent & component)
     {
       return ComponentType::COOLING;
     }
+    case openstudio::IddObjectType::OS_ThermalStorage_ChilledWater_Stratified :
+    {
+      return ComponentType::COOLING;
+    }
     case openstudio::IddObjectType::OS_ThermalStorage_Ice_Detailed :
     {
+      // TODO: Are you sure about this @kbenne?
       return ComponentType::BOTH;
     }
     case openstudio::IddObjectType::OS_DistrictCooling :

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSizingPlant.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSizingPlant.cpp
@@ -66,7 +66,7 @@ PlantSizingType plantSizingType(const ModelObject & component)
     case openstudio::IddObjectType::OS_DistrictHeating :
     {
       return PlantSizingType::HOTWATER;
-    }      
+    }
     case openstudio::IddObjectType::OS_Chiller_Electric_EIR :
     {
       return PlantSizingType::CHILLEDWATER;
@@ -86,7 +86,7 @@ PlantSizingType plantSizingType(const ModelObject & component)
     case openstudio::IddObjectType::OS_DistrictCooling :
     {
       return PlantSizingType::CHILLEDWATER;
-    }      
+    }
     case openstudio::IddObjectType::OS_CoolingTower_SingleSpeed :
     {
       return PlantSizingType::CONDENSER;
@@ -131,7 +131,7 @@ boost::optional<IdfObject> ForwardTranslator::translateSizingPlant( SizingPlant 
 
   if( (modelObject.designLoopExitTemperature() < 0.01) && (modelObject.loopDesignTemperatureDifference() < 0.01) )
   {
-    const auto & components = modelObject.plantLoop().supplyComponents(); 
+    const auto & components = modelObject.plantLoop().supplyComponents();
     if( std::find_if(components.begin(),components.end(),condensorCheck) != components.end() ) {
       modelObject.setLoopType("Condenser");
       modelObject.setDesignLoopExitTemperature(29.4);
@@ -167,7 +167,7 @@ boost::optional<IdfObject> ForwardTranslator::translateSizingPlant( SizingPlant 
   {
     idfObject.setString(Sizing_PlantFields::LoopType,s.get());
   }
-  
+
   // DesignLoopExitTemperature
 
   value = modelObject.designLoopExitTemperature();

--- a/openstudiocore/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
@@ -1,0 +1,309 @@
+/***********************************************************************************************************************
+ *  OpenStudio(R), Copyright (c) 2008-2017, Alliance for Sustainable Energy, LLC. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ *  following conditions are met:
+ *
+ *  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *  disclaimer.
+ *
+ *  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *  following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote
+ *  products derived from this software without specific prior written permission from the respective party.
+ *
+ *  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative
+ *  works may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without
+ *  specific prior written permission from Alliance for Sustainable Energy, LLC.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/PlantLoop.hpp"
+#include "../../model/Node.hpp"
+
+
+#include "../../model/HeatExchangerFluidToFluid.hpp"
+// #include "../../model/HeatExchangerFluidToFluid_Impl.hpp"
+#include "../../model/WaterHeaterMixed.hpp"
+
+#include "../../model/BoilerHotWater.hpp"
+
+#include <utilities/idd/PlantLoop_FieldEnums.hxx>
+#include <utilities/idd/PlantEquipmentOperationSchemes_FieldEnums.hxx>
+
+#include <utilities/idd/PlantEquipmentOperation_HeatingLoad_FieldEnums.hxx>
+#include <utilities/idd/PlantEquipmentOperation_CoolingLoad_FieldEnums.hxx>
+#include <utilities/idd/PlantEquipmentOperation_Uncontrolled_FieldEnums.hxx>
+
+#include <utilities/idd/PlantEquipmentList_FieldEnums.hxx>
+
+
+#include "../../utilities/idf/IdfObject.hpp"
+#include "../../utilities/idf/IdfObject_Impl.hpp"
+
+
+#include "../../utilities/idf/WorkspaceObject.hpp"
+#include "../../utilities/idf/WorkspaceObject_Impl.hpp"
+
+#include "../../utilities/idf/IdfExtensibleGroup.hpp"
+#include "../../utilities/idf/WorkspaceExtensibleGroup.hpp"
+
+#include <utilities/idd/IddEnums.hxx>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+/*
+ * Tests the "smart" logic for guessing the operation type of a Heat Exchanger
+ */
+TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_HeatExchanger_UncontrolledOn) {
+
+    ForwardTranslator forwardTranslator;
+
+    boost::optional<WorkspaceObject> _wo;
+
+    Model m;
+    PlantLoop p(m);
+    BoilerHotWater b(m);
+    HeatExchangerFluidToFluid hx(m);
+
+    p.addSupplyBranchForComponent(b);
+    p.addSupplyBranchForComponent(hx);
+
+    ASSERT_TRUE(hx.setControlType("UncontrolledOn"));
+
+    Workspace w = forwardTranslator.translateModel(m);
+
+
+    /*
+     *WorkspaceObjectVector idfObjs(w.getObjectsByType(IddObjectType::PlantLoop));
+     *EXPECT_EQ(1u, idfObjs.size());
+     *WorkspaceObject idf_p(idfObjs[0]);
+     *WorkspaceObject idf_plant_op = idf_p.getTarget(PlantLoopFields::PlantEquipmentOperationSchemeName).get();
+     */
+
+    WorkspaceObjectVector idfObjs(w.getObjectsByType(IddObjectType::PlantEquipmentOperationSchemes));
+    EXPECT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_plant_op(idfObjs[0]);
+
+    // Should have created a Heating Load one and an Uncontrolled one
+    ASSERT_EQ(2u, idf_plant_op.extensibleGroups().size());
+    WorkspaceExtensibleGroup w_eg = idf_plant_op.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    ASSERT_EQ("PlantEquipmentOperation:HeatingLoad", w_eg.getString(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeObjectType).get());
+
+    w_eg = idf_plant_op.extensibleGroups()[1].cast<WorkspaceExtensibleGroup>();
+    ASSERT_EQ("PlantEquipmentOperation:Uncontrolled", w_eg.getString(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeObjectType).get());
+
+    // Get the Operation Scheme
+    _wo = w_eg.getTarget(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_op_scheme = _wo.get();
+
+    // Get the Plant Equipment List of this Uncontrolled scheme
+    _wo = idf_op_scheme.getTarget(PlantEquipmentOperation_UncontrolledFields::EquipmentListName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_peq_list = _wo.get();
+
+    // Should have one equipment on it
+    ASSERT_EQ(1u, idf_peq_list.extensibleGroups().size());
+    IdfExtensibleGroup idf_eg(idf_peq_list.extensibleGroups()[0]);
+    // Which should be the HX
+    ASSERT_EQ(hx.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_HeatExchanger_HeatingSetpointModulated) {
+
+
+    ForwardTranslator forwardTranslator;
+
+    boost::optional<WorkspaceObject> _wo;
+
+    Model m;
+    PlantLoop p(m);
+    BoilerHotWater b(m);
+    HeatExchangerFluidToFluid hx(m);
+
+    p.addSupplyBranchForComponent(b);
+    p.addSupplyBranchForComponent(hx);
+
+    ASSERT_TRUE(hx.setControlType("HeatingSetpointModulated"));
+
+    Workspace w = forwardTranslator.translateModel(m);
+
+
+    /*
+     *WorkspaceObjectVector idfObjs(w.getObjectsByType(IddObjectType::PlantLoop));
+     *EXPECT_EQ(1u, idfObjs.size());
+     *WorkspaceObject idf_p(idfObjs[0]);
+     *WorkspaceObject idf_plant_op = idf_p.getTarget(PlantLoopFields::PlantEquipmentOperationSchemeName).get();
+     */
+
+    WorkspaceObjectVector idfObjs(w.getObjectsByType(IddObjectType::PlantEquipmentOperationSchemes));
+    EXPECT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_plant_op(idfObjs[0]);
+
+    // Should have created a Heating Load one only
+    ASSERT_EQ(1u, idf_plant_op.extensibleGroups().size());
+    WorkspaceExtensibleGroup w_eg = idf_plant_op.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    ASSERT_EQ("PlantEquipmentOperation:HeatingLoad", w_eg.getString(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeObjectType).get());
+
+    // Get the Operation Scheme
+    _wo = w_eg.getTarget(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_op_scheme = _wo.get();
+
+    // Get the Plant Equipment List of this HeatingLoad scheme
+    // There should only be one Load Range
+    ASSERT_EQ(1u, idf_op_scheme.extensibleGroups().size());
+    // Load range 1
+    w_eg = idf_op_scheme.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    _wo = w_eg.getTarget(PlantEquipmentOperation_HeatingLoadExtensibleFields::RangeEquipmentListName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_peq_list = _wo.get();
+
+    // Should have two equipment on it: boiler, then HX
+    ASSERT_EQ(2u, idf_peq_list.extensibleGroups().size());
+    IdfExtensibleGroup idf_eg(idf_peq_list.extensibleGroups()[0]);
+    ASSERT_EQ(b.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+    idf_eg = idf_peq_list.extensibleGroups()[1];
+    ASSERT_EQ(hx.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_WaterHeaterMixed_Capacity_NoSource) {
+
+    boost::optional<WorkspaceObject> _wo;
+
+    Model m;
+
+    PlantLoop use_loop(m);
+    use_loop.setName("Use Loop");
+
+    BoilerHotWater b(m);
+    WaterHeaterMixed wh(m);
+
+    use_loop.addSupplyBranchForComponent(b);
+    use_loop.addSupplyBranchForComponent(wh);
+
+    ASSERT_TRUE(wh.setHeaterMaximumCapacity(50000));
+
+    ForwardTranslator forwardTranslator;
+    Workspace w = forwardTranslator.translateModel(m);
+
+
+    // Get the Use Loop, and find it's plant operation scheme
+    _wo = w.getObjectByTypeAndName(IddObjectType::PlantLoop, use_loop.name().get());
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_use_loop = _wo.get();
+    WorkspaceObject idf_plant_op = idf_use_loop.getTarget(PlantLoopFields::PlantEquipmentOperationSchemeName).get();
+
+    // Should have created a Heating Load one only
+    ASSERT_EQ(1u, idf_plant_op.extensibleGroups().size());
+    WorkspaceExtensibleGroup w_eg = idf_plant_op.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    ASSERT_EQ("PlantEquipmentOperation:HeatingLoad", w_eg.getString(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeObjectType).get());
+
+    // Get the Operation Scheme
+    _wo = w_eg.getTarget(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_op_scheme = _wo.get();
+
+    // Get the Plant Equipment List of this HeatingLoad scheme
+    // There should only be one Load Range
+    ASSERT_EQ(1u, idf_op_scheme.extensibleGroups().size());
+    // Load range 1
+    w_eg = idf_op_scheme.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    _wo = w_eg.getTarget(PlantEquipmentOperation_HeatingLoadExtensibleFields::RangeEquipmentListName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_peq_list = _wo.get();
+
+    // Should have two equipment on it: boiler, then WaterHeater:Mixed
+    ASSERT_EQ(2u, idf_peq_list.extensibleGroups().size());
+    IdfExtensibleGroup idf_eg(idf_peq_list.extensibleGroups()[0]);
+    ASSERT_EQ(b.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+    idf_eg = idf_peq_list.extensibleGroups()[1];
+    ASSERT_EQ(wh.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_WaterHeaterMixed_Tank_SourceHeating) {
+
+    boost::optional<WorkspaceObject> _wo;
+
+    Model m;
+
+    PlantLoop use_loop(m);
+    use_loop.setName("Use Loop");
+
+    BoilerHotWater b1(m);
+    WaterHeaterMixed wh(m);
+    ASSERT_TRUE(wh.setHeaterMaximumCapacity(0));
+
+    use_loop.addSupplyBranchForComponent(b1);
+    use_loop.addSupplyBranchForComponent(wh);
+
+
+    PlantLoop source_loop(m);
+    source_loop.setName("Source Loop");
+    BoilerHotWater b2(m);
+
+    source_loop.addSupplyBranchForComponent(b2);
+    source_loop.addDemandBranchForComponent(wh);
+
+
+    ForwardTranslator forwardTranslator;
+    Workspace w = forwardTranslator.translateModel(m);
+
+
+    // Get the Use Loop, and find it's plant operation scheme
+    _wo = w.getObjectByTypeAndName(IddObjectType::PlantLoop, use_loop.name().get());
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_use_loop = _wo.get();
+    WorkspaceObject idf_plant_op = idf_use_loop.getTarget(PlantLoopFields::PlantEquipmentOperationSchemeName).get();
+
+    // Should have created a Heating Load one only
+    ASSERT_EQ(1u, idf_plant_op.extensibleGroups().size());
+    WorkspaceExtensibleGroup w_eg = idf_plant_op.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    ASSERT_EQ("PlantEquipmentOperation:HeatingLoad", w_eg.getString(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeObjectType).get());
+
+    // Get the Operation Scheme
+    _wo = w_eg.getTarget(PlantEquipmentOperationSchemesExtensibleFields::ControlSchemeName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_op_scheme = _wo.get();
+
+    // Get the Plant Equipment List of this HeatingLoad scheme
+    // There should only be one Load Range
+    ASSERT_EQ(1u, idf_op_scheme.extensibleGroups().size());
+    // Load range 1
+    w_eg = idf_op_scheme.extensibleGroups()[0].cast<WorkspaceExtensibleGroup>();
+    _wo = w_eg.getTarget(PlantEquipmentOperation_HeatingLoadExtensibleFields::RangeEquipmentListName);
+    ASSERT_TRUE(_wo.is_initialized());
+    WorkspaceObject idf_peq_list = _wo.get();
+
+    // Should have two equipment on it: boiler, then WaterHeater:Mixed
+    ASSERT_EQ(2u, idf_peq_list.extensibleGroups().size());
+    IdfExtensibleGroup idf_eg(idf_peq_list.extensibleGroups()[0]);
+    ASSERT_EQ(b1.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+    idf_eg = idf_peq_list.extensibleGroups()[1];
+    ASSERT_EQ(wh.name().get(), idf_eg.getString(PlantEquipmentListExtensibleFields::EquipmentName).get());
+
+}


### PR DESCRIPTION
Better PlantEquipmentOperation defaults for `HeatExchangerFluidToFluid`, `WaterHeater:Mixed` and `WaterHeater:Stratified`, with Gtest #2749, #2275.

Here's the logic I have used:

**`HeatExchangerFluidToFluid`**:

* Check the `controlType` first, if it's a heating/cooling/dualsetpoint type then assign `ComponentType::HEATING`, `COOLING`, and `BOTH` respectively
* If it's `OperationSchemeModulated` or `OperationSchemeOnOff`, do as before and return BOTH.
* If it's `Uncontrolled`, check the secondary (source) loop supply side (call `plantLoopType`). If no secondary plant loop (weird for a HX...), then `NONE`.

** `WaterHeater:Mixed` and `WaterHeater:Stratified`:**

* If they have a heating capacity (autosized or hardsized > 0): `HEATING`.
* If they don't have a capacity it's a storage tank.
    * If no secondary loop, it's a buffer tank => `NONE`
    * Otherwise inherit the secondary loop (call `plantLoopType`)

**plantLoopType:** call componentType for each component on the supply side, and check the following:

* If there is only heating, no cooling, no "both": Heating
* If there is only cooling, no heating, no "both": Cooling
* If there is no cooling, no heating, no "both": None
* All other cases: "both"

Gtests have been added.