### PR TITLE
Fix 2022 air terminal magic

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -13,6 +13,7 @@ project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
 include(CPackComponent)
+include(CheckCXXCompilerFlag)
 
 if( POLICY CMP0022 )
   cmake_policy(SET CMP0022 NEW)
@@ -322,6 +323,19 @@ if(MSVC)
   # ignore warnings about the stl being insecure
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
 
+endif()
+
+# Add Color Output if Using Ninja
+macro(AddCXXFlagIfSupported flag test)
+   CHECK_CXX_COMPILER_FLAG(${flag} ${test})
+   if( ${${test}} )
+      message("adding ${flag}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+   endif()
+endmacro()
+
+if("Ninja" STREQUAL ${CMAKE_GENERATOR})
+   AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
 endif()
 ###############################################################################
 

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -335,9 +335,20 @@ macro(AddCXXFlagIfSupported flag test)
 endmacro()
 
 if("Ninja" STREQUAL ${CMAKE_GENERATOR})
-   AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
+  # Clang
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    AddCXXFlagIfSupported(-fcolor-diagnostics COMPILER_SUPPORTS_fcolor-diagnostics)
+  endif()
+
+  # g++
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # For some reason it doesn't say its supported, but it works...
+    # AddCXXFlagIfSupported(-fdiagnostics-color COMPILER_SUPPORTS_fdiagnostics-color)
+    message("Forcing -fdiagnostics-color=always")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  endif()
 endif()
-###############################################################################
+##############################################################################
 
 
 ###############################################################################

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.7.0)
 cmake_policy(SET CMP0048 NEW)
 
+# Use ccache is available, has to be before "project()"
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  # Support Unix Makefiles and Ninja
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
+
 project(OpenStudio VERSION 2.3.0)
 
 include(ExternalProject)
@@ -649,6 +657,14 @@ endif()
 
 # SWIG
 
+# Xcode/Ninja generators undefined MAKE
+if(CMAKE_GENERATOR MATCHES "Make")
+  set(MAKE "$(MAKE)")
+else()
+  set(MAKE make)
+endif()
+
+
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
@@ -656,8 +672,8 @@ if(UNIX)
     URL_MD5 7fff46c84b8c630ede5b0f0827e3d90a
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) install
+    BUILD_COMMAND ${MAKE}
+    INSTALL_COMMAND ${MAKE} install
     BUILD_IN_SOURCE 1
   )
   set(SWIG_EXECUTABLE ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)

--- a/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctConstantVolumeReheat.cpp
@@ -29,7 +29,6 @@
 #include "AirTerminalSingleDuctConstantVolumeReheat.hpp"
 #include "AirTerminalSingleDuctConstantVolumeReheat_Impl.hpp"
 
-// TODO: Check the following class names against object getters and setters.
 #include "Schedule.hpp"
 #include "Schedule_Impl.hpp"
 #include "HVACComponent.hpp"

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.cpp
@@ -333,7 +333,7 @@ namespace detail {
     return value.get();
   }
 
-  void AirTerminalSingleDuctParallelPIUReheat_Impl::setReheatCoil( HVACComponent & hvacComponent )
+  bool AirTerminalSingleDuctParallelPIUReheat_Impl::setReheatCoil( HVACComponent & hvacComponent )
   {
     bool isTypeCorrect = false;
 
@@ -352,11 +352,14 @@ namespace detail {
 
     if( isTypeCorrect )
     {
-      setPointer(OS_AirTerminal_SingleDuct_ParallelPIU_ReheatFields::ReheatCoilName,hvacComponent.handle());
+      return setPointer(OS_AirTerminal_SingleDuct_ParallelPIU_ReheatFields::ReheatCoilName,hvacComponent.handle());
+    } else {
+      return false;
     }
+
   }
 
-  void AirTerminalSingleDuctParallelPIUReheat_Impl::setFan( HVACComponent & hvacComponent )
+  bool AirTerminalSingleDuctParallelPIUReheat_Impl::setFan( HVACComponent & hvacComponent )
   {
     bool isTypeCorrect = false;
 
@@ -367,7 +370,10 @@ namespace detail {
 
     if( isTypeCorrect )
     {
-      setPointer(OS_AirTerminal_SingleDuct_ParallelPIU_ReheatFields::FanName,hvacComponent.handle());
+      return setPointer(OS_AirTerminal_SingleDuct_ParallelPIU_ReheatFields::FanName,hvacComponent.handle());
+    } else {
+      LOG(Error, briefDescription() << " only accepts a Fan:ConstantVolume, and not the supplied " << hvacComponent.briefDescription() );
+      return false;
     }
   }
 
@@ -680,9 +686,20 @@ AirTerminalSingleDuctParallelPIUReheat::AirTerminalSingleDuctParallelPIUReheat( 
         << "availability schedule to " << schedule.briefDescription() << ".");
   }
 
-  setFan(fan);
+  test = setFan(fan);
+  if (!test) {
+    remove();
+    LOG_AND_THROW("Could not construct " << briefDescription() << ", because could not set its Fan to "
+        << fan.briefDescription() << ".");
+  }
 
-  setReheatCoil(reheatCoil);
+  test = setReheatCoil(reheatCoil);
+  if (!test) {
+    remove();
+     LOG_AND_THROW("Could not construct " << briefDescription() << ", because could not set its reheatCoil to "
+        << reheatCoil.briefDescription() << ".");
+  }
+
 
   autosizeMaximumHotWaterorSteamFlowRate();
 
@@ -834,14 +851,14 @@ Schedule AirTerminalSingleDuctParallelPIUReheat::availabilitySchedule() const
   return getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->availabilitySchedule();
 }
 
-void AirTerminalSingleDuctParallelPIUReheat::setReheatCoil( HVACComponent & hvacComponent )
+bool AirTerminalSingleDuctParallelPIUReheat::setReheatCoil( HVACComponent & hvacComponent )
 {
-  getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->setReheatCoil(hvacComponent);
+  return getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->setReheatCoil(hvacComponent);
 }
 
-void AirTerminalSingleDuctParallelPIUReheat::setFan( HVACComponent & hvacComponent )
+bool AirTerminalSingleDuctParallelPIUReheat::setFan( HVACComponent & hvacComponent )
 {
-  getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->setFan(hvacComponent);
+  return getImpl<detail::AirTerminalSingleDuctParallelPIUReheat_Impl>()->setFan(hvacComponent);
 }
 
 bool AirTerminalSingleDuctParallelPIUReheat::setAvailabilitySchedule(Schedule& schedule )

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat.hpp
@@ -125,9 +125,9 @@ class MODEL_API AirTerminalSingleDuctParallelPIUReheat : public StraightComponen
 
   void autosizeFanOnFlowFraction();
 
-  void setFan( HVACComponent & hvacComponent );
+  bool setFan( HVACComponent & hvacComponent );
 
-  void setReheatCoil( HVACComponent & hvacComponent );
+  bool setReheatCoil( HVACComponent & hvacComponent );
 
   void setMaximumHotWaterorSteamFlowRate(double maximumHotWaterorSteamFlowRate);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctParallelPIUReheat_Impl.hpp
@@ -41,24 +41,7 @@ namespace detail {
 
   /** AirTerminalSingleDuctParallelPIUReheat_Impl is a StraightComponent_Impl that is the implementation class for AirTerminalSingleDuctParallelPIUReheat.*/
   class MODEL_API AirTerminalSingleDuctParallelPIUReheat_Impl : public StraightComponent_Impl {
-    
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-    
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -143,6 +126,10 @@ namespace detail {
     /** @name Setters */
     //@{
 
+
+    // TODO: @macumber all of these should have a return type of bool, and shouldn't accept boost::optional double (or at least be overloaded to accept a
+    // double too), see https://github.com/NREL/OpenStudio/issues/2620 and https://github.com/jmarrec/OpenStudio/commit/5d295638aea240becc14a45641ea72a413e1c360
+    // and https://github.com/NREL/OpenStudio/pull/2589
     bool setAvailabilitySchedule(Schedule& schedule);
 
     void setMaximumPrimaryAirFlowRate(boost::optional<double> maximumPrimaryAirFlowRate);
@@ -161,9 +148,9 @@ namespace detail {
 
     void autosizeFanOnFlowFraction();
 
-    void setFan( HVACComponent & hvacComponent );
+    bool setFan( HVACComponent & hvacComponent );
 
-    void setReheatCoil( HVACComponent & hvacComponent );
+    bool setReheatCoil( HVACComponent & hvacComponent );
 
     void setMaximumHotWaterorSteamFlowRate(boost::optional<double> maximumHotWaterorSteamFlowRate);
 

--- a/openstudiocore/src/model/CoilCoolingCooledBeam.cpp
+++ b/openstudiocore/src/model/CoilCoolingCooledBeam.cpp
@@ -100,6 +100,28 @@ namespace detail {
     return OS_Coil_Cooling_CooledBeamFields::ChilledWaterOutletNodeName;
   }
 
+
+  // contaningHVACComponent is important: used for airLoopHVAC::addBranchForZone to connect the coil to the right loop
+  boost::optional<HVACComponent> CoilCoolingCooledBeam_Impl::containingHVACComponent() const
+  {
+    std::vector<AirTerminalSingleDuctConstantVolumeCooledBeam> airTerminalSingleDuctConstantVolumeCooledBeam;
+
+    airTerminalSingleDuctConstantVolumeCooledBeam = this->model().getConcreteModelObjects<AirTerminalSingleDuctConstantVolumeCooledBeam>();
+
+    for( const auto & elem : airTerminalSingleDuctConstantVolumeCooledBeam )
+    {
+      if( boost::optional<HVACComponent> coil = elem.coilCoolingCooledBeam() )
+      {
+        if( coil->handle() == this->handle() )
+        {
+          return elem;
+        }
+      }
+    }
+    return boost::none;
+  }
+
+
   boost::optional<StraightComponent> CoilCoolingCooledBeam_Impl::containingStraightComponent() const
   {
     // this coil can only be found in a AirTerminalSingleDuctConstantVolumeCooledBeam

--- a/openstudiocore/src/model/CoilCoolingCooledBeam_Impl.hpp
+++ b/openstudiocore/src/model/CoilCoolingCooledBeam_Impl.hpp
@@ -61,29 +61,31 @@ namespace detail {
     /** @name Virtual Methods */
     //@{
 
-    virtual const std::vector<std::string>& outputVariableNames() const override; 
+    virtual const std::vector<std::string>& outputVariableNames() const override;
 
-    virtual IddObjectType iddObjectType() const override; 
+    virtual IddObjectType iddObjectType() const override;
 
     virtual unsigned inletPort() override;
 
     virtual unsigned outletPort() override;
-    
-    virtual boost::optional<StraightComponent> containingStraightComponent() const override; 
+
+    virtual boost::optional<HVACComponent> containingHVACComponent() const override;
+
+    virtual boost::optional<StraightComponent> containingStraightComponent() const override;
 
     //@}
     /** @name Getters */
     //@{
 
-    double coilSurfaceAreaperCoilLength() const; 
+    double coilSurfaceAreaperCoilLength() const;
 
-    bool isCoilSurfaceAreaperCoilLengthDefaulted() const; 
+    bool isCoilSurfaceAreaperCoilLengthDefaulted() const;
 
-    double modelParametera() const; 
+    double modelParametera() const;
 
-    bool isModelParameteraDefaulted() const; 
+    bool isModelParameteraDefaulted() const;
 
-    double modelParametern1() const; 
+    double modelParametern1() const;
 
     bool isModelParametern1Defaulted() const;
 
@@ -115,13 +117,13 @@ namespace detail {
     /** @name Setters */
     //@{
 
-    bool setCoilSurfaceAreaperCoilLength(double coilSurfaceAreaperCoilLength); 
+    bool setCoilSurfaceAreaperCoilLength(double coilSurfaceAreaperCoilLength);
 
-    void resetCoilSurfaceAreaperCoilLength(); 
+    void resetCoilSurfaceAreaperCoilLength();
 
-    bool setModelParametera(double modelParametera); 
+    bool setModelParametera(double modelParametera);
 
-    void resetModelParametera(); 
+    void resetModelParametera();
 
     bool setModelParametern1(double modelParametern1);
 
@@ -154,7 +156,7 @@ namespace detail {
     //@}
     /** @name Other */
     //@{
-    
+
     bool addToNode(Node & node) override;
 
     //@}

--- a/openstudiocore/src/model/CoilCoolingWater.cpp
+++ b/openstudiocore/src/model/CoilCoolingWater.cpp
@@ -43,6 +43,8 @@
 #include "ZoneHVACComponent_Impl.hpp"
 #include "ZoneHVACFourPipeFanCoil.hpp"
 #include "ZoneHVACFourPipeFanCoil_Impl.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction_Impl.hpp"
 #include <utilities/idd/OS_Coil_Cooling_Water_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include "../utilities/core/Compare.hpp"
@@ -419,6 +421,22 @@ namespace detail {
         }
       }
     }
+
+
+    // AirTerminalSingleDuctConstantVolumeFourPipeInduction
+    std::vector<AirTerminalSingleDuctConstantVolumeFourPipeInduction> fourPipeSystems = this->model().getConcreteModelObjects<AirTerminalSingleDuctConstantVolumeFourPipeInduction>();
+
+    for( const auto & fourPipeSystem : fourPipeSystems )
+    {
+      if( boost::optional<HVACComponent> coolingCoil = fourPipeSystem.coolingCoil() )
+      {
+        if( coolingCoil->handle() == this->handle() )
+        {
+          return fourPipeSystem;
+        }
+      }
+    }
+
 
     return boost::none;
   }

--- a/openstudiocore/src/model/CoilHeatingWater.cpp
+++ b/openstudiocore/src/model/CoilHeatingWater.cpp
@@ -58,8 +58,15 @@
 #include "AirTerminalSingleDuctConstantVolumeReheat_Impl.hpp"
 #include "AirTerminalSingleDuctVAVReheat.hpp"
 #include "AirTerminalSingleDuctVAVReheat_Impl.hpp"
+#include "AirTerminalSingleDuctVAVHeatAndCoolReheat.hpp"
+#include "AirTerminalSingleDuctVAVHeatAndCoolReheat_Impl.hpp"
 #include "AirTerminalSingleDuctParallelPIUReheat.hpp"
 #include "AirTerminalSingleDuctParallelPIUReheat_Impl.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction_Impl.hpp"
+
 #include "Model.hpp"
 #include <utilities/idd/OS_Coil_Heating_Water_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
@@ -337,6 +344,28 @@ namespace detail{
   {
     // Process all types that might contain a CoilHeatingWater object.
 
+    // Here is the list of AirTerminals and AirLoopHVACUnitary that are in OpenStudio as of 2.3.0
+
+    // Can have a heating coil (and are implemented below)
+    // * AirTerminalSingleDuctConstantVolumeFourPipeInduction
+    // * AirTerminalSingleDuctConstantVolumeReheat
+    // * AirTerminalSingleDuctParallelPIUReheat
+    // * AirTerminalSingleDuctSeriesPIUReheat
+    // * AirTerminalSingleDuctVAVHeatAndCoolReheat
+    // * AirTerminalSingleDuctVAVReheat
+    // * AirLoopHVACUnitarySystem
+    // * AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass
+    // * AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed
+
+    // Cannot have a heating coil:
+    // * AirTerminalDualDuctVAV
+    // * AirTerminalSingleDuctConstantVolumeCooledBeam
+    // * AirTerminalSingleDuctInletSideMixer
+    // * AirTerminalSingleDuctUncontrolled
+    // * AirTerminalSingleDuctVAVHeatAndCoolNoReheat
+    // * AirTerminalSingleDuctVAVNoReheat
+
+
     // AirLoopHVACUnitarySystem
     std::vector<AirLoopHVACUnitarySystem> airLoopHVACUnitarySystems = this->model().getConcreteModelObjects<AirLoopHVACUnitarySystem>();
 
@@ -387,6 +416,19 @@ namespace detail{
       }
     }
 
+    // AirTerminalSingleDuctVAVHeatAndCoolReheat
+    std::vector<AirTerminalSingleDuctVAVHeatAndCoolReheat> airTerminalSingleDuctVAVHeatAndCoolReheatObjects = this->model().getConcreteModelObjects<AirTerminalSingleDuctVAVHeatAndCoolReheat>();
+
+    for( const auto & airTerminalSingleDuctVAVHeatAndCoolReheatObject : airTerminalSingleDuctVAVHeatAndCoolReheatObjects )
+    {
+      // Not an optional
+      if( airTerminalSingleDuctVAVHeatAndCoolReheatObject.reheatCoil().handle() == this->handle() )
+      {
+        return airTerminalSingleDuctVAVHeatAndCoolReheatObject;
+      }
+    }
+
+
     // AirTerminalSingleDuctConstantVolumeReheat
 
     std::vector<AirTerminalSingleDuctConstantVolumeReheat> airTerminalSingleDuctConstantVolumeReheatObjects = this->model().getConcreteModelObjects<AirTerminalSingleDuctConstantVolumeReheat>();
@@ -395,10 +437,25 @@ namespace detail{
     {
       if( boost::optional<HVACComponent> coil = airTerminalSingleDuctConstantVolumeReheatObject.reheatCoil() )
       {
+        // Not an optional actually...
         if( coil->handle() == this->handle() )
         {
           return airTerminalSingleDuctConstantVolumeReheatObject;
         }
+      }
+    }
+
+
+    // AirTerminalSingleDuctSeriesPIUReheat
+
+    std::vector<AirTerminalSingleDuctSeriesPIUReheat> airTerminalSingleDuctSeriesPIUReheatObjects = this->model().getConcreteModelObjects<AirTerminalSingleDuctSeriesPIUReheat>();
+
+    for( const auto & airTerminalSingleDuctSeriesPIUReheatObject : airTerminalSingleDuctSeriesPIUReheatObjects )
+    {
+      // Not an optional
+      if( airTerminalSingleDuctSeriesPIUReheatObject.reheatCoil().handle() == this->handle() )
+      {
+        return airTerminalSingleDuctSeriesPIUReheatObject;
       }
     }
 
@@ -408,12 +465,23 @@ namespace detail{
 
     for( const auto & airTerminalSingleDuctParallelPIUReheatObject : airTerminalSingleDuctParallelPIUReheatObjects )
     {
-      if( boost::optional<HVACComponent> coil = airTerminalSingleDuctParallelPIUReheatObject.reheatCoil() )
+      // Not an optional
+      if( airTerminalSingleDuctParallelPIUReheatObject.reheatCoil().handle() == this->handle() )
       {
-        if( coil->handle() == this->handle() )
-        {
-          return airTerminalSingleDuctParallelPIUReheatObject;
-        }
+        return airTerminalSingleDuctParallelPIUReheatObject;
+      }
+    }
+
+
+    // AirTerminalSingleDuctConstantVolumeFourPipeInduction
+    std::vector<AirTerminalSingleDuctConstantVolumeFourPipeInduction> fourPipeSystems = this->model().getConcreteModelObjects<AirTerminalSingleDuctConstantVolumeFourPipeInduction>();
+
+    for( const auto & fourPipeSystem : fourPipeSystems )
+    {
+      // Not an optional
+      if( fourPipeSystem.heatingCoil().handle() == this->handle() )
+      {
+        return fourPipeSystem;
       }
     }
 

--- a/openstudiocore/src/model/test/ZoneHVACPackagedTerminalHeatPump_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACPackagedTerminalHeatPump_GTest.cpp
@@ -59,12 +59,12 @@ TEST(ZoneHVACPackagedTerminalHeatPump,ZoneHVACPackagedTerminalHeatPump_ZoneHVACP
 {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
-  ASSERT_EXIT ( 
-  {  
-     model::Model m; 
+  ASSERT_EXIT (
+  {
+     model::Model m;
 
      model::ScheduleCompact availabilitySchedule(m);
-  
+
      model::FanConstantVolume fan(m,availabilitySchedule);
 
      model::CoilHeatingElectric supplementalHeatingCoil(m,availabilitySchedule);
@@ -165,10 +165,10 @@ TEST(ZoneHVACPackagedTerminalHeatPump,ZoneHVACPackagedTerminalHeatPump_ZoneHVACP
                                            totalHeatingCapacityFunctionofFlowFractionCurve,
                                            energyInputRatioFunctionofTemperatureCurve,
                                            energyInputRatioFunctionofFlowFractionCurve,
-                                           partLoadFractionCorrelationCurve ); 
+                                           partLoadFractionCorrelationCurve );
 
      model::ZoneHVACPackagedTerminalHeatPump pthp( m,
-                                                   availabilitySchedule, 
+                                                   availabilitySchedule,
                                                    fan,
                                                    heatingCoil,
                                                    coolingCoil,
@@ -184,17 +184,17 @@ TEST(ZoneHVACPackagedTerminalHeatPump,ZoneHVACPackagedTerminalHeatPump_ZoneHVACP
 
      pthp.supplementalHeatingCoil();
 
-     exit(0); 
+     exit(0);
   } ,
     ::testing::ExitedWithCode(0), "" );
 }
 
 TEST_F(ModelFixture,ZoneHVACPackagedTerminalHeatPump_Clone)
 {
-  model::Model m; 
+  model::Model m;
 
   model::ScheduleCompact availabilitySchedule(m);
-  
+
   model::FanConstantVolume fan(m,availabilitySchedule);
 
   model::CoilHeatingElectric supplementalHeatingCoil(m,availabilitySchedule);
@@ -308,10 +308,10 @@ TEST_F(ModelFixture,ZoneHVACPackagedTerminalHeatPump_Clone)
                                         totalHeatingCapacityFunctionofFlowFractionCurve,
                                         energyInputRatioFunctionofTemperatureCurve,
                                         energyInputRatioFunctionofFlowFractionCurve,
-                                        partLoadFractionCorrelationCurve ); 
+                                        partLoadFractionCorrelationCurve );
 
   model::ZoneHVACPackagedTerminalHeatPump pthp( m,
-                                                availabilitySchedule, 
+                                                availabilitySchedule,
                                                 fan,
                                                 heatingCoil,
                                                 coolingCoil,


### PR DESCRIPTION
Fix #2022. I realized that the AirTerminal or Coils clone() method isn't called after following the Qt stuff.

Instead AirLoopHVAC::addBranchForZone is called, and in there it's going to rely on the coil 'containingHVACComponent' method. Some missing AirTerminalTypes were uncovered in CoilCoolingWater and CoilHeatingWater, so I implemented that. Also added a containingHVACComponent method to CoilCooledBeam though that was perhaps not necessary due to the need for a check (see next point)

I then realized that ATU:FourPipeInduction is special because it has both a cooling and heating coil.
ATU:CooledBeam is also special because the coilCoolingCooledBeam is a StraightComponent and not a WaterToAirComponent, so I add to implement a check for this in AirLoopHVAC::addBranchForZone.

Wrote Gtests for all terminal types to make sure "magic" is indeed happening.


More info on #2022.


