### PR TITLE
Fix #2883 failing EMS tests

### DIFF
--- a/openstudiocore/src/model/EnergyManagementSystemGlobalVariable.cpp
+++ b/openstudiocore/src/model/EnergyManagementSystemGlobalVariable.cpp
@@ -82,10 +82,16 @@ EnergyManagementSystemGlobalVariable::EnergyManagementSystemGlobalVariable(const
 {
   OS_ASSERT(getImpl<detail::EnergyManagementSystemGlobalVariable_Impl>());
   bool ok = getImpl<detail::EnergyManagementSystemGlobalVariable_Impl>()->setName(variableName);
-  if ((!ok) || (variableName != this->nameString())) {
+  if (!ok) {
     remove();
     LOG_AND_THROW("Unable to set " << briefDescription() << "'s Name to " << variableName << ".");
   }
+
+  if (variableName != this->nameString()) {
+    LOG(Warn, "Because spaces aren't allowed in ERL variable names, renamed " << briefDescription()
+           << " (requested variableName = '" << variableName << "').");
+  }
+
 }
 
 IddObjectType EnergyManagementSystemGlobalVariable::iddObjectType() {

--- a/openstudiocore/src/model/test/EnergyManagementSystemGlobalVariable_GTest.cpp
+++ b/openstudiocore/src/model/test/EnergyManagementSystemGlobalVariable_GTest.cpp
@@ -46,8 +46,8 @@ using std::string;
 TEST_F(ModelFixture, EMSGlobalVariable_EMSGlobalVariable)
 {
   Model model;
-    
-  // add global variable
+
+  // add global variable, should rename it to remove the space
   EnergyManagementSystemGlobalVariable var(model, "glob var");
   EXPECT_EQ("glob_var", var.nameString());
 }

--- a/openstudiocore/src/model/test/EnergyManagementSystemTrendVariable_GTest.cpp
+++ b/openstudiocore/src/model/test/EnergyManagementSystemTrendVariable_GTest.cpp
@@ -47,7 +47,7 @@ using std::string;
 TEST_F(ModelFixture, EMSTrendVariable_EMSTrendVariable)
 {
   Model model;
-  
+
   // add global variable
   EnergyManagementSystemGlobalVariable globvar(model, "glob var");
 


### PR DESCRIPTION
Fixes #2883: Warn user if a varName with spaces is supplied but do allow it, it'll just replace the space with an underscore.

FYI @brianlball 