### PR TITLE
Fix #2888 - Enter fractional fields when locale has a comma separator.

### DIFF
--- a/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
@@ -36,6 +36,7 @@
 
 #include <QDoubleValidator>
 #include <QFocusEvent>
+#include <QLocale>
 
 #include <iomanip>
 
@@ -51,6 +52,10 @@ OSDoubleEdit2::OSDoubleEdit2( QWidget * parent )
   setEnabled(false);
 
   m_doubleValidator = new QDoubleValidator();
+  // Set the Locale to C, so that "1234.56" is accepted, but not "1234,56", no matter the user's system locale
+  QLocale lo(QLocale::C);
+  m_doubleValidator->setLocale(lo);
+
   //this->setValidator(m_doubleValidator);
 }
 
@@ -202,9 +207,9 @@ void OSDoubleEdit2::bind(model::ModelExtensibleGroup& modelExtensibleGroup,
 void OSDoubleEdit2::completeBind() {
 
   // only let one of autosize/autocalculate
-  if ((m_isAutosized && m_isAutocalculated) || 
-      (m_isAutosized && m_autocalculate) || 
-      (m_isAutocalculated && m_autosize)) 
+  if ((m_isAutosized && m_isAutocalculated) ||
+      (m_isAutosized && m_autocalculate) ||
+      (m_isAutocalculated && m_autosize))
   {
     LOG_AND_THROW("A field can only be autosized or autocalculated, it cannot be both.");
   }
@@ -225,7 +230,7 @@ void OSDoubleEdit2::unbind() {
 
     m_modelObject->getImpl<openstudio::model::detail::ModelObject_Impl>().get()->onChange.disconnect<OSDoubleEdit2, &OSDoubleEdit2::onModelObjectChange>(this);
     m_modelObject->getImpl<openstudio::model::detail::ModelObject_Impl>().get()->onRemoveFromWorkspace.disconnect<OSDoubleEdit2, &OSDoubleEdit2::onModelObjectRemove>(this);
-    
+
     m_modelObject.reset();
     m_modelExtensibleGroup.reset();
     m_get.reset();
@@ -315,7 +320,7 @@ void OSDoubleEdit2::onEditingFinished() {
           (*m_setVoidReturn)(value);
         }
       }
-      catch (...) 
+      catch (...)
       {
         //restore
         refreshTextAndLabel();
@@ -365,7 +370,7 @@ void OSDoubleEdit2::refreshTextAndLabel() {
       OS_ASSERT(m_getOptional);
       od = (*m_getOptional)();
     }
-  
+
     if (od) {
       double value = *od;
       if (m_isScientific) {
@@ -612,13 +617,13 @@ void OSDoubleEdit2::focusOutEvent(QFocusEvent * e)
 //         ss << std::fixed;
 //       }
 //       if (m_precision) {
-        
+
 //         // check if precision is too small to display value
 //         int precision = *m_precision;
 //         double minValue = std::pow(10.0, -precision);
 //         if (value < minValue){
 //           m_precision.reset();
-//         }  
+//         }
 
 //         if (m_precision){
 //           ss << std::setprecision(*m_precision);

--- a/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
@@ -41,6 +41,7 @@
 #include <QBoxLayout>
 #include <QDoubleValidator>
 #include <QFocusEvent>
+#include <QLocale>
 
 #include <iomanip>
 
@@ -48,7 +49,7 @@ using openstudio::model::ModelObject;
 
 namespace openstudio {
 
-OSQuantityEdit2::OSQuantityEdit2(const std::string& modelUnits, const std::string& siUnits, 
+OSQuantityEdit2::OSQuantityEdit2(const std::string& modelUnits, const std::string& siUnits,
                                  const std::string& ipUnits, bool isIP, QWidget * parent)
   : m_lineEdit(new QuantityLineEdit()),
     m_units(new QLabel()),
@@ -77,6 +78,9 @@ OSQuantityEdit2::OSQuantityEdit2(const std::string& modelUnits, const std::strin
   hLayout->addWidget(m_units);
 
   m_doubleValidator = new QDoubleValidator();
+  // Set the Locale to C, so that "1234.56" is accepted, but not "1234,56", no matter the user's system locale
+  QLocale lo(QLocale::C);
+  m_doubleValidator->setLocale(lo);
   //m_lineEdit->setValidator(m_doubleValidator);
 
   m_lineEdit->setMinimumWidth(60);
@@ -181,13 +185,13 @@ void OSQuantityEdit2::completeBind(bool isIP,
                                    boost::optional<BasicQuery> isAutocalculated)
 {
   // only let one of autosize/autocalculate
-  if ((isAutosized && isAutocalculated) || 
-      (isAutosized && autocalculate) || 
-      (isAutocalculated && autosize)) 
+  if ((isAutosized && isAutocalculated) ||
+      (isAutosized && autocalculate) ||
+      (isAutocalculated && autosize))
   {
     LOG_AND_THROW("A field can only be autosized or autocalculated, it cannot be both.");
   }
-  
+
   m_isIP = isIP;
   m_modelObject = modelObject;
   m_reset = reset;
@@ -198,7 +202,7 @@ void OSQuantityEdit2::completeBind(bool isIP,
   m_isAutocalculated = isAutocalculated;
 
   setEnabled(true);
-  
+
   connect(m_lineEdit, &QLineEdit::editingFinished, this, &OSQuantityEdit2::onEditingFinished); // Evan note: would behaviors improve with "textChanged"?
 
   m_modelObject->getImpl<openstudio::model::detail::ModelObject_Impl>().get()->onChange.connect<OSQuantityEdit2, &OSQuantityEdit2::onModelObjectChange>(this);
@@ -327,7 +331,7 @@ void OSQuantityEdit2::onModelObjectChange() {
   //    unbind();
   //    return;
   //  }
-  //}  
+  //}
   refreshTextAndLabel();
 }
 
@@ -421,7 +425,7 @@ void OSQuantityEdit2::refreshTextAndLabel() {
     m_units->setTextFormat(Qt::RichText);
     m_units->setText(toQString(formatUnitString(ss.str(),DocumentFormat::XHTML)));
     m_units->blockSignals(false);
-  
+
     if (m_isDefaulted) {
       if ((*m_isDefaulted)()) {
         m_lineEdit->setStyleSheet("color:green");


### PR DESCRIPTION
Set the QDoubleValidator local for Double and Quantity fields to accept decimal number with a "." separator.

Even my my LC_NUMERIC=ft_FR.UTF-8 I can now edit double/Quantity fields with a "." in there, eg 0.5 is accepted.