### PR TITLE
Fix #2891 version translation for AVM List

### DIFF
--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -118,7 +118,6 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("1.12.4")] = &VersionTranslator::update_1_12_3_to_1_12_4;
   m_updateMethods[VersionString("2.1.1")] = &VersionTranslator::update_2_1_0_to_2_1_1;
   m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::update_2_1_1_to_2_1_2;
-  m_updateMethods[VersionString("2.3.0")] = &VersionTranslator::update_2_1_2_to_2_3_0;
   m_updateMethods[VersionString("2.3.1")] = &VersionTranslator::update_2_3_0_to_2_3_1;
   m_updateMethods[VersionString("2.4.0")] = &VersionTranslator::defaultUpdate;
 
@@ -3519,20 +3518,20 @@ std::string VersionTranslator::update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, c
   return ss.str();
 }
 
-std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, const IddFileAndFactoryWrapper& idd_2_3_0) {
+std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1) {
   std::stringstream ss;
 
-  ss << idf_2_1_2.header() << std::endl << std::endl;
-  IdfFile targetIdf(idd_2_3_0.iddFile());
+  ss << idf_2_3_0.header() << std::endl << std::endl;
+  IdfFile targetIdf(idd_2_3_1.iddFile());
   ss << targetIdf.versionObject().get();
 
   boost::optional<std::string> value;
 
-  for (const IdfObject& object : idf_2_1_2.objects()) {
+  for (const IdfObject& object : idf_2_3_0.objects()) {
     auto iddname = object.iddObject().name();
 
     if (iddname == "OS:Pump:ConstantSpeed") {
-      auto iddObject = idd_2_3_0.getObject("OS:Pump:ConstantSpeed");
+      auto iddObject = idd_2_3_1.getObject("OS:Pump:ConstantSpeed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3548,7 +3547,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
     } else if (iddname == "OS:Pump:VariableSpeed") {
-      auto iddObject = idd_2_3_0.getObject("OS:Pump:VariableSpeed");
+      auto iddObject = idd_2_3_1.getObject("OS:Pump:VariableSpeed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3566,7 +3565,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
     } else if (iddname == "OS:CoolingTower:SingleSpeed") {
-      auto iddObject = idd_2_3_0.getObject("OS:CoolingTower:SingleSpeed");
+      auto iddObject = idd_2_3_1.getObject("OS:CoolingTower:SingleSpeed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3588,7 +3587,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
     } else if (iddname == "OS:CoolingTower:TwoSpeed") {
-      auto iddObject = idd_2_3_0.getObject("OS:CoolingTower:TwoSpeed");
+      auto iddObject = idd_2_3_1.getObject("OS:CoolingTower:TwoSpeed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3606,7 +3605,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
     } else if (iddname == "OS:CoolingTower:VariableSpeed") {
-      auto iddObject = idd_2_3_0.getObject("OS:CoolingTower:VariableSpeed");
+      auto iddObject = idd_2_3_1.getObject("OS:CoolingTower:VariableSpeed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3621,7 +3620,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
       ss << newObject;
 
     } else if (iddname == "OS:Chiller:Electric:EIR") {
-      auto iddObject = idd_2_3_0.getObject("OS:Chiller:Electric:EIR");
+      auto iddObject = idd_2_3_1.getObject("OS:Chiller:Electric:EIR");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3638,27 +3637,7 @@ std::string VersionTranslator::update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, c
 
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
-    } else {
-      ss << object;
-    }
-  }
-
-  return ss.str();
-}
-
-std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1) {
-  std::stringstream ss;
-
-  ss << idf_2_3_0.header() << std::endl << std::endl;
-  IdfFile targetIdf(idd_2_3_1.iddFile());
-  ss << targetIdf.versionObject().get();
-
-  boost::optional<std::string> value;
-
-  for (const IdfObject& object : idf_2_3_0.objects()) {
-    auto iddname = object.iddObject().name();
-
-    if (iddname == "OS:AirLoopHVAC") {
+    } else if (iddname == "OS:AirLoopHVAC") {
       auto iddObject = idd_2_3_1.getObject("OS:AirLoopHVAC");
       IdfObject newObject(iddObject.get());
 

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -3734,6 +3734,92 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
       ss << newObject;
       ss << avmList;
 
+    } else if (iddname == "OS:AvailabilityManager:NightCycle") {
+      auto iddObject = idd_2_3_1.getObject("OS:AvailabilityManager:NightCycle");
+      IdfObject newObject(iddObject.get());
+
+      // Cycling Run Time Control Type was placed before Cycling Run Time
+      for( size_t i = 0; i < object.numNonextensibleFields() - 1; ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+
+      // No need to set the default Cycling Run Time Control Type, it has a defaulted option
+      // But we need to carry the cycling Run Time (seconds) in the right field
+      if (auto cyclingRunTime = newObject.getDouble(6)) {
+        newObject.setDouble(7, cyclingRunTime.get());
+      }
+
+      // We need to create the four ModelObjectLists for the control zones
+      // 8 = Control Zone or Zone List Name
+      std::string  controlThermalZoneListName = "";
+      if( auto avmName = object.getString(1) ) {
+        controlThermalZoneListName = avmName.get();
+      }
+      controlThermalZoneListName = controlThermalZoneListName + " Control Zone List";
+
+      IdfObject controlThermalZoneList(idd_2_3_1.getObject("OS:ModelObjectList").get());
+      std::string controlThermalZoneListHandle = toString(createUUID());
+      controlThermalZoneList.setString(0, controlThermalZoneListHandle);
+      controlThermalZoneList.setString(1, controlThermalZoneListName);
+      newObject.setString(8, controlThermalZoneListHandle);
+
+      // 9 = Cooling Control Zone or Zone List Name
+      std::string  coolingControlThermalZoneListName = "";
+      if( auto avmName = object.getString(1) ) {
+        coolingControlThermalZoneListName = avmName.get();
+      }
+      coolingControlThermalZoneListName = coolingControlThermalZoneListName + " Cooling Control Zone List";
+
+      IdfObject coolingControlThermalZoneList(idd_2_3_1.getObject("OS:ModelObjectList").get());
+      std::string coolingControlThermalZoneListHandle = toString(createUUID());
+      coolingControlThermalZoneList.setString(0, coolingControlThermalZoneListHandle);
+      coolingControlThermalZoneList.setString(1, coolingControlThermalZoneListName);
+      newObject.setString(9, coolingControlThermalZoneListHandle);
+
+
+      // 10 = Heating Control Zone or Zone List Name
+      std::string  heatingControlThermalZoneListName = "";
+      if( auto avmName = object.getString(1) ) {
+        heatingControlThermalZoneListName = avmName.get();
+      }
+      heatingControlThermalZoneListName = heatingControlThermalZoneListName + " Heating Control Zone List";
+
+      IdfObject heatingControlThermalZoneList(idd_2_3_1.getObject("OS:ModelObjectList").get());
+      std::string heatingControlThermalZoneListHandle = toString(createUUID());
+      heatingControlThermalZoneList.setString(0, heatingControlThermalZoneListHandle);
+      heatingControlThermalZoneList.setString(1, heatingControlThermalZoneListName);
+      newObject.setString(10, heatingControlThermalZoneListHandle);
+
+
+      // 11 = Heating Control Zone or Zone List Name
+      std::string  heatingZoneFansOnlyThermalZoneListName = "";
+      if( auto avmName = object.getString(1) ) {
+        heatingZoneFansOnlyThermalZoneListName = avmName.get();
+      }
+      heatingZoneFansOnlyThermalZoneListName = heatingZoneFansOnlyThermalZoneListName + " Heating Zone Fans Only Zone List";
+
+      IdfObject heatingZoneFansOnlyThermalZoneList(idd_2_3_1.getObject("OS:ModelObjectList").get());
+      std::string heatingZoneFansOnlyThermalZoneListHandle = toString(createUUID());
+      heatingZoneFansOnlyThermalZoneList.setString(0, heatingZoneFansOnlyThermalZoneListHandle);
+      heatingZoneFansOnlyThermalZoneList.setString(1, heatingZoneFansOnlyThermalZoneListName);
+      newObject.setString(11, heatingZoneFansOnlyThermalZoneListHandle);
+
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      m_new.push_back(controlThermalZoneList);
+      m_new.push_back(coolingControlThermalZoneList);
+      m_new.push_back(heatingControlThermalZoneList);
+      m_new.push_back(heatingZoneFansOnlyThermalZoneList);
+
+
+      ss << newObject;
+      ss << controlThermalZoneList;
+      ss << coolingControlThermalZoneList;
+      ss << heatingControlThermalZoneList;
+      ss << heatingZoneFansOnlyThermalZoneList;
+
     } else {
       ss << object;
     }

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -220,6 +220,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, const IddFileAndFactoryWrapper& idd_2_1_1);
   std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
   std::string update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, const IddFileAndFactoryWrapper& idd_2_3_0);
+  std::string update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -219,7 +219,6 @@ class OSVERSION_API VersionTranslator {
   std::string update_1_12_3_to_1_12_4(const IdfFile& idf_1_12_3, const IddFileAndFactoryWrapper& idd_1_12_4);
   std::string update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, const IddFileAndFactoryWrapper& idd_2_1_1);
   std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
-  std::string update_2_1_2_to_2_3_0(const IdfFile& idf_2_1_2, const IddFileAndFactoryWrapper& idd_2_3_0);
   std::string update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);


### PR DESCRIPTION
Fix #2891: Move the AirLoop/PlantLoop update in a 2.3.0 to 2.3.1 function as it should. Implement a check to assign any existing AvaialbiltiyManager to the newly created AvailabilityManagerAssignementList