### PR TITLE
Storage Converter isn't translated for FacilityDemandLeveling while required

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -19836,14 +19836,14 @@ OS:PlantEquipmentOperation:OutdoorWetBulb,
    A2 ,\field Name
         \required-field
         \reference ControlSchemeList
-   N1 ,\field Dry-Bulb Temperature Range 1 Lower Limit
+   N1 ,\field Wet-Bulb Temperature Range 1 Lower Limit
         \required-field
        \type real
        \units C
        \minimum -70
        \maximum 70
        \begin-extensible
-   N2 ,\field Dry-Bulb Temperature Range 1 Upper Limit
+   N2 ,\field Wet-Bulb Temperature Range 1 Upper Limit
         \required-field
        \type real
        \units C

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
@@ -121,7 +121,7 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
     }
   }
 
-  // NEW
+  // NEW: Note all of these checks should have been implemented in ElectricLoadCenter_Impl::validityCheck...
 
   // Logic based on Electrical Buss Type to translate or not translate inverters, storage
   std::string bussType = modelObject.electricalBussType();
@@ -196,7 +196,7 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
       }
 
     } else if (storageOperationScheme == "TrackChargeDischargeSchedules") {
-      // Storage Converter Object Name
+      // Storage Converter Object Name - This is actually a mandatory field
       boost::optional<ElectricLoadCenterStorageConverter> elcConv = modelObject.storageConverter();
       if (elcConv) {
         // If the buss is compatible, we translate the invert
@@ -242,19 +242,18 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
       }
 
     } else if (storageOperationScheme == "FacilityDemandLeveling") {
-      // Storage Converter Object Name
-      //boost::optional<ElectricLoadCenterStorageConverter> storageConverter = modelObject.storageConverter();
-      //if (storageConverter) {
-      //  // If the buss is compatible, we translate the invert
-      //  boost::optional<IdfObject> storageConverterIdf = translateAndMapModelObject(*storageConverter);
-      //  if (storageConverterIdf) {
-      //    idfObject.setString(ElectricLoadCenter_DistributionFields
-      //      ::StorageConverterObjectName, storageConverterIdf->name().get());
-      //  }
-      //} else {
-      //  LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-      //    << " but you didn't specify the required 'Storage Converter Object Name'");
-      //}
+      // Storage Converter Object Name - This is actually a required field
+      boost::optional<ElectricLoadCenterStorageConverter> elcConv = modelObject.storageConverter();
+      if (elcConv) {
+        // If the buss is compatible, we translate the invert
+        boost::optional<IdfObject> storageConverterIdf = translateAndMapModelObject(*elcConv);
+        if (storageConverterIdf) {
+          idfObject.setString(ElectricLoadCenter_DistributionFields::StorageConverterObjectName, storageConverterIdf->name().get());
+        }
+      } else {
+        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+          << " but you didn't specify the required 'Storage Converter Object Name'");
+      }
 
       // Design Storage Control Charge Power
       if ( (optD = modelObject.designStorageControlChargePower()) ) {

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
@@ -185,6 +185,20 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
     // Minimum Storage State of Charge Fraction, defaults
     idfObject.setDouble(ElectricLoadCenter_DistributionFields::MinimumStorageStateofChargeFraction, modelObject.minimumStorageStateofChargeFraction());
 
+
+    // Translate any storage converter if there is one, store it into a bool so we can check if present when mandatory
+    bool has_storage_conv = false;
+    // Storage Converter Object Name - This is actually a mandatory field
+    boost::optional<ElectricLoadCenterStorageConverter> elcConv = modelObject.storageConverter();
+    if (elcConv) {
+      // If the buss is compatible, we translate the invert
+      boost::optional<IdfObject> storageConverterIdf = translateAndMapModelObject(*elcConv);
+      if (storageConverterIdf) {
+        has_storage_conv = true;
+        idfObject.setString(ElectricLoadCenter_DistributionFields::StorageConverterObjectName, storageConverterIdf->name().get());
+      }
+    }
+
     /// Further testing based on storageOperationScheme
     if (storageOperationScheme == "TrackMeterDemandStoreExcessOnSite") {
       // Storage Control Track Meter Name, required if operation = TrackMeterDemandStoreExcessOnSite or it'll produce a fatal
@@ -197,14 +211,7 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
 
     } else if (storageOperationScheme == "TrackChargeDischargeSchedules") {
       // Storage Converter Object Name - This is actually a mandatory field
-      boost::optional<ElectricLoadCenterStorageConverter> elcConv = modelObject.storageConverter();
-      if (elcConv) {
-        // If the buss is compatible, we translate the invert
-        boost::optional<IdfObject> storageConverterIdf = translateAndMapModelObject(*elcConv);
-        if (storageConverterIdf) {
-          idfObject.setString(ElectricLoadCenter_DistributionFields::StorageConverterObjectName, storageConverterIdf->name().get());
-        }
-      } else {
+      if( !has_storage_conv ) {
         LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
           << " but you didn't specify the required 'Storage Converter Object Name'");
       }
@@ -242,15 +249,8 @@ boost::optional<IdfObject> ForwardTranslator::translateElectricLoadCenterDistrib
       }
 
     } else if (storageOperationScheme == "FacilityDemandLeveling") {
-      // Storage Converter Object Name - This is actually a required field
-      boost::optional<ElectricLoadCenterStorageConverter> elcConv = modelObject.storageConverter();
-      if (elcConv) {
-        // If the buss is compatible, we translate the invert
-        boost::optional<IdfObject> storageConverterIdf = translateAndMapModelObject(*elcConv);
-        if (storageConverterIdf) {
-          idfObject.setString(ElectricLoadCenter_DistributionFields::StorageConverterObjectName, storageConverterIdf->name().get());
-        }
-      } else {
+      // Storage Converter Object Name - This is actually a mandatory field
+      if( !has_storage_conv ) {
         LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
           << " but you didn't specify the required 'Storage Converter Object Name'");
       }

--- a/openstudiocore/src/model/ElectricLoadCenterDistribution.cpp
+++ b/openstudiocore/src/model/ElectricLoadCenterDistribution.cpp
@@ -611,8 +611,8 @@ namespace detail {
     /// Inverter and Buss Type
     boost::optional<Inverter> inv = inverter();
     bool bussWithInverter = (bussType == "DirectCurrentWithInverter" ||
-      bussType == "DirectCurrentWithInverterDCStorage" ||
-      bussType == "DirectCurrentWithInverterACStorage");
+                             bussType == "DirectCurrentWithInverterDCStorage" ||
+                             bussType == "DirectCurrentWithInverterACStorage");
 
     // Case 1: There is an inverter and a Buss with inverter: all good
     if (inv && bussWithInverter) {
@@ -637,8 +637,8 @@ namespace detail {
     /// Storage & Buss Type
     boost::optional<ElectricalStorage> elcSto = electricalStorage();
     bool bussWithStorage = (bussType == "AlternatingCurrentWithStorage" ||
-      bussType == "DirectCurrentWithInverterDCStorage" ||
-      bussType == "DirectCurrentWithInverterACStorage");
+                            bussType == "DirectCurrentWithInverterDCStorage" ||
+                            bussType == "DirectCurrentWithInverterACStorage");
 
     // Case 1: There is a Storage object and a Buss with Storage: all good
     if (elcSto && bussWithStorage) {


### PR DESCRIPTION
I think it was just a mistake on my part, I forgot to uncomment this section, which I think I wrote before I actually implement the StorageConv object. Found this while writing a regression test for storage objects.

Also found a random copy/paste error in the IDD. Note that the copy/paste error has no actual effect aside that it isn't pretty when you look at it, because you need to use addLoadRange anyways (and not setWetBulbTemperature.....etc)