### PR TITLE
Add end use sub categories where missing

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -11508,11 +11508,16 @@ OS:Boiler:HotWater,
        \units W
        \minimum 0
        \default 0.0
-  N10; \field Sizing Factor
+  N10, \field Sizing Factor
        \note Multiplies the autosized capacity and flow rates
        \type real
        \minimum> 0
        \default 1.0
+  A9 ; \field End-Use Subcategory
+       \note Any text may be used here to categorize the end-uses in the ABUPS End Uses by Subcategory table.
+       \type alpha
+       \retaincase
+       \default General
 
 OS:Boiler:Steam,
        \memo This boiler model is an adaptation of the empirical model from the Building
@@ -11566,11 +11571,16 @@ OS:Boiler:Steam,
        \type object-list
        \required-field
        \object-list ConnectionNames
-  N11; \field Sizing Factor
+  N11, \field Sizing Factor
        \note Multiplies the autosized capacity and flow rates
        \type real
        \minimum> 0.0
        \default 1.0
+  A6 ; \field End-Use Subcategory
+       \note Any text may be used here to categorize the end-uses in the ABUPS End Uses by Subcategory table.
+       \type alpha
+       \retaincase
+       \default General
 
 OS:HeatPump:WaterToWater:EquationFit:Heating,
    A1, \field Handle
@@ -11946,7 +11956,7 @@ OS:Chiller:Electric:EIR,
        \units C
        \minimum 2
        \default 2.0
-  A14; \field Basin Heater Operating Schedule Name
+  A14, \field Basin Heater Operating Schedule Name
        \note This field is only used for Condenser Type = EvaporativelyCooled.
        \note Schedule values greater than 0 allow the basin heater to operate whenever the outdoor
        \note air dry-bulb temperature is below the basin heater setpoint temperature.
@@ -11954,6 +11964,25 @@ OS:Chiller:Electric:EIR,
        \note throughout the entire simulation.
        \type object-list
        \object-list ScheduleNames
+  N18, \field Condenser Heat Recovery Relative Capacity Fraction
+       \note This optional field is the fraction of total rejected heat that can be recovered at full load
+       \type real
+       \minimum 0.0
+       \maximum 1.0
+  A15, \field Heat Recovery Inlet High Temperature Limit Schedule Name
+       \note This optional schedule of temperatures will turn off heat recovery if inlet exceeds the value
+       \type object-list
+       \object-list ScheduleNames
+  A16, \field Heat Recovery Leaving Temperature Setpoint Node Name
+       \note This optional field provides control over the heat recovery
+       \note Using this triggers a model more suited to series bundle and chillers with higher temperature heat recovery
+       \note If this field is not used, the bundles are modeled as being in parallel
+       \type node
+  A17; \field End-Use Subcategory
+       \note Any text may be used here to categorize the end-uses in the ABUPS End Uses by Subcategory table.
+       \type alpha
+       \retaincase
+       \default General
 
 OS:CentralHeatPumpSystem,
   A1,  \field Handle
@@ -24077,13 +24106,31 @@ OS:WaterHeater:Mixed,
        \units m3/s
        \ip-units gal/min
        \minimum 0.0
-  N22; \field Indirect Water Heating Recovery Time
+  N22, \field Indirect Water Heating Recovery Time
        \type real
        \default 1.5
        \note Parameter for autosizing design flow rates for indirectly heated water tanks
        \note Time required to raise temperature of entire tank from 14.4C to 57.2C
        \units hr
        \minimum> 0.0
+  A19, \field Source Side Flow Control Mode
+       \type choice
+       \key StorageTank
+       \key IndirectHeatPrimarySetpoint
+       \key IndirectHeatAlternateSetpoint
+       \default IndirectHeatPrimarySetpoint
+       \note StorageTank mode always requests flow unless tank is at its Maximum Temperature Limit
+       \note IndirectHeatPrimarySetpoint mode requests flow whenever primary setpoint calls for heat
+       \note IndirectHeatAlternateSetpoint mode requests flow whenever alternate indirect setpoint calls for heat
+  A20, \field Indirect Alternate Setpoint Temperature Schedule Name
+       \note This field is only used if the previous is set to IndirectHeatAlternateSetpoint
+       \type object-list
+       \object-list ScheduleNames
+  A21; \field End-Use Subcategory
+       \note Any text may be used here to categorize the end-uses in the ABUPS End Uses by Subcategory table.
+       \type alpha
+       \retaincase
+       \default General
 
 OS:WaterHeater:HeatPump,
        \min-fields 25

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateBoilerHotWater.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateBoilerHotWater.cpp
@@ -199,6 +199,11 @@ boost::optional<IdfObject> ForwardTranslator::translateBoilerHotWater( BoilerHot
     idfObject.setDouble(Boiler_HotWaterFields::SizingFactor,value.get());
   }
 
+  // End Use Subcategory
+  if( (s = modelObject.endUseSubcategory()) ) {
+    idfObject.setString(Boiler_HotWaterFields::EndUseSubcategory,s.get());
+  }
+
   return boost::optional<IdfObject>(idfObject);
 }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateBoilerSteam.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateBoilerSteam.cpp
@@ -176,6 +176,11 @@ boost::optional<IdfObject> ForwardTranslator::translateBoilerSteam( BoilerSteam 
     idfObject.setDouble(Boiler_SteamFields::SizingFactor,value.get());
   }
 
+  // End Use Subcategory
+  if( (s = modelObject.endUseSubcategory()) ) {
+    idfObject.setString(Boiler_SteamFields::EndUseSubcategory,s.get());
+  }
+
   return boost::optional<IdfObject>(idfObject);
 }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateChillerElectricEIR.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateChillerElectricEIR.cpp
@@ -282,6 +282,11 @@ boost::optional<IdfObject> ForwardTranslator::translateChillerElectricEIR( Chill
     }
   }
 
+  // End Use Subcategory
+  if( (s = modelObject.endUseSubcategory()) ) {
+    idfObject.setString(Chiller_Electric_EIRFields::EndUseSubcategory,s.get());
+  }
+
   return boost::optional<IdfObject>(idfObject);
 }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateWaterHeaterMixed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateWaterHeaterMixed.cpp
@@ -466,6 +466,12 @@ boost::optional<IdfObject> ForwardTranslator::translateWaterHeaterMixed( WaterHe
 
   idfObject.setString(WaterHeater_MixedFields::SourceSideFlowControlMode,"IndirectHeatPrimarySetpoint");
 
+  if( (s = modelObject.endUseSubcategory()) ) {
+    idfObject.setString(WaterHeater_MixedFields::EndUseSubcategory,s.get());
+  }
+
+
+
   return boost::optional<IdfObject>(idfObject);
 }
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateWaterHeaterMixed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateWaterHeaterMixed.cpp
@@ -464,13 +464,32 @@ boost::optional<IdfObject> ForwardTranslator::translateWaterHeaterMixed( WaterHe
     idfObject.setDouble(WaterHeater_MixedFields::IndirectWaterHeatingRecoveryTime,value.get());
   }
 
-  idfObject.setString(WaterHeater_MixedFields::SourceSideFlowControlMode,"IndirectHeatPrimarySetpoint");
+  // SourceSideFlowControlMode
+  s = modelObject.sourceSideFlowControlMode();
+  if( s )
+  {
+    idfObject.setString(WaterHeater_MixedFields::SourceSideFlowControlMode,s.get());
 
-  if( (s = modelObject.endUseSubcategory()) ) {
-    idfObject.setString(WaterHeater_MixedFields::EndUseSubcategory,s.get());
+    if ( openstudio::istringEqual("IndirectHeatAlternateSetpoint", s.get()) ) {
+      // IndirectAlternateSetpointTemperatureScheduleName
+      schedule = modelObject.indirectAlternateSetpointTemperatureSchedule();
+      if( schedule  ) {
+        translateAndMapModelObject(schedule.get());
+        idfObject.setString(WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName,schedule->name().get());
+      } else {
+        LOG(Error, "Something really wrong happened, the Source Side Control Mode is set to 'IndirectHeatAlternateSetpoint' yet "
+                   "there is no IndirectAlternateSetpointTemperatureScheduleName which is impossible per model logic for "
+                   << modelObject.briefDescription());
+      }
+    }
+
   }
 
 
+  // EndUseSubcategory
+  if( (s = modelObject.endUseSubcategory()) ) {
+    idfObject.setString(WaterHeater_MixedFields::EndUseSubcategory,s.get());
+  }
 
   return boost::optional<IdfObject>(idfObject);
 }

--- a/openstudiocore/src/model/BoilerSteam.cpp
+++ b/openstudiocore/src/model/BoilerSteam.cpp
@@ -749,6 +749,19 @@ namespace detail {
 
   }
 
+
+  std::string BoilerSteam_Impl::endUseSubcategory() const {
+    auto value = getString(OS_Boiler_SteamFields::EndUseSubcategory,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool BoilerSteam_Impl::setEndUseSubcategory(const std::string & endUseSubcategory) {
+    return setString(OS_Boiler_SteamFields::EndUseSubcategory,endUseSubcategory);
+  }
+
+
+
 } // detail
 
 BoilerSteam::BoilerSteam(const Model& model)
@@ -768,6 +781,7 @@ BoilerSteam::BoilerSteam(const Model& model)
   setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(0.1);
   setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(0.1);
   setSizingFactor(1.0);
+  setEndUseSubcategory("General");
 }
 
 IddObjectType BoilerSteam::iddObjectType() {
@@ -1018,6 +1032,15 @@ bool BoilerSteam::setSizingFactor(const Quantity& sizingFactor) {
 void BoilerSteam::resetSizingFactor() {
   getImpl<detail::BoilerSteam_Impl>()->resetSizingFactor();
 }
+
+std::string BoilerSteam::endUseSubcategory() const {
+  return getImpl<detail::BoilerSteam_Impl>()->endUseSubcategory();
+}
+
+bool BoilerSteam::setEndUseSubcategory(const std::string & endUseSubcategory) {
+  return getImpl<detail::BoilerSteam_Impl>()->setEndUseSubcategory(endUseSubcategory);
+}
+
 
 /// @cond
 BoilerSteam::BoilerSteam(std::shared_ptr<detail::BoilerSteam_Impl> impl)

--- a/openstudiocore/src/model/BoilerSteam.hpp
+++ b/openstudiocore/src/model/BoilerSteam.hpp
@@ -58,128 +58,84 @@ class MODEL_API BoilerSteam : public StraightComponent {
 
   static std::vector<std::string> fuelTypeValues();
 
-  /** @name Getters */
+  /** @name Getters and Setters */
   //@{
 
   std::string fuelType() const;
-
   bool setFuelType(std::string fuelType);
 
   boost::optional<double> maximumOperatingPressure() const;
-
   OSOptionalQuantity getMaximumOperatingPressure(bool returnIP=false) const;
-
-  bool setMaximumOperatingPressure(double maximumOperatingPressure);
-
+  void setMaximumOperatingPressure(double maximumOperatingPressure);
   bool setMaximumOperatingPressure(const Quantity& maximumOperatingPressure);
-
   void resetMaximumOperatingPressure();
 
   boost::optional<double> theoreticalEfficiency() const;
-
   OSOptionalQuantity getTheoreticalEfficiency(bool returnIP=false) const;
-
   bool setTheoreticalEfficiency(double theoreticalEfficiency);
-
   bool setTheoreticalEfficiency(const Quantity& theoreticalEfficiency);
-
   void resetTheoreticalEfficiency();
 
   boost::optional<double> designOutletSteamTemperature() const;
-
   OSOptionalQuantity getDesignOutletSteamTemperature(bool returnIP=false) const;
-
-  bool setDesignOutletSteamTemperature(double designOutletSteamTemperature);
-
+  void setDesignOutletSteamTemperature(double designOutletSteamTemperature);
   bool setDesignOutletSteamTemperature(const Quantity& designOutletSteamTemperature);
-
   void resetDesignOutletSteamTemperature();
 
   boost::optional<double> nominalCapacity() const;
-
   OSOptionalQuantity getNominalCapacity(bool returnIP=false) const;
-
   bool isNominalCapacityAutosized() const;
-
-  bool setNominalCapacity(double nominalCapacity);
-
+  void setNominalCapacity(double nominalCapacity);
   bool setNominalCapacity(const Quantity& nominalCapacity);
-
   void resetNominalCapacity();
-
   void autosizeNominalCapacity();
 
   boost::optional<double> minimumPartLoadRatio() const;
-
   OSOptionalQuantity getMinimumPartLoadRatio(bool returnIP=false) const;
-
   bool setMinimumPartLoadRatio(double minimumPartLoadRatio);
-
   bool setMinimumPartLoadRatio(const Quantity& minimumPartLoadRatio);
-
   void resetMinimumPartLoadRatio();
 
   boost::optional<double> maximumPartLoadRatio() const;
-
   OSOptionalQuantity getMaximumPartLoadRatio(bool returnIP=false) const;
-
   bool setMaximumPartLoadRatio(double maximumPartLoadRatio);
-
   bool setMaximumPartLoadRatio(const Quantity& maximumPartLoadRatio);
-
   void resetMaximumPartLoadRatio();
 
   boost::optional<double> optimumPartLoadRatio() const;
-
   OSOptionalQuantity getOptimumPartLoadRatio(bool returnIP=false) const;
-
   bool setOptimumPartLoadRatio(double optimumPartLoadRatio);
-
   bool setOptimumPartLoadRatio(const Quantity& optimumPartLoadRatio);
-
   void resetOptimumPartLoadRatio();
 
   boost::optional<double> coefficient1ofFuelUseFunctionofPartLoadRatioCurve() const;
-
   OSOptionalQuantity getCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-
-  bool setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(double coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
-
+  void setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(double coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
-
   void resetCoefficient1ofFuelUseFunctionofPartLoadRatioCurve();
 
   boost::optional<double> coefficient2ofFuelUseFunctionofPartLoadRatioCurve() const;
-
   OSOptionalQuantity getCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-
-  bool setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(double coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
-
+  void setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(double coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
-
   void resetCoefficient2ofFuelUseFunctionofPartLoadRatioCurve();
 
   boost::optional<double> coefficient3ofFuelUseFunctionofPartLoadRatioCurve() const;
-
   OSOptionalQuantity getCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-
-  bool setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(double coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
-
+  void setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(double coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
-
   void resetCoefficient3ofFuelUseFunctionofPartLoadRatioCurve();
 
   double sizingFactor() const;
-
   Quantity getSizingFactor(bool returnIP=false) const;
-
   bool isSizingFactorDefaulted() const;
-
   bool setSizingFactor(double sizingFactor);
-
   bool setSizingFactor(const Quantity& sizingFactor);
-
   void resetSizingFactor();
+
+  std::string endUseSubcategory() const;
+  bool setEndUseSubcategory(const std::string & endUseSubcategory);
+
 
   //@}
   /** @name Other */

--- a/openstudiocore/src/model/BoilerSteam.hpp
+++ b/openstudiocore/src/model/BoilerSteam.hpp
@@ -66,7 +66,7 @@ class MODEL_API BoilerSteam : public StraightComponent {
 
   boost::optional<double> maximumOperatingPressure() const;
   OSOptionalQuantity getMaximumOperatingPressure(bool returnIP=false) const;
-  void setMaximumOperatingPressure(double maximumOperatingPressure);
+  bool setMaximumOperatingPressure(double maximumOperatingPressure);
   bool setMaximumOperatingPressure(const Quantity& maximumOperatingPressure);
   void resetMaximumOperatingPressure();
 
@@ -78,14 +78,14 @@ class MODEL_API BoilerSteam : public StraightComponent {
 
   boost::optional<double> designOutletSteamTemperature() const;
   OSOptionalQuantity getDesignOutletSteamTemperature(bool returnIP=false) const;
-  void setDesignOutletSteamTemperature(double designOutletSteamTemperature);
+  bool setDesignOutletSteamTemperature(double designOutletSteamTemperature);
   bool setDesignOutletSteamTemperature(const Quantity& designOutletSteamTemperature);
   void resetDesignOutletSteamTemperature();
 
   boost::optional<double> nominalCapacity() const;
   OSOptionalQuantity getNominalCapacity(bool returnIP=false) const;
   bool isNominalCapacityAutosized() const;
-  void setNominalCapacity(double nominalCapacity);
+  bool setNominalCapacity(double nominalCapacity);
   bool setNominalCapacity(const Quantity& nominalCapacity);
   void resetNominalCapacity();
   void autosizeNominalCapacity();
@@ -110,19 +110,19 @@ class MODEL_API BoilerSteam : public StraightComponent {
 
   boost::optional<double> coefficient1ofFuelUseFunctionofPartLoadRatioCurve() const;
   OSOptionalQuantity getCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-  void setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(double coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
+  bool setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(double coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient1ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient1ofFuelUseFunctionofPartLoadRatioCurve);
   void resetCoefficient1ofFuelUseFunctionofPartLoadRatioCurve();
 
   boost::optional<double> coefficient2ofFuelUseFunctionofPartLoadRatioCurve() const;
   OSOptionalQuantity getCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-  void setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(double coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
+  bool setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(double coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient2ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient2ofFuelUseFunctionofPartLoadRatioCurve);
   void resetCoefficient2ofFuelUseFunctionofPartLoadRatioCurve();
 
   boost::optional<double> coefficient3ofFuelUseFunctionofPartLoadRatioCurve() const;
   OSOptionalQuantity getCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(bool returnIP=false) const;
-  void setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(double coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
+  bool setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(double coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
   bool setCoefficient3ofFuelUseFunctionofPartLoadRatioCurve(const Quantity& coefficient3ofFuelUseFunctionofPartLoadRatioCurve);
   void resetCoefficient3ofFuelUseFunctionofPartLoadRatioCurve();
 

--- a/openstudiocore/src/model/BoilerSteam_Impl.hpp
+++ b/openstudiocore/src/model/BoilerSteam_Impl.hpp
@@ -44,56 +44,6 @@ namespace detail {
   /** BoilerSteam_Impl is a StraightComponent_Impl that is the implementation class for BoilerSteam.*/
   class MODEL_API BoilerSteam_Impl : public StraightComponent_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -119,6 +69,16 @@ namespace detail {
     virtual const std::vector<std::string>& outputVariableNames() const override;
 
     virtual IddObjectType iddObjectType() const override;
+
+    virtual void autosize() override;
+
+    virtual void applySizingValues() override;
+
+    virtual unsigned inletPort() override;
+
+    virtual unsigned outletPort() override;
+
+    virtual bool addToNode(Node & node) override;
 
     //@}
     /** @name Getters */
@@ -174,11 +134,10 @@ namespace detail {
 
     bool isSizingFactorDefaulted() const;
 
-  boost::optional<double> autosizedNominalCapacity() const ;
+    boost::optional<double> autosizedNominalCapacity() const ;
 
-  virtual void autosize() override;
+    std::string endUseSubcategory() const;
 
-  virtual void applySizingValues() override;
 
     //@}
     /** @name Setters */
@@ -254,15 +213,13 @@ namespace detail {
 
     void resetSizingFactor();
 
+    bool setEndUseSubcategory(const std::string & endUseSubcategory);
+
+
     //@}
     /** @name Other */
     //@{
 
-    unsigned inletPort() override;
-
-    unsigned outletPort() override;
-
-    bool addToNode(Node & node) override;
 
     //@}
    protected:

--- a/openstudiocore/src/model/ChillerElectricEIR.cpp
+++ b/openstudiocore/src/model/ChillerElectricEIR.cpp
@@ -866,6 +866,17 @@ namespace detail {
 
   }
 
+  std::string ChillerElectricEIR_Impl::endUseSubcategory() const {
+    auto value = getString(OS_Chiller_Electric_EIRFields::EndUseSubcategory,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool ChillerElectricEIR_Impl::setEndUseSubcategory(const std::string & endUseSubcategory) {
+    return setString(OS_Chiller_Electric_EIRFields::EndUseSubcategory,endUseSubcategory);
+  }
+
+
 } // detail
 
 ChillerElectricEIR::ChillerElectricEIR(const Model& model,
@@ -895,6 +906,9 @@ ChillerElectricEIR::ChillerElectricEIR(const Model& model,
   setBasinHeaterSetpointTemperature(10.0);
 
   resetBasinHeaterSchedule();
+
+  setEndUseSubcategory("General");
+
 }
 
 ChillerElectricEIR::ChillerElectricEIR(const Model& model)
@@ -946,6 +960,9 @@ ChillerElectricEIR::ChillerElectricEIR(const Model& model)
   setBasinHeaterCapacity(0.0);
   setBasinHeaterSetpointTemperature(10.0);
   resetBasinHeaterSchedule();
+
+  setEndUseSubcategory("General");
+
 }
 
 IddObjectType ChillerElectricEIR::iddObjectType() {
@@ -1402,6 +1419,14 @@ void ChillerElectricEIR::resetBasinHeaterSchedule()
 boost::optional<Schedule> ChillerElectricEIR::basinHeaterSchedule() const
 {
   return getImpl<detail::ChillerElectricEIR_Impl>()->basinHeaterSchedule();
+}
+
+std::string ChillerElectricEIR::endUseSubcategory() const {
+  return getImpl<detail::ChillerElectricEIR_Impl>()->endUseSubcategory();
+}
+
+bool ChillerElectricEIR::setEndUseSubcategory(const std::string & endUseSubcategory) {
+  return getImpl<detail::ChillerElectricEIR_Impl>()->setEndUseSubcategory(endUseSubcategory);
 }
 
 /// @cond

--- a/openstudiocore/src/model/ChillerElectricEIR.hpp
+++ b/openstudiocore/src/model/ChillerElectricEIR.hpp
@@ -172,6 +172,8 @@ class MODEL_API ChillerElectricEIR : public WaterToWaterComponent {
 
   boost::optional<Schedule> basinHeaterSchedule() const;
 
+  std::string endUseSubcategory() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -303,7 +305,21 @@ class MODEL_API ChillerElectricEIR : public WaterToWaterComponent {
 
   boost::optional<double> autosizedReferenceCondenserFluidFlowRate() const ;
 
+  bool setEndUseSubcategory(const std::string & endUseSubcategory);
 
+  // TODO
+  /*
+   *N18, \field Condenser Heat Recovery Relative Capacity Fraction
+   *     \note This optional field is the fraction of total rejected heat that can be recovered at full load
+   *     \type real
+   *     \minimum 0.0
+   *     \maximum 1.0
+   *A15, \field Heat Recovery Inlet High Temperature Limit Schedule Name
+   *     \note This optional schedule of temperatures will turn off heat recovery if inlet exceeds the value
+   *     \type object-list
+   *     \object-list ScheduleNames
+   *A16, \field Heat Recovery Leaving Temperature Setpoint Node Name
+   */
 
   //@}
  protected:

--- a/openstudiocore/src/model/ChillerElectricEIR_Impl.hpp
+++ b/openstudiocore/src/model/ChillerElectricEIR_Impl.hpp
@@ -87,6 +87,10 @@ class MODEL_API ChillerElectricEIR_Impl : public WaterToWaterComponent_Impl
 
   virtual unsigned tertiaryOutletPort() const override;
 
+  virtual void autosize() override;
+
+  virtual void applySizingValues() override;
+
   //@}
   boost::optional<double> referenceCapacity() const;
 
@@ -188,9 +192,7 @@ class MODEL_API ChillerElectricEIR_Impl : public WaterToWaterComponent_Impl
 
   boost::optional<double> autosizedReferenceCondenserFluidFlowRate() const ;
 
-  virtual void autosize() override;
-
-  virtual void applySizingValues() override;
+  std::string endUseSubcategory() const;
 
   //@}
   /** @name Setters */
@@ -317,6 +319,22 @@ class MODEL_API ChillerElectricEIR_Impl : public WaterToWaterComponent_Impl
   bool setBasinHeaterSchedule(Schedule & schedule );
 
   void resetBasinHeaterSchedule();
+
+  bool setEndUseSubcategory(const std::string & endUseSubcategory);
+
+  // TODO
+  /*
+   *N18, \field Condenser Heat Recovery Relative Capacity Fraction
+   *     \note This optional field is the fraction of total rejected heat that can be recovered at full load
+   *     \type real
+   *     \minimum 0.0
+   *     \maximum 1.0
+   *A15, \field Heat Recovery Inlet High Temperature Limit Schedule Name
+   *     \note This optional schedule of temperatures will turn off heat recovery if inlet exceeds the value
+   *     \type object-list
+   *     \object-list ScheduleNames
+   *A16, \field Heat Recovery Leaving Temperature Setpoint Node Name
+   */
 
   //@}
  protected:

--- a/openstudiocore/src/model/ScheduleTypeRegistry.cpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.cpp
@@ -353,6 +353,7 @@ ScheduleTypeRegistrySingleton::ScheduleTypeRegistrySingleton()
     {"WaterHeaterMixed","Ambient Temperature","ambientTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
     {"WaterHeaterMixed","Use Flow Rate Fraction","useFlowRateFractionSchedule",true,"",0.0,1.0},
     {"WaterHeaterMixed","Cold Water Supply Temperature","coldWaterSupplyTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
+    {"WaterHeaterMixed","Indirect Alternate Setpoint Temperature","indirectAlternateSetpointTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
     {"WaterHeaterHeatPump","Availability Schedule","availabilitySchedule",false,"Availability",0.0,1.0},
     {"WaterHeaterHeatPump","Compressor Setpoint Temperature Schedule","compressorSetpointTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
     {"WaterHeaterHeatPump","Inlet Air Temperature Schedule","inletAirTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},

--- a/openstudiocore/src/model/WaterHeaterMixed.cpp
+++ b/openstudiocore/src/model/WaterHeaterMixed.cpp
@@ -1714,6 +1714,16 @@ namespace detail {
 
   }
 
+  std::string WaterHeaterMixed_Impl::endUseSubcategory() const {
+    auto value = getString(OS_WaterHeater_MixedFields::EndUseSubcategory,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool WaterHeaterMixed_Impl::setEndUseSubcategory(const std::string & endUseSubcategory) {
+    return setString(OS_WaterHeater_MixedFields::EndUseSubcategory,endUseSubcategory);
+  }
+
 } // detail
 
 WaterHeaterMixed::WaterHeaterMixed(const Model& model)
@@ -1748,6 +1758,8 @@ WaterHeaterMixed::WaterHeaterMixed(const Model& model)
   ScheduleRuleset setpoint_schedule(model);
   setpoint_schedule.defaultDaySchedule().addValue(Time(0,24,0,0),60.0);
   setSetpointTemperatureSchedule(setpoint_schedule);
+
+  setEndUseSubcategory("General");
 }
 
 IddObjectType WaterHeaterMixed::iddObjectType() {
@@ -2449,6 +2461,14 @@ bool WaterHeaterMixed::setIndirectWaterHeatingRecoveryTime(const Quantity& indir
 
 void WaterHeaterMixed::resetIndirectWaterHeatingRecoveryTime() {
   getImpl<detail::WaterHeaterMixed_Impl>()->resetIndirectWaterHeatingRecoveryTime();
+}
+
+std::string WaterHeaterMixed::endUseSubcategory() const {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->endUseSubcategory();
+}
+
+bool WaterHeaterMixed::setEndUseSubcategory(const std::string & endUseSubcategory) {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->setEndUseSubcategory(endUseSubcategory);
 }
 
 /// @cond

--- a/openstudiocore/src/model/WaterHeaterMixed.cpp
+++ b/openstudiocore/src/model/WaterHeaterMixed.cpp
@@ -1741,6 +1741,8 @@ namespace detail {
 
   bool WaterHeaterMixed_Impl::setSourceSideFlowControlMode(const std::string & sourceSideFlowControlMode) {
 
+    bool result = false;
+
     // Do not accept IndirectHeatAlternateSetpoint unless there is already a schedule that is set
     if ( openstudio::istringEqual("IndirectHeatAlternateSetpoint", sourceSideFlowControlMode) )
     {
@@ -1753,14 +1755,18 @@ namespace detail {
     // If other than IndirectHeatAlternateSetpoint, Reset the indirect alternate setpoint temp schedule
     else
     {
-      if (indirectAlternateSetpointTemperatureSchedule()) {
+      // Have to do this before resetting the schedule, in case a bad (per IDD) value other than 'IndirectHeatAlternateSetpoint' is provided
+      result = setString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode, sourceSideFlowControlMode);
+
+      if (result && indirectAlternateSetpointTemperatureSchedule()) {
         LOG(Info, "Resetting the 'Indirect Alternate Setpoint Temperature Schedule Name' for " << briefDescription());
         setString(OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName, "");
       }
+
     }
 
-    bool result = setString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode, sourceSideFlowControlMode);
     return result;
+
   }
 
 

--- a/openstudiocore/src/model/WaterHeaterMixed.cpp
+++ b/openstudiocore/src/model/WaterHeaterMixed.cpp
@@ -192,6 +192,10 @@ namespace detail {
     {
       result.push_back(ScheduleTypeKey("WaterHeaterMixed","Cold Water Supply Temperature"));
     }
+    if (std::find(b,e,OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName) != e)
+    {
+      result.push_back(ScheduleTypeKey("WaterHeaterMixed","Indirect Alternate Setpoint Temperature"));
+    }
     return result;
   }
 
@@ -1724,6 +1728,97 @@ namespace detail {
     return setString(OS_WaterHeater_MixedFields::EndUseSubcategory,endUseSubcategory);
   }
 
+
+  std::vector<std::string> WaterHeaterMixed_Impl::sourceSideFlowControlModeValues() const {
+    return WaterHeaterMixed::sourceSideFlowControlModeValues();
+  }
+
+  std::string WaterHeaterMixed_Impl::sourceSideFlowControlMode() const {
+    boost::optional<std::string> value = getString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool WaterHeaterMixed_Impl::setSourceSideFlowControlMode(const std::string & sourceSideFlowControlMode) {
+
+    // Do not accept IndirectHeatAlternateSetpoint unless there is already a schedule that is set
+    if ( openstudio::istringEqual("IndirectHeatAlternateSetpoint", sourceSideFlowControlMode) )
+    {
+      if (!indirectAlternateSetpointTemperatureSchedule()) {
+        LOG(Warn, "If you want to use a Source Side Flow Control Mode of 'IndirectHeatAlternateSetpoint', "
+                  "use setIndirectAlternateSetpointTemperatureSchedule(schedule) instead for " << briefDescription());
+        return false;
+      }
+    }
+    // If other than IndirectHeatAlternateSetpoint, Reset the indirect alternate setpoint temp schedule
+    else
+    {
+      if (indirectAlternateSetpointTemperatureSchedule()) {
+        LOG(Info, "Resetting the 'Indirect Alternate Setpoint Temperature Schedule Name' for " << briefDescription());
+        setString(OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName, "");
+      }
+    }
+
+    bool result = setString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode, sourceSideFlowControlMode);
+    return result;
+  }
+
+
+  boost::optional<Schedule> WaterHeaterMixed_Impl::indirectAlternateSetpointTemperatureSchedule() const {
+    return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName);
+  }
+
+  bool WaterHeaterMixed_Impl::setIndirectAlternateSetpointTemperatureSchedule(Schedule& indirectAlternateSetpointTemperatureSchedule) {
+    bool result = setSchedule(OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName,
+                              "WaterHeaterMixed",
+                              "Indirect Alternate Setpoint Temperature",
+                              indirectAlternateSetpointTemperatureSchedule);
+    // Also set the source Side Flow Control Mode accordingly
+    if (result && !openstudio::istringEqual("IndirectHeatAlternateSetpoint", sourceSideFlowControlMode()) ) {
+      LOG(Info, "Setting the Source Side Flow Control Mode to 'IndirectHeatAlternateSetpoint' for " << briefDescription());
+      result = setString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode, "IndirectHeatAlternateSetpoint");
+    }
+    return result;
+  }
+
+  void WaterHeaterMixed_Impl::resetIndirectAlternateSetpointTemperatureSchedule() {
+    bool result = setString(OS_WaterHeater_MixedFields::IndirectAlternateSetpointTemperatureScheduleName, "");
+    OS_ASSERT(result);
+    // Reset the Source Side Flow Control Mode to the default "IndirectHeatPrimarySetpoint"
+    if ( openstudio::istringEqual("IndirectHeatAlternateSetpoint", sourceSideFlowControlMode()) ) {
+      LOG(Info, "Resetting the Source Side Flow Control Mode to the default 'IndirectHeatPrimarySetpoint' for " << briefDescription());
+      result = setString(OS_WaterHeater_MixedFields::SourceSideFlowControlMode, "IndirectHeatPrimarySetpoint");
+    }
+    OS_ASSERT(result);
+  }
+
+  boost::optional<ModelObject> WaterHeaterMixed_Impl::indirectAlternateSetpointTemperatureScheduleAsModelObject() const {
+    OptionalModelObject result;
+    OptionalSchedule intermediate = indirectAlternateSetpointTemperatureSchedule();
+    if (intermediate) {
+      result = *intermediate;
+    }
+    return result;
+  }
+
+  bool WaterHeaterMixed_Impl::setIndirectAlternateSetpointTemperatureScheduleAsModelObject(const boost::optional<ModelObject>& modelObject) {
+    if (modelObject) {
+      OptionalSchedule intermediate = modelObject->optionalCast<Schedule>();
+      if (intermediate) {
+        Schedule schedule(*intermediate);
+        return setIndirectAlternateSetpointTemperatureSchedule(schedule);
+      }
+      else {
+        return false;
+      }
+    }
+    else {
+      resetIndirectAlternateSetpointTemperatureSchedule();
+    }
+    return true;
+  }
+
+
 } // detail
 
 WaterHeaterMixed::WaterHeaterMixed(const Model& model)
@@ -1759,6 +1854,7 @@ WaterHeaterMixed::WaterHeaterMixed(const Model& model)
   setpoint_schedule.defaultDaySchedule().addValue(Time(0,24,0,0),60.0);
   setSetpointTemperatureSchedule(setpoint_schedule);
 
+  setSourceSideFlowControlMode("IndirectHeatPrimarySetpoint");
   setEndUseSubcategory("General");
 }
 
@@ -2461,6 +2557,32 @@ bool WaterHeaterMixed::setIndirectWaterHeatingRecoveryTime(const Quantity& indir
 
 void WaterHeaterMixed::resetIndirectWaterHeatingRecoveryTime() {
   getImpl<detail::WaterHeaterMixed_Impl>()->resetIndirectWaterHeatingRecoveryTime();
+}
+
+
+std::vector<std::string> WaterHeaterMixed::sourceSideFlowControlModeValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_WaterHeater_MixedFields::SourceSideFlowControlMode);
+}
+
+std::string WaterHeaterMixed::sourceSideFlowControlMode() const {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->sourceSideFlowControlMode();
+}
+
+bool WaterHeaterMixed::setSourceSideFlowControlMode(const std::string & sourceSideFlowControlMode) {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->setSourceSideFlowControlMode(sourceSideFlowControlMode);
+}
+
+
+boost::optional<Schedule> WaterHeaterMixed::indirectAlternateSetpointTemperatureSchedule() const {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->indirectAlternateSetpointTemperatureSchedule();
+}
+
+bool WaterHeaterMixed::setIndirectAlternateSetpointTemperatureSchedule(Schedule& indirectAlternateSetpointTemperatureSchedule) {
+  return getImpl<detail::WaterHeaterMixed_Impl>()->setIndirectAlternateSetpointTemperatureSchedule(indirectAlternateSetpointTemperatureSchedule);
+}
+void WaterHeaterMixed::resetIndirectAlternateSetpointTemperatureSchedule() {
+  getImpl<detail::WaterHeaterMixed_Impl>()->resetIndirectAlternateSetpointTemperatureSchedule();
 }
 
 std::string WaterHeaterMixed::endUseSubcategory() const {

--- a/openstudiocore/src/model/WaterHeaterMixed.hpp
+++ b/openstudiocore/src/model/WaterHeaterMixed.hpp
@@ -74,6 +74,8 @@ class MODEL_API WaterHeaterMixed : public WaterToWaterComponent {
 
   static std::vector<std::string> ambientTemperatureIndicatorValues();
 
+  static std::vector<std::string> sourceSideFlowControlModeValues();
+
   /** @name Getters */
   //@{
 
@@ -228,6 +230,10 @@ class MODEL_API WaterHeaterMixed : public WaterToWaterComponent {
   Quantity getIndirectWaterHeatingRecoveryTime(bool returnIP=false) const;
 
   bool isIndirectWaterHeatingRecoveryTimeDefaulted() const;
+
+  std::string sourceSideFlowControlMode() const;
+
+  boost::optional<Schedule> indirectAlternateSetpointTemperatureSchedule() const;
 
   std::string endUseSubcategory() const;
 
@@ -427,24 +433,18 @@ class MODEL_API WaterHeaterMixed : public WaterToWaterComponent {
 
   boost::optional<double> autosizedSourceSideDesignFlowRate() const;
 
-  bool setEndUseSubcategory(const std::string & endUseSubcategory);
-
-  // TODO
-  /*
-   *A19, \field Source Side Flow Control Mode
-   *     \type choice
-   *     \key StorageTank
-   *     \key IndirectHeatPrimarySetpoint
-   *     \key IndirectHeatAlternateSetpoint
-   *     \default IndirectHeatPrimarySetpoint
-   *     \note StorageTank mode always requests flow unless tank is at its Maximum Temperature Limit
-   *     \note IndirectHeatPrimarySetpoint mode requests flow whenever primary setpoint calls for heat
-   *     \note IndirectHeatAlternateSetpoint mode requests flow whenever alternate indirect setpoint calls for heat
-   *A20, \field Indirect Alternate Setpoint Temperature Schedule Name
-   *     \note This field is only used if the previous is set to IndirectHeatAlternateSetpoint
-   *     \type object-list
-   *     \object-list ScheduleName
+  /* This will not accept 'IndirectHeatAlternateSetpoint' as a control mode, you should instead use 'setIndirectAlternateSetpointTemperatureSchedule'.
+   * For any other modes ('StorageTank', 'IndirectHeatPrimarySetpoint'), this resets the indirect alternate setpoint temperature schedule
    */
+  bool setSourceSideFlowControlMode(const std::string & sourceSideFlowControlMode);
+
+  /* This will automatically switch the Source Side Flow Control Mode to 'IndirectHeatAlternateSetpoint' */
+  bool setIndirectAlternateSetpointTemperatureSchedule(Schedule& indirectAlternateSetpointTemperatureSchedule);
+
+  /* This will automatically reset the Source Side Flow Control Mode to default 'IndirectHeatPrimarySetpoint' */
+  void resetIndirectAlternateSetpointTemperatureSchedule();
+
+  bool setEndUseSubcategory(const std::string & endUseSubcategory);
 
   //@}
  protected:

--- a/openstudiocore/src/model/WaterHeaterMixed.hpp
+++ b/openstudiocore/src/model/WaterHeaterMixed.hpp
@@ -229,6 +229,8 @@ class MODEL_API WaterHeaterMixed : public WaterToWaterComponent {
 
   bool isIndirectWaterHeatingRecoveryTimeDefaulted() const;
 
+  std::string endUseSubcategory() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -417,15 +419,32 @@ class MODEL_API WaterHeaterMixed : public WaterToWaterComponent {
 
   void resetIndirectWaterHeatingRecoveryTime();
 
-  boost::optional<double> autosizedTankVolume() const ;
+  boost::optional<double> autosizedTankVolume() const;
 
-  boost::optional<double> autosizedHeaterMaximumCapacity() const ;
+  boost::optional<double> autosizedHeaterMaximumCapacity() const;
 
-  boost::optional<double> autosizedUseSideDesignFlowRate() const ;
+  boost::optional<double> autosizedUseSideDesignFlowRate() const;
 
-  boost::optional<double> autosizedSourceSideDesignFlowRate() const ;
+  boost::optional<double> autosizedSourceSideDesignFlowRate() const;
 
+  bool setEndUseSubcategory(const std::string & endUseSubcategory);
 
+  // TODO
+  /*
+   *A19, \field Source Side Flow Control Mode
+   *     \type choice
+   *     \key StorageTank
+   *     \key IndirectHeatPrimarySetpoint
+   *     \key IndirectHeatAlternateSetpoint
+   *     \default IndirectHeatPrimarySetpoint
+   *     \note StorageTank mode always requests flow unless tank is at its Maximum Temperature Limit
+   *     \note IndirectHeatPrimarySetpoint mode requests flow whenever primary setpoint calls for heat
+   *     \note IndirectHeatAlternateSetpoint mode requests flow whenever alternate indirect setpoint calls for heat
+   *A20, \field Indirect Alternate Setpoint Temperature Schedule Name
+   *     \note This field is only used if the previous is set to IndirectHeatAlternateSetpoint
+   *     \type object-list
+   *     \object-list ScheduleName
+   */
 
   //@}
  protected:

--- a/openstudiocore/src/model/WaterHeaterMixed_Impl.hpp
+++ b/openstudiocore/src/model/WaterHeaterMixed_Impl.hpp
@@ -46,139 +46,6 @@ namespace detail {
 
   class MODEL_API WaterHeaterMixed_Impl : public WaterToWaterComponent_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -214,6 +81,13 @@ namespace detail {
     virtual unsigned demandInletPort() override;
 
     virtual unsigned demandOutletPort() override;
+
+    virtual void autosize() override;
+
+    virtual void applySizingValues() override;
+
+    boost::optional<ZoneHVACComponent> containingZoneHVACComponent() const override;
+
 
     //@}
     /** @name Getters */
@@ -371,17 +245,15 @@ namespace detail {
 
     bool isIndirectWaterHeatingRecoveryTimeDefaulted() const;
 
-  boost::optional<double> autosizedTankVolume() const ;
+    boost::optional<double> autosizedTankVolume() const;
 
-  boost::optional<double> autosizedHeaterMaximumCapacity() const ;
+    boost::optional<double> autosizedHeaterMaximumCapacity() const;
 
-  boost::optional<double> autosizedUseSideDesignFlowRate() const ;
+    boost::optional<double> autosizedUseSideDesignFlowRate() const;
 
-  boost::optional<double> autosizedSourceSideDesignFlowRate() const ;
+    boost::optional<double> autosizedSourceSideDesignFlowRate() const;
 
-  virtual void autosize() override;
-
-  virtual void applySizingValues() override;
+    std::string endUseSubcategory() const;
 
     //@}
     /** @name Setters */
@@ -571,7 +443,24 @@ namespace detail {
 
     void resetIndirectWaterHeatingRecoveryTime();
 
-    boost::optional<ZoneHVACComponent> containingZoneHVACComponent() const override;
+    bool setEndUseSubcategory(const std::string & endUseSubcategory);
+
+    // TODO
+  /*
+   *A19, \field Source Side Flow Control Mode
+   *     \type choice
+   *     \key StorageTank
+   *     \key IndirectHeatPrimarySetpoint
+   *     \key IndirectHeatAlternateSetpoint
+   *     \default IndirectHeatPrimarySetpoint
+   *     \note StorageTank mode always requests flow unless tank is at its Maximum Temperature Limit
+   *     \note IndirectHeatPrimarySetpoint mode requests flow whenever primary setpoint calls for heat
+   *     \note IndirectHeatAlternateSetpoint mode requests flow whenever alternate indirect setpoint calls for heat
+   *A20, \field Indirect Alternate Setpoint Temperature Schedule Name
+   *     \note This field is only used if the previous is set to IndirectHeatAlternateSetpoint
+   *     \type object-list
+   *     \object-list ScheduleName
+   */
 
     //@}
    protected:

--- a/openstudiocore/src/model/WaterHeaterMixed_Impl.hpp
+++ b/openstudiocore/src/model/WaterHeaterMixed_Impl.hpp
@@ -253,6 +253,10 @@ namespace detail {
 
     boost::optional<double> autosizedSourceSideDesignFlowRate() const;
 
+    std::string sourceSideFlowControlMode() const;
+
+    boost::optional<Schedule> indirectAlternateSetpointTemperatureSchedule() const;
+
     std::string endUseSubcategory() const;
 
     //@}
@@ -443,24 +447,12 @@ namespace detail {
 
     void resetIndirectWaterHeatingRecoveryTime();
 
-    bool setEndUseSubcategory(const std::string & endUseSubcategory);
+    bool setSourceSideFlowControlMode(const std::string & sourceSideFlowControlMode);
 
-    // TODO
-  /*
-   *A19, \field Source Side Flow Control Mode
-   *     \type choice
-   *     \key StorageTank
-   *     \key IndirectHeatPrimarySetpoint
-   *     \key IndirectHeatAlternateSetpoint
-   *     \default IndirectHeatPrimarySetpoint
-   *     \note StorageTank mode always requests flow unless tank is at its Maximum Temperature Limit
-   *     \note IndirectHeatPrimarySetpoint mode requests flow whenever primary setpoint calls for heat
-   *     \note IndirectHeatAlternateSetpoint mode requests flow whenever alternate indirect setpoint calls for heat
-   *A20, \field Indirect Alternate Setpoint Temperature Schedule Name
-   *     \note This field is only used if the previous is set to IndirectHeatAlternateSetpoint
-   *     \type object-list
-   *     \object-list ScheduleName
-   */
+    bool setIndirectAlternateSetpointTemperatureSchedule(Schedule& indirectAlternateSetpointTemperatureSchedule);
+    void resetIndirectAlternateSetpointTemperatureSchedule();
+
+    bool setEndUseSubcategory(const std::string & endUseSubcategory);
 
     //@}
    protected:
@@ -518,6 +510,7 @@ namespace detail {
     openstudio::OSOptionalQuantity sourceSideDesignFlowRate_IP() const;
     openstudio::Quantity indirectWaterHeatingRecoveryTime_SI() const;
     openstudio::Quantity indirectWaterHeatingRecoveryTime_IP() const;
+    std::vector<std::string> sourceSideFlowControlModeValues() const;
 
     boost::optional<ModelObject> setpointTemperatureScheduleAsModelObject() const;
     boost::optional<ModelObject> partLoadFactorCurveAsModelObject() const;
@@ -526,12 +519,17 @@ namespace detail {
     boost::optional<ModelObject> useFlowRateFractionScheduleAsModelObject() const;
     boost::optional<ModelObject> coldWaterSupplyTemperatureScheduleAsModelObject() const;
 
+    boost::optional<ModelObject> indirectAlternateSetpointTemperatureScheduleAsModelObject() const;
+
     bool setSetpointTemperatureScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setPartLoadFactorCurveAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setAmbientTemperatureScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setAmbientTemperatureThermalZoneAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setUseFlowRateFractionScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setColdWaterSupplyTemperatureScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
+
+    bool setIndirectAlternateSetpointTemperatureScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
+
   };
 
 } // detail

--- a/openstudiocore/src/model/test/WaterHeaterMixed_GTest.cpp
+++ b/openstudiocore/src/model/test/WaterHeaterMixed_GTest.cpp
@@ -31,6 +31,9 @@
 #include "../WaterHeaterMixed.hpp"
 #include "../WaterHeaterMixed_Impl.hpp"
 
+#include "../ScheduleConstant.hpp"
+
+
 using namespace openstudio;
 using namespace openstudio::model;
 
@@ -48,4 +51,43 @@ TEST(WaterHeaterMixed,WaterHeaterMixed_WaterHeaterMixed)
   } ,
     ::testing::ExitedWithCode(0), "" );
 }
+
+TEST(WaterHeaterMixed,WaterHeaterMixed_NewFields)
+{
+  Model m;
+
+  WaterHeaterMixed wh(m);
+
+  // Test defaults
+  EXPECT_EQ("IndirectHeatPrimarySetpoint", wh.sourceSideFlowControlMode());
+  EXPECT_FALSE(wh.indirectAlternateSetpointTemperatureSchedule());
+  EXPECT_EQ("General", wh.endUseSubcategory());
+
+
+  EXPECT_TRUE(wh.setSourceSideFlowControlMode("StorageTank"));
+  // Shouldn't accept it, it should be set via the schedule method
+  EXPECT_FALSE(wh.setSourceSideFlowControlMode("IndirectHeatAlternateSetpoint"));
+  EXPECT_FALSE(wh.setSourceSideFlowControlMode("BadValue"));
+
+  ScheduleConstant sch(m);
+  EXPECT_TRUE(wh.setIndirectAlternateSetpointTemperatureSchedule(sch));
+  ASSERT_TRUE(wh.indirectAlternateSetpointTemperatureSchedule());
+  EXPECT_EQ(sch, wh.indirectAlternateSetpointTemperatureSchedule().get());
+  EXPECT_EQ("IndirectHeatAlternateSetpoint", wh.sourceSideFlowControlMode());
+
+  // Reset the schedule also resets the flow control mode
+  wh.resetIndirectAlternateSetpointTemperatureSchedule();
+  EXPECT_FALSE(wh.indirectAlternateSetpointTemperatureSchedule());
+  EXPECT_EQ("IndirectHeatPrimarySetpoint", wh.sourceSideFlowControlMode());
+
+  EXPECT_TRUE(wh.setIndirectAlternateSetpointTemperatureSchedule(sch));
+  // Changing the flow control should reset the schedule
+  EXPECT_TRUE(wh.setSourceSideFlowControlMode("StorageTank"));
+  EXPECT_FALSE(wh.indirectAlternateSetpointTemperatureSchedule());
+
+  EXPECT_TRUE(wh.setEndUseSubcategory("SomethingElse"));
+  EXPECT_EQ("SomethingElse", wh.endUseSubcategory());
+
+}
+
 

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -556,6 +556,11 @@
     <rule IddField="Basin Heater Setpoint Temperature" Access="HIDDEN"/>
     <rule IddField="Basin Heater Operating Schedule Name" Access="HIDDEN"/>
     <rule IddField="Condenser Type" Access="HIDDEN"/>
+
+    <!-- REMOVE ONCE IMPLEMENTED IN SDK -->
+    <rule IddField="Condenser Heat Recovery Relative Capacity Fraction" Access="HIDDEN"/>
+    <rule IddField="Heat Recovery Inlet High Temperature Limit Schedule Name" Access="HIDDEN"/>
+    <rule IddField="Heat Recovery Leaving Temperature Setpoint Node Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_Chiller_Absorption_Indirect">
     <rule IddField="Chilled Water Inlet Node Name" Access="HIDDEN"/>

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -3909,6 +3909,12 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
         }
       }
 
+      // Source Side Flow Control Mode
+      newObject.setString(40,"IndirectHeatPrimarySetpoint");
+
+      // Indirect Alternate Setpoint Temperature Schedule Name: nothing to do, leave empty
+
+      // End Use Subcategory
       newObject.setString(42,"General");
 
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
@@ -3923,6 +3929,16 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
           newObject.setString(i,value.get());
         }
       }
+
+      // Condenser Heat Recovery Relative Capacity Fraction: this is an optional
+      // but in E+ code (ChillerElectricEIR.cc > GetElectricEIRChillerInput() around line 655)
+      // if omitted (and heat recovery is used), it defaults to 1.0
+      // newObject.setDouble(32, 1.0);
+
+      // Heat Recovery Inlet High Temperature Limit Schedule Name: leave empty
+
+
+      // Heat Recovery Leaving Temperature Setpoint Node Name: leave empty
 
       // endUseSubcategory
       newObject.setString(34,"General");

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -119,8 +119,8 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("2.1.1")] = &VersionTranslator::update_2_1_0_to_2_1_1;
   m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::update_2_1_1_to_2_1_2;
   m_updateMethods[VersionString("2.3.1")] = &VersionTranslator::update_2_3_0_to_2_3_1;
-  m_updateMethods[VersionString("2.4.1")] = &VersionTranslator::update_2_4_0_to_2_4_1;
-  // m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::defaultUpdate;
+  m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::update_2_4_1_to_2_4_2;
+  //m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::defaultUpdate;
 
   // List of previous versions that may be updated to this one.
   //   - To increment the translator, add an entry for the version just released (branched for
@@ -3622,49 +3622,6 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
 
-    } else if (iddname == "OS:Boiler:HotWater") {
-      auto iddObject = idd_2_3_1.getObject("OS:Boiler:HotWater");
-      IdfObject newObject(iddObject.get());
-
-      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
-        if( (value = object.getString(i)) ) {
-          newObject.setString(i,value.get());
-        }
-      }
-      newObject.setString(18,"General");
-
-      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
-      ss << newObject;
-
-    } else if (iddname == "OS:Boiler:Steam") {
-      auto iddObject = idd_2_3_1.getObject("OS:Boiler:Steam");
-      IdfObject newObject(iddObject.get());
-
-      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
-        if( (value = object.getString(i)) ) {
-          newObject.setString(i,value.get());
-        }
-      }
-      newObject.setString(16,"General");
-
-      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
-      ss << newObject;
-
-    } else if (iddname == "OS:WaterHeater:Mixed") {
-      auto iddObject = idd_2_3_1.getObject("OS:WaterHeater:Mixed");
-      IdfObject newObject(iddObject.get());
-
-      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
-        if( (value = object.getString(i)) ) {
-          newObject.setString(i,value.get());
-        }
-      }
-
-      newObject.setString(42,"General");
-
-      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
-      ss << newObject;
-
     } else if (iddname == "OS:Chiller:Electric:EIR") {
       auto iddObject = idd_2_3_1.getObject("OS:Chiller:Electric:EIR");
       IdfObject newObject(iddObject.get());
@@ -3674,9 +3631,6 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
           newObject.setString(i,value.get());
         }
       }
-
-      // endUseSubcategory
-      newObject.setString(34,"General");
 
       if( object.getString(17) && (! object.getString(17).get().empty()) ) {
         newObject.setString(19,"WaterCooled");
@@ -3859,20 +3813,45 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
 std::string VersionTranslator::update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, const IddFileAndFactoryWrapper& idd_2_4_2) {
   std::stringstream ss;
 
-std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, const IddFileAndFactoryWrapper& idd_2_4_1) {
-  std::stringstream ss;
-
-  ss << idf_2_4_0.header() << std::endl << std::endl;
-  IdfFile targetIdf(idd_2_4_1.iddFile());
+  ss << idf_2_4_1.header() << std::endl << std::endl;
+  IdfFile targetIdf(idd_2_4_2.iddFile());
   ss << targetIdf.versionObject().get();
 
   boost::optional<std::string> value;
 
-  for (const IdfObject& object : idf_2_4_0.objects()) {
+  for (const IdfObject& object : idf_2_4_1.objects()) {
     auto iddname = object.iddObject().name();
 
-    if (iddname == "OS:Boiler:HotWater") {
-      auto iddObject = idd_2_4_1.getObject("OS:Boiler:HotWater");
+    if (iddname == "OS:BuildingUnit") {
+      auto iddObject = idd_2_4_2.getObject("OS:BuildingUnit");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
+      iddObject = idd_2_4_2.getObject("OS:AdditionalProperties");
+      IdfObject additionalProperties(iddObject.get());
+      additionalProperties.setString(0, toString(createUUID()));
+      additionalProperties.setString(1, newObject.getString(0).get()); // point additional properties to new object
+
+      size_t newIdx = 2;
+      for( size_t oldIdx = object.numNonextensibleFields(); oldIdx < object.numFields(); ++oldIdx, ++newIdx ) {
+        if( (value = object.getString(oldIdx)) ) {
+          additionalProperties.setString(newIdx, value.get());
+        }
+      }
+
+      m_new.push_back(additionalProperties);
+      ss << additionalProperties;
+
+    } else if (iddname == "OS:Boiler:HotWater") {
+      auto iddObject = idd_2_4_2.getObject("OS:Boiler:HotWater");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3886,7 +3865,7 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
       ss << newObject;
 
     } else if (iddname == "OS:Boiler:Steam") {
-      auto iddObject = idd_2_4_1.getObject("OS:Boiler:Steam");
+      auto iddObject = idd_2_4_2.getObject("OS:Boiler:Steam");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3900,7 +3879,7 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
       ss << newObject;
 
     } else if (iddname == "OS:WaterHeater:Mixed") {
-      auto iddObject = idd_2_4_1.getObject("OS:WaterHeater:Mixed");
+      auto iddObject = idd_2_4_2.getObject("OS:WaterHeater:Mixed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3921,7 +3900,7 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
       ss << newObject;
 
     } else if (iddname == "OS:Chiller:Electric:EIR") {
-      auto iddObject = idd_2_4_1.getObject("OS:Chiller:Electric:EIR");
+      auto iddObject = idd_2_4_2.getObject("OS:Chiller:Electric:EIR");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3946,6 +3925,7 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
 
+    // Default case
     } else {
       ss << object;
     }
@@ -3953,7 +3933,6 @@ std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, c
 
   return ss.str();
 }
-
 
 } // osversion
 } // openstudio

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -119,8 +119,8 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("2.1.1")] = &VersionTranslator::update_2_1_0_to_2_1_1;
   m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::update_2_1_1_to_2_1_2;
   m_updateMethods[VersionString("2.3.1")] = &VersionTranslator::update_2_3_0_to_2_3_1;
-  m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::update_2_4_1_to_2_4_2;
-  //m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::defaultUpdate;
+  m_updateMethods[VersionString("2.4.1")] = &VersionTranslator::update_2_4_0_to_2_4_1;
+  // m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::defaultUpdate;
 
   // List of previous versions that may be updated to this one.
   //   - To increment the translator, add an entry for the version just released (branched for
@@ -3622,8 +3622,6 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
 
-
-
     } else if (iddname == "OS:Boiler:HotWater") {
       auto iddObject = idd_2_3_1.getObject("OS:Boiler:HotWater");
       IdfObject newObject(iddObject.get());
@@ -3635,6 +3633,9 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
       }
       newObject.setString(18,"General");
 
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
     } else if (iddname == "OS:Boiler:Steam") {
       auto iddObject = idd_2_3_1.getObject("OS:Boiler:Steam");
       IdfObject newObject(iddObject.get());
@@ -3645,6 +3646,9 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
         }
       }
       newObject.setString(16,"General");
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
 
     } else if (iddname == "OS:WaterHeater:Mixed") {
       auto iddObject = idd_2_3_1.getObject("OS:WaterHeater:Mixed");
@@ -3658,6 +3662,8 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
 
       newObject.setString(42,"General");
 
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
 
     } else if (iddname == "OS:Chiller:Electric:EIR") {
       auto iddObject = idd_2_3_1.getObject("OS:Chiller:Electric:EIR");
@@ -3853,17 +3859,48 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
 std::string VersionTranslator::update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, const IddFileAndFactoryWrapper& idd_2_4_2) {
   std::stringstream ss;
 
-  ss << idf_2_4_1.header() << std::endl << std::endl;
-  IdfFile targetIdf(idd_2_4_2.iddFile());
+std::string VersionTranslator::update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, const IddFileAndFactoryWrapper& idd_2_4_1) {
+  std::stringstream ss;
+
+  ss << idf_2_4_0.header() << std::endl << std::endl;
+  IdfFile targetIdf(idd_2_4_1.iddFile());
   ss << targetIdf.versionObject().get();
 
   boost::optional<std::string> value;
 
-  for (const IdfObject& object : idf_2_4_1.objects()) {
+  for (const IdfObject& object : idf_2_4_0.objects()) {
     auto iddname = object.iddObject().name();
 
-    if (iddname == "OS:BuildingUnit") {
-      auto iddObject = idd_2_4_2.getObject("OS:BuildingUnit");
+    if (iddname == "OS:Boiler:HotWater") {
+      auto iddObject = idd_2_4_1.getObject("OS:Boiler:HotWater");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+      newObject.setString(18,"General");
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
+    } else if (iddname == "OS:Boiler:Steam") {
+      auto iddObject = idd_2_4_1.getObject("OS:Boiler:Steam");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+      newObject.setString(16,"General");
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
+    } else if (iddname == "OS:WaterHeater:Mixed") {
+      auto iddObject = idd_2_4_1.getObject("OS:WaterHeater:Mixed");
       IdfObject newObject(iddObject.get());
 
       for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
@@ -3872,23 +3909,27 @@ std::string VersionTranslator::update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, c
         }
       }
 
+      newObject.setString(42,"General");
+
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
 
-      iddObject = idd_2_4_2.getObject("OS:AdditionalProperties");
-      IdfObject additionalProperties(iddObject.get());
-      additionalProperties.setString(0, toString(createUUID()));
-      additionalProperties.setString(1, newObject.getString(0).get()); // point additional properties to new object
+    } else if (iddname == "OS:Chiller:Electric:EIR") {
+      auto iddObject = idd_2_4_1.getObject("OS:Chiller:Electric:EIR");
+      IdfObject newObject(iddObject.get());
 
-      size_t newIdx = 2;
-      for( size_t oldIdx = object.numNonextensibleFields(); oldIdx < object.numFields(); ++oldIdx, ++newIdx ) {
-        if( (value = object.getString(oldIdx)) ) {
-          additionalProperties.setString(newIdx, value.get());
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
         }
       }
 
-      m_new.push_back(additionalProperties);
-      ss << additionalProperties;
+      // endUseSubcategory
+      newObject.setString(34,"General");
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
     } else {
       ss << object;
     }
@@ -3896,6 +3937,7 @@ std::string VersionTranslator::update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, c
 
   return ss.str();
 }
+
 
 } // osversion
 } // openstudio

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -3622,6 +3622,43 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;
 
+
+
+    } else if (iddname == "OS:Boiler:HotWater") {
+      auto iddObject = idd_2_3_1.getObject("OS:Boiler:HotWater");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+      newObject.setString(18,"General");
+
+    } else if (iddname == "OS:Boiler:Steam") {
+      auto iddObject = idd_2_3_1.getObject("OS:Boiler:Steam");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+      newObject.setString(16,"General");
+
+    } else if (iddname == "OS:WaterHeater:Mixed") {
+      auto iddObject = idd_2_3_1.getObject("OS:WaterHeater:Mixed");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          newObject.setString(i,value.get());
+        }
+      }
+
+      newObject.setString(42,"General");
+
+
     } else if (iddname == "OS:Chiller:Electric:EIR") {
       auto iddObject = idd_2_3_1.getObject("OS:Chiller:Electric:EIR");
       IdfObject newObject(iddObject.get());
@@ -3631,6 +3668,9 @@ std::string VersionTranslator::update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, c
           newObject.setString(i,value.get());
         }
       }
+
+      // endUseSubcategory
+      newObject.setString(34,"General");
 
       if( object.getString(17) && (! object.getString(17).get().empty()) ) {
         newObject.setString(19,"WaterCooled");

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -220,7 +220,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, const IddFileAndFactoryWrapper& idd_2_1_1);
   std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
   std::string update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1);
-  std::string update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, const IddFileAndFactoryWrapper& idd_2_4_2);
+  std::string update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, const IddFileAndFactoryWrapper& idd_2_4_1);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -220,7 +220,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_1_0_to_2_1_1(const IdfFile& idf_2_1_0, const IddFileAndFactoryWrapper& idd_2_1_1);
   std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
   std::string update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1);
-  std::string update_2_4_0_to_2_4_1(const IdfFile& idf_2_4_0, const IddFileAndFactoryWrapper& idd_2_4_1);
+  std::string update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, const IddFileAndFactoryWrapper& idd_2_4_2);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
I noticed in @JasonGlazer 's Leed reporting measure, there are notes about missing "End Use Subcategory" Fields (see [here](https://github.com/JasonGlazer/LEEDreport/blob/master/apply_end_use_subcategory/resources/End-Use%20Subcategory%20OpenStudio%20Measure%20Design%20Doc-rev01.pdf).


The cooling towers already had them. I added it for WaterHeater:Mixed, Boiler:HotWater and Boiler:Steam and Chiller:Electric:EIR, and that should be all of it now.
Wrote version translation to hardset these fields to "General".

I added the fields in between (end use subcat is the last in IDD) where there were any, but I only implemented setters, getters and forward translation for the WaterHeater;Mixed new fields Source Side Flow Control Mode and IndirectAlternateSetpointTemperatureSchedule.

For Chiller:Electric:EIR, I did **not** implement these so I hide them in the OS App
```
<rule IddField="Condenser Heat Recovery Relative Capacity Fraction" Access="HIDDEN"/> 
<rule IddField="Heat Recovery Inlet High Temperature Limit Schedule Name" Access="HIDDEN"/> 
<rule IddField="Heat Recovery Leaving Temperature Setpoint Node Name
```