### PR TITLE
Update link to openstudio cli

### DIFF
--- a/openstudiocore/src/install_utility/main.cpp
+++ b/openstudiocore/src/install_utility/main.cpp
@@ -77,6 +77,9 @@ int main(int argc, char *argv[])
           if( ! openstudio::filesystem::exists(dir) ) {
             openstudio::filesystem::create_directories(dir);
           }
+          try {
+            openstudio::filesystem::remove("/usr/local/bin/openstudio");
+          } catch(...) {}
           fs::create_symlink(cliPath.string(),"/usr/local/bin/openstudio");
         }
       } catch(...) {}


### PR DESCRIPTION
On Mac, if the /usr/bin/openstudio link already exists,
perhaps from a previous version, then the attempt to
make a new link will fail.

Remove the old stale link before making the new link.

close #2428