### PR TITLE
Fix #3084 and NREL/OpenStudio-resources#43

### DIFF
--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -121,6 +121,7 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("2.1.2")] = &VersionTranslator::update_2_1_1_to_2_1_2;
   m_updateMethods[VersionString("2.3.1")] = &VersionTranslator::update_2_3_0_to_2_3_1;
   m_updateMethods[VersionString("2.4.2")] = &VersionTranslator::update_2_4_1_to_2_4_2;
+  m_updateMethods[VersionString("2.5.0")] = &VersionTranslator::update_2_4_3_to_2_5_0;
   m_updateMethods[VersionString("2.5.1")] = &VersionTranslator::defaultUpdate;
 
   // List of previous versions that may be updated to this one.
@@ -258,6 +259,7 @@ VersionTranslator::VersionTranslator()
   m_startVersions.push_back(VersionString("2.4.0"));
   m_startVersions.push_back(VersionString("2.4.1"));
   m_startVersions.push_back(VersionString("2.4.2"));
+  m_startVersions.push_back(VersionString("2.4.3"));
   m_startVersions.push_back(VersionString("2.5.0"));
 }
 
@@ -3924,6 +3926,64 @@ std::string VersionTranslator::update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, c
 
       // endUseSubcategory
       newObject.setString(34,"General");
+
+      m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
+      ss << newObject;
+
+    // Default case
+    } else {
+      ss << object;
+    }
+  }
+
+  return ss.str();
+}
+
+
+std::string VersionTranslator::update_2_4_3_to_2_5_0(const IdfFile& idf_2_4_3, const IddFileAndFactoryWrapper& idd_2_5_0){
+  std::stringstream ss;
+
+  ss << idf_2_4_3.header() << std::endl << std::endl;
+  IdfFile targetIdf(idd_2_5_0.iddFile());
+  ss << targetIdf.versionObject().get();
+
+  boost::optional<std::string> value;
+
+  for (const IdfObject& object : idf_2_4_3.objects()) {
+    auto iddname = object.iddObject().name();
+
+    if (iddname == "OS:AirflowNetworkZone") {
+      // In 2.5.0, a field "Name" was inserted right after the handle
+      auto iddObject = idd_2_5_0.getObject("OS:AirflowNetworkZone");
+      IdfObject newObject(iddObject.get());
+
+      for( size_t i = 0; i < object.numNonextensibleFields(); ++i ) {
+        if( (value = object.getString(i)) ) {
+          if (i == 0) {
+            // Handle
+            newObject.setString(i, value.get());
+          } else if (i == 1) {
+            // Thermal Zone Name field
+
+            // We place the Thermal Zone's handle into the right field
+            newObject.setString(i+1, value.get());
+
+            // We want to rename the AFN Zone object with its thermal Zone name
+            // So we need to locate the right thermal zone from its handle so we can get the name
+            boost::optional<IdfObject> _zone = idf_2_4_3.getObject(toUUID(value.get()));
+            if (_zone) {
+              newObject.setString(i, "Airflow Network Zone " + _zone->nameString());
+            } else {
+              // Safety fall back, name it with the thermal zone handle instead...
+              newObject.setString(i, "Airflow Network Zone " + value.get());
+            }
+
+          } else {
+            // Every other is shifted by one field
+            newObject.setString(i+1, value.get());
+          }
+        }
+      }
 
       m_refactored.push_back( std::pair<IdfObject,IdfObject>(object,newObject) );
       ss << newObject;

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -222,6 +222,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_1_1_to_2_1_2(const IdfFile& idf_2_1_1, const IddFileAndFactoryWrapper& idd_2_1_2);
   std::string update_2_3_0_to_2_3_1(const IdfFile& idf_2_3_0, const IddFileAndFactoryWrapper& idd_2_3_1);
   std::string update_2_4_1_to_2_4_2(const IdfFile& idf_2_4_1, const IddFileAndFactoryWrapper& idd_2_4_2);
+  std::string update_2_4_3_to_2_5_0(const IdfFile& idf_2_4_3, const IddFileAndFactoryWrapper& idd_2_5_0);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
Fix #3084 and NREL/OpenStudio-resources#43 (only the `afn_single_zone_nv.osm` portion of that issue)

Changelog:

* 2.4.3 was removed from `m_startVersions` -> add it back. 
* Handle 2.4.3 to 2.5.0 version translation for `OS:AirflowNetworkZone` which has a newly inserted `Name` field right after the handle. Shift all fields by 1, and for the 'Name', get the attached thermal zone name and name it like `"Airflow Network Zone " + _zone->nameString());`

Could you review @evanweaver please?

----

FYI this new field was added in 18387eb0be4ff41a5d5e0ab3d28060ba817d80cb by @jasondegraw (exactly [here](https://github.com/NREL/OpenStudio/commit/18387eb0be4ff41a5d5e0ab3d28060ba817d80cb#diff-20dc466cd26aed8488ee9b0bb0d5ce9aR28947))

----

Note that the official 2.5.0 build doesn't have this change and therefore will fail to load up a 2.4.3 osm with an `OS:AirflowNetworkZone` object in it. You can find an offending 2.4.3 OSM in the OpenStudio resources repo: https://github.com/NREL/OpenStudio-resources/blob/develop/model/simulationtests/afn_single_zone_nv.osm

