### PR TITLE
Fix #3096

### DIFF
--- a/openstudiocore/src/openstudio_lib/LightsInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/LightsInspectorView.cpp
@@ -203,7 +203,7 @@ void LightsDefinitionInspectorView::attach(openstudio::model::LightsDefinition &
   );
 
   // m_returnAirFractionEdit->bind(lightsDefinition,"returnAirFraction",m_isIP);
-  m_fractionVisibleEdit->bind(
+  m_returnAirFractionEdit->bind(
     m_isIP,
     *m_lightsDefinition,
     OptionalDoubleGetter(std::bind(&model::LightsDefinition::returnAirFraction, m_lightsDefinition.get_ptr())),


### PR DESCRIPTION
Fixes #3096 where the Return Air Fraction field was actually binding to the OSQuantityEdit2 for Fraction Visible. 

Just a copy paste error probably, easy to fix.