### PR TITLE
Turn Off standardOutLogger in Individual tests

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -819,7 +819,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
 
           if (outdoorAirFlowperPerson > 0){
 
-            // todo: improve this?
+            // TODO: improve this?
             // find first people schedule
             std::vector<People> allPeople;
             for (People people : spaces[0].people()){

--- a/openstudiocore/src/energyplus/Test/ForwardTranslator_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ForwardTranslator_GTest.cpp
@@ -614,7 +614,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorTest_MultiThreadedLogMessages) {
     }
   };
 
-  Logger::instance().standardOutLogger().enable();
+  // Logger::instance().standardOutLogger().enable();
 
   Model model;
   Space space(model); // not in thermal zone will generate a warning

--- a/openstudiocore/src/energyplus/Test/SurfacePropertyConvectionCoefficients.cpp
+++ b/openstudiocore/src/energyplus/Test/SurfacePropertyConvectionCoefficients.cpp
@@ -64,8 +64,8 @@ using namespace openstudio::model;
 using namespace openstudio;
 
 TEST_F(EnergyPlusFixture, ForwardTranslator_SurfacePropertyConvectionCoefficients_InternalMass) {
-  openstudio::Logger::instance().standardOutLogger().enable();
-  openstudio::Logger::instance().standardOutLogger().setLogLevel(Debug);
+  // openstudio::Logger::instance().standardOutLogger().enable();
+  // openstudio::Logger::instance().standardOutLogger().setLogLevel(Debug);
   Model model;
   ThermalZone zone(model);
   Space space(model);
@@ -133,8 +133,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_SurfacePropertyConvectionCoefficient
 }
 
 TEST_F(EnergyPlusFixture, ForwardTranslator_SurfacePropertyConvectionCoefficients_Surface) {
-  openstudio::Logger::instance().standardOutLogger().enable();
-  openstudio::Logger::instance().standardOutLogger().setLogLevel(Debug);
+  // openstudio::Logger::instance().standardOutLogger().enable();
+  // openstudio::Logger::instance().standardOutLogger().setLogLevel(Debug);
   Model model;
   ThermalZone zone(model);
   Space space(model);

--- a/openstudiocore/src/model/test/AirflowNetworkDuctViewFactors_GTest.cpp
+++ b/openstudiocore/src/model/test/AirflowNetworkDuctViewFactors_GTest.cpp
@@ -41,8 +41,8 @@ using namespace openstudio::model;
 
 TEST_F(ModelFixture, AirflowNetwork_DuctViewFactors_Basic)
 {
-  openstudio::Logger::instance().standardOutLogger().enable();
-  openstudio::Logger::instance().standardOutLogger().setLogLevel(Info);
+  // openstudio::Logger::instance().standardOutLogger().enable();
+  // openstudio::Logger::instance().standardOutLogger().setLogLevel(Info);
   Model model;
   Point3dVector points;
 


### PR DESCRIPTION
This is a very minor change.

The Model/EnergyPlusFixture redirects LogMessages to a log file for a reason! Three tests  were responsible for an output that was unreadable, because the problem is that when you run all GTests, it'll affect ALL subsequent tests.
