### PR TITLE
Fix 3116 catch orphaned components

### DIFF
--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -1197,12 +1197,20 @@ HorizontalBranchGroupItem::HorizontalBranchGroupItem( model::Splitter & splitter
             ss << " Removing it.";
             comp1->remove();
           } else {
-            ss << " But this component is not removable. Trying to forcibly remove it";
-            // TODO: Trying to call the base ModelObject_Impl but it ends up calling Node_Impl::remove anyways
-            std::vector<IdfObject> delComps = comp1->getImpl<model::detail::ModelObject_Impl>().get()->remove();
-            if (delComps.empty()) {
-              ss << ", but it didn't work.";
-            }
+
+            ss << " But this component is not removable. You should use the Ruby bindings to disconnect then remove it";
+
+            //ss << " But this component is not removable. Trying to forcibly disconnect then remove it";
+            //// Start by disconnecting
+            //comp1->disconnect();
+            //// Then remove
+            //// TODO: Problem: this will produce a crash when drawing later...
+            //std::vector<IdfObject> delComps = comp1->remove();
+            //// Check whether it did delete something or not
+            //if (delComps.empty()) {
+              //ss << ", but it didn't work.";
+            //}
+
           }
           QMessageBox box(QMessageBox::Warning,
                           QString("Orphaned component Found"),

--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -1208,7 +1208,6 @@ HorizontalBranchGroupItem::HorizontalBranchGroupItem( model::Splitter & splitter
                           QString("Orphaned component Found"),
                           toQString(ss.str()),
                           QMessageBox::Ok);
-          // box.setDetailedText(toQString(ss.string()));
           box.exec();
 
         } else {


### PR DESCRIPTION
## Catch orphaned components when drawing PlantLoops

This PR implements an extra check to avoid a hard crash as reported in #3116. You can't `pop_back()` on an empty `std::vector` so it checks for that.

The only thing I didn't manage to do is to actually remove said orphaned object. I'm trying to call `ModelObject_Impl::remove()` directly and not the actual component's remove, which, in case of a `Node` for eg will check if `isRemovable()` - which returns False since it does have a Loop.

I left a TODO: 

https://github.com/NREL/OpenStudio/compare/develop...jmarrec:Fix_3116_Catch_Orphaned_Components?expand=1#diff-72d558d6b647a3c0057d728d2739b681R1201

With this fix, at least the Loop loads fine in OS App for review, a warning is issued to the user (always a good thing), and the model should run fine since it's going to get caught in Forward Translation.
