### PR TITLE
Fix #2974 - libwxgtk dependencies on Linux

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1555,7 +1555,8 @@ set(CPACK_PACKAGE_VENDOR "National Renewable Energy Laboratory")
 set(CPACK_PACKAGE_VERSION_MAJOR ${OpenStudio_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${OpenStudio_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${OpenStudio_VERSION_PATCH})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libwxgtk3.0-0")
+# Trusty (14.04) uses 3.0-0, all other including Xenial (16.04) use 3.0-0v5
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libwxgtk3.0-0v5 (>= 3.0.0) | libwxgtk3.0-0 (>=3.0.0)")
 # Default the debian package name to include version to allow several versions to be installed concurrently instead of overwritting any existing one
 set(CPACK_DEBIAN_PACKAGE_NAME "openstudio-${OpenStudio_VERSION}")
 # CPACK_DEBIAN_PACKAGE_DESCRIPTION defaults to this one too. dpkg-deb -I xxx.deb will show this description


### PR DESCRIPTION
Fix #2974 

Trusty (14.04) has libwxgtk3.0-0, all subsequent ubuntu versions including Xenial (16.04) use libwxgtk3.0-0v5.
So I set the CPACK_DEBIAN_PACKAGE_DEPENDS to include either of these two so it should work on 14.04 and 16.04 (I tested that it fixes it in 16.04 at least)
