### PR TITLE
Fix thermostat schedule control value

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -609,6 +609,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
           zoneControlThermostat.setString(ZoneControl_ThermostatFields::ZoneorZoneListName,modelObject.name().get());
           m_idfObjects.push_back(zoneControlThermostat);
 
+          // Need to handle the control type base don thermostat type (1: Single heating, 2: single cooling, 4: Dual setpoint)
           IdfObject scheduleCompact(openstudio::IddObjectType::Schedule_Compact);
           scheduleCompact.setName(modelObject.name().get() + " Thermostat Schedule");
           m_idfObjects.push_back(scheduleCompact);
@@ -633,6 +634,13 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             values[ZoneControl_ThermostatExtensibleFields::ControlObjectType] = idfThermostat->iddObject().name();
             values[ZoneControl_ThermostatExtensibleFields::ControlName] = idfThermostat->name().get();
             IdfExtensibleGroup eg = zoneControlThermostat.pushExtensibleGroup(values);
+            if (idfThermostat->iddObject().name() == "ThermostatSetpoint:SingleHeating" ) {
+              scheduleCompact.setString(5, "1");
+            } else if (idfThermostat->iddObject().name() == "ThermostatSetpoint:SingleCooling" ) {
+              scheduleCompact.setString(5, "2");
+            } else {
+              scheduleCompact.setString(5, "4");
+            }
           }
         };
 


### PR DESCRIPTION
I forgot to handle that when I made #2813. If you put a Cooling schedule only on a zone (no heating) that has equipment, you end up with a Thermostat:SingleCooling BUT the ZoneControl:Thermostat still has a ControlTypeScheduleName with a value of 4, which is wrong (4 = DualSetpoint) 
