### PR TITLE
Fix #2274 Cannot drag HPWH tank to plantloop from my model.

### DIFF
--- a/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
@@ -128,7 +128,8 @@ std::vector<OSItemId> ModelObjectListController::makeVector()
         if( (! hvacComponent->containingHVACComponent()) && (! hvacComponent->containingZoneHVACComponent()) ) {
           result.push_back(modelObjectToItemId(hvacComponent.get(), false));
         }
-        // Special case when there is a containingZoneHVACComponent
+        // Special case when there is a containingZoneHVACComponent, it might be a tank for a HPWH that we DO want to be able
+        // to drag and drop...
         else if ( boost::optional<openstudio::model::ZoneHVACComponent> zComp = hvacComponent->containingZoneHVACComponent() ) {
 
           openstudio::IddObjectType zCompType = zComp->iddObjectType();


### PR DESCRIPTION
I had addressed some of the other concerns of #2274 at end of 2017 (see [here](https://github.com/NREL/OpenStudio/issues/2274#issuecomment-334411783)) but after a brief look I didn't get why the tank still couldn't get dragged

Turns out it's because it checks if its part of another component: currently if any component is contained in a ZoneHVACComp or HVACComp, it's not shown in model list. So I just handled this special case.

*Note: this will have the side effect of allowing the HPWH Tanks from the hvac_library to be dragged, but it's not a big deal since this won't drag the HeatPump and other associated components (DX coil, fan, etc).
And this behavior is existing with the fans contained in some of the ZoneHVACComp etc.*

----

After adding an HPWH:WrappedCondenser to one of my thermal zones:

![image](https://user-images.githubusercontent.com/5479063/43142439-b06178bc-8f58-11e8-9c03-2d85905ae60b.png)

----

Original issue assignee: @kbenne. Could you review this one please?
