### PR TITLE
Fix #2555 - vrf font size too large

### DIFF
--- a/openstudiocore/src/openstudio_lib/VRFGraphicsItems.cpp
+++ b/openstudiocore/src/openstudio_lib/VRFGraphicsItems.cpp
@@ -43,8 +43,8 @@
 namespace openstudio {
 
 const int VRFSystemView::margin = 20;
-const int VRFSystemView::terminalDropZoneWidth = 200;
-const int VRFSystemView::zoneDropZoneWidth = 300;
+const int VRFSystemView::terminalDropZoneWidth = 300;
+const int VRFSystemView::zoneDropZoneWidth = 500;
 const int VRFSystemView::dropZoneHeight = 150;
 const int VRFSystemView::terminalViewHeight = 100;
 
@@ -319,7 +319,7 @@ void VRFTerminalView::paint( QPainter *painter,
 VRFThermalZoneDropZoneView::VRFThermalZoneDropZoneView()
   : m_hasZone(false)
 {
-  setSize(300,50);
+  setSize(600,50);
   setText("Drop Thermal Zone");
 }
 

--- a/openstudiocore/src/openstudio_lib/VRFGraphicsItems.cpp
+++ b/openstudiocore/src/openstudio_lib/VRFGraphicsItems.cpp
@@ -342,7 +342,8 @@ void VRFThermalZoneDropZoneView::paint( QPainter *painter,
     painter->drawRect(boundingRect());
 
     QFont font = painter->font();
-    font.setPointSize(25);
+    // This changes the size of the font for the name of the Thermal Zone once you've dragged it next to a VRF Terminal
+    font.setPointSize(16);
     painter->setFont(font);
     painter->setPen(QPen(QColor(109,109,109),2,Qt::DashLine, Qt::RoundCap));
     QRectF t_rec = boundingRect();
@@ -505,6 +506,7 @@ void VRFSystemDropZoneView::paint( QPainter *painter,
   painter->drawRect(boundingRect());
 
   QFont font = painter->font();
+  // This is first "Drop VRF System" one, make it big!
   font.setPointSize(30);
   painter->setFont(font);
   painter->setPen(QPen(QColor(109,109,109),2,Qt::DashLine, Qt::RoundCap));


### PR DESCRIPTION
Fix for #2555.

I change the thermalzone font size from 25 to 16. I don't know if that's enough to close #2555 or not, or if we should consider making the whole view larger.

Before:
![before-font25](https://user-images.githubusercontent.com/5479063/43143969-59a4bdfa-8f5c-11e8-8d92-c5778e71568b.png)


After
![after-font16](https://user-images.githubusercontent.com/5479063/43143975-5ceab55a-8f5c-11e8-855e-43acb2d1e5a3.png)



Original issue assignee: @kbenne, though isn't really HVAC related, so perhaps @macumber should take it?
Can one of you two review this one please?

