### PR TITLE
Fix #1717 - wrong fan direction in Outdoor Air Supply

### DIFF
--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -2120,13 +2120,17 @@ OASupplyBranchItem::OASupplyBranchItem( std::vector<model::ModelObject> supplyMo
 {
   setAcceptHoverEvents(false);
 
+  // reliefIt = components from return to outside
   auto reliefIt = reliefModelObjects.begin();
+  // supplyIt = components from mixed air node to outside (= oaSystem.oaComponents.reverse)
   auto supplyIt = supplyModelObjects.begin();
 
   while(supplyIt < supplyModelObjects.end())
   {
+    // If this is an AirToAirComponent (an ERV basically...)
     if(boost::optional<model::AirToAirComponent> comp = supplyIt->optionalCast<model::AirToAirComponent>())
     {
+      // We fake draw the relief side until we get to the ERV so ERV is ligned up in both cases
       while( (reliefIt < reliefModelObjects.end()) && (! reliefIt->optionalCast<model::AirToAirComponent>()) )
       {
         GridItem * gridItem = new OASupplyStraightItem(this);
@@ -2153,7 +2157,7 @@ OASupplyBranchItem::OASupplyBranchItem( std::vector<model::ModelObject> supplyMo
     }
     else if(boost::optional<model::StraightComponent> comp = supplyIt->optionalCast<model::StraightComponent>())
     {
-      GridItem * gridItem = new OAReliefStraightItem(this);
+      GridItem * gridItem = new OASupplyStraightItem(this);
       gridItem->setModelObject( comp->optionalCast<model::ModelObject>() );
       if( comp->isRemovable() )
       {


### PR DESCRIPTION
Fix #1717 - wrong fan direction in Outdoor Air Supply

Before:

![before](https://user-images.githubusercontent.com/5479063/43150067-4660538c-8f69-11e8-8d72-ba2b73110513.png)

After:

![after](https://user-images.githubusercontent.com/5479063/43150066-463f700e-8f69-11e8-8e30-6c334fc9cd77.png)


Original issue assignee: @kbenne. Could you review this one please?