### PR TITLE
Fix 1465: Can't remove some SPMs via GUI because icons don't show

### DIFF
--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -2156,22 +2156,22 @@ std::vector<ModelObject> AirLoopHVAC::oaComponents(openstudio::IddObjectType typ
   return getImpl<detail::AirLoopHVAC_Impl>()->oaComponents( type );
 }
 
-boost::optional<Node> AirLoopHVAC::outdoorAirNode()
+boost::optional<Node> AirLoopHVAC::outdoorAirNode() const
 {
   return getImpl<detail::AirLoopHVAC_Impl>()->outdoorAirNode();
 }
 
-boost::optional<Node> AirLoopHVAC::reliefAirNode()
+boost::optional<Node> AirLoopHVAC::reliefAirNode() const
 {
   return getImpl<detail::AirLoopHVAC_Impl>()->reliefAirNode();
 }
 
-boost::optional<Node> AirLoopHVAC::mixedAirNode()
+boost::optional<Node> AirLoopHVAC::mixedAirNode() const
 {
   return getImpl<detail::AirLoopHVAC_Impl>()->mixedAirNode();
 }
 
-boost::optional<Node> AirLoopHVAC::returnAirNode()
+boost::optional<Node> AirLoopHVAC::returnAirNode() const
 {
   return getImpl<detail::AirLoopHVAC_Impl>()->returnAirNode();
 }

--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -840,6 +840,18 @@ namespace detail {
     }
   }
 
+  boost::optional<Node> AirLoopHVAC_Impl::outdoorAirNode() const
+  {
+    if( airLoopHVACOutdoorAirSystem() )
+    {
+      return airLoopHVACOutdoorAirSystem()->outboardOANode();
+    }
+    else
+    {
+      return boost::optional<Node>();
+    }
+  }
+
   boost::optional<Node> AirLoopHVAC_Impl::reliefAirNode() const
   {
     if( airLoopHVACOutdoorAirSystem() )
@@ -1375,6 +1387,21 @@ namespace detail {
     if( boost::optional<AirLoopHVACOutdoorAirSystem> oaSystem = airLoopHVACOutdoorAirSystem() )
     {
       if( boost::optional<ModelObject> mo = oaSystem->mixedAirModelObject() )
+      {
+        result = mo->optionalCast<Node>();
+      }
+    }
+
+    return result;
+  }
+
+  boost::optional<Node> AirLoopHVAC_Impl::returnAirNode() const
+  {
+    boost::optional<Node> result;
+
+    if( boost::optional<AirLoopHVACOutdoorAirSystem> oaSystem = airLoopHVACOutdoorAirSystem() )
+    {
+      if( boost::optional<ModelObject> mo = oaSystem->returnAirModelObject() )
       {
         result = mo->optionalCast<Node>();
       }
@@ -2131,8 +2158,7 @@ std::vector<ModelObject> AirLoopHVAC::oaComponents(openstudio::IddObjectType typ
 
 boost::optional<Node> AirLoopHVAC::outdoorAirNode()
 {
-  // ETH@20111101 Adding to get Ruby bindings building.
-  LOG_AND_THROW("Not implemented.");
+  return getImpl<detail::AirLoopHVAC_Impl>()->outdoorAirNode();
 }
 
 boost::optional<Node> AirLoopHVAC::reliefAirNode()
@@ -2147,8 +2173,7 @@ boost::optional<Node> AirLoopHVAC::mixedAirNode()
 
 boost::optional<Node> AirLoopHVAC::returnAirNode()
 {
-  // ETH@20111101 Adding to get Ruby bindings building.
-  LOG_AND_THROW("Not implemented.");
+  return getImpl<detail::AirLoopHVAC_Impl>()->returnAirNode();
 }
 
 boost::optional<Splitter> AirLoopHVAC::supplySplitter() const {

--- a/openstudiocore/src/model/AirLoopHVAC.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC.hpp
@@ -132,21 +132,21 @@ class MODEL_API AirLoopHVAC : public Loop
    * is an outdoor air system within the air loop.  A freshly constructed
    * AirLoopHVAC object will not have an outdoor air system.
    */
-  boost::optional<Node> outdoorAirNode();
+  boost::optional<Node> outdoorAirNode() const;
 
   /** Returns the relief air node.  This is the outermost node from which
    * air is relieved from the air loop to the outdoor air.  This node only exists
    * if there is an outdoor air system within the air loop.  A freshly
    * constructed AirLoopHVAC object will not have an outdoor air system.
    */
-  boost::optional<Node> reliefAirNode();
+  boost::optional<Node> reliefAirNode() const;
 
   /** Returns the mixed air node.  This is the mixed air node of the outdoor
    * air mixer of the air loop.  This node only exists if there is an outdoor air
    * system within the air loop.  A freshly constructed AirLoopHVAC object
    * will not have an outdoor air system.
    */
-  boost::optional<Node> mixedAirNode();
+  boost::optional<Node> mixedAirNode() const;
 
   /** Returns the return air node.  This is the return air node of the outdoor
    * air mixer of the air loop.  This node only exists if there is an outdoor air
@@ -155,7 +155,7 @@ class MODEL_API AirLoopHVAC : public Loop
    * same as the supply inlet node, because there is often no hvac equipment
    * before the outdoor air mixer.
    */
-  boost::optional<Node> returnAirNode();
+  boost::optional<Node> returnAirNode() const;
 
   /** Returns true if the system is "dual duct"
     * ie. there is a supply splitter

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -94,9 +94,13 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   Node demandOutletNode() const override;
 
+  boost::optional<Node> outdoorAirNode() const;
+
   boost::optional<Node> reliefAirNode() const;
 
   boost::optional<Node> mixedAirNode() const;
+
+  boost::optional<Node> returnAirNode() const;
 
   std::vector<ModelObject> oaComponents(openstudio::IddObjectType type = openstudio::IddObjectType("Catchall"));
 

--- a/openstudiocore/src/model/SetpointManager.cpp
+++ b/openstudiocore/src/model/SetpointManager.cpp
@@ -34,6 +34,9 @@
 #include "Node_Impl.hpp"
 #include "AirLoopHVAC.hpp"
 #include "PlantLoop.hpp"
+#include "Splitter.hpp"
+#include "Mixer.hpp"
+#include <algorithm>
 
 #include "../utilities/core/Assert.hpp"
 
@@ -90,6 +93,14 @@ namespace detail{
     return result;
   }
 
+
+  /** Returns false by default. This is a virtual method which will be overriden for specific SPMs to return true
+   * if they are allowed on a plantLoop
+   **/
+  bool SetpointManager_Impl::isAllowedOnPlantLoop() const {
+    return false;
+  }
+
   bool SetpointManager_Impl::addToNode(Node & node)
   {
     if( node.model() != this->model() )
@@ -127,6 +138,31 @@ namespace detail{
       // We only accept it if it's neither the relief or the OA node (doesn't make sense to place one there)
       if ( (node != oaSystem->outboardReliefNode()) && (node != oaSystem->outboardOANode()) ) {
         return this->setSetpointNode(node);
+      }
+    }
+
+    // If the specific SPM (derived class) is allowed on PlantLoop, then we allow it on the supply side,
+    // or the demand side EXCEPT on a demand branch
+    if ( boost::optional<PlantLoop> plant = node.plantLoop() ) {
+      if( this->isAllowedOnPlantLoop() ) {
+        // If it's the supply side
+        if( plant->supplyComponent(node.handle()) ) {
+          return this->setSetpointNode(node);
+        } else {
+          // On the demand side
+          Splitter splitter = plant->demandSplitter();
+          Mixer mixer = plant->demandMixer();
+          // We check that the node is NOT between the splitter and the mixer
+          auto branchcomps = plant->demandComponents(splitter, mixer);
+          if ( std::find(branchcomps.begin(), branchcomps.end(), node) == branchcomps.end() ) {
+            return this->setSetpointNode(node);
+          } else {
+            LOG(Info, this->briefDescription() << " cannot be added on a demand branch");
+
+          }
+        }
+      } else {
+        LOG(Info,"This SetpointManager cannot be connected to a PlantLoop, for " << this->briefDescription());
       }
     }
 
@@ -204,6 +240,14 @@ bool SetpointManager::setControlVariable(const std::string & value)
 {
   return getImpl<detail::SetpointManager_Impl>()->setControlVariable(value);
 }
+
+
+//bool SetpointManager::isAllowedOnPlantLoop() const
+//{
+  //return getImpl<detail::SetpointManager_Impl>()->isAllowedOnPlantLoop();
+//}
+
+
 
 } // model
 } // openstudio

--- a/openstudiocore/src/model/SetpointManager.cpp
+++ b/openstudiocore/src/model/SetpointManager.cpp
@@ -125,7 +125,7 @@ namespace detail{
     if(OptionalAirLoopHVACOutdoorAirSystem oaSystem = node.airLoopHVACOutdoorAirSystem())
     {
       // We only accept it if it's neither the relief or the OA node (doesn't make sense to place one there)
-      if ( (node != oaSystem->reliefAirNode()) && (node != oaSystem->outdoorAirNode()) ) {
+      if ( (node != oaSystem->outboardReliefNode()) && (node != oaSystem->outboardOANode()) ) {
         return this->setSetpointNode(node);
       }
     }

--- a/openstudiocore/src/model/SetpointManager.cpp
+++ b/openstudiocore/src/model/SetpointManager.cpp
@@ -241,11 +241,10 @@ bool SetpointManager::setControlVariable(const std::string & value)
   return getImpl<detail::SetpointManager_Impl>()->setControlVariable(value);
 }
 
-
-//bool SetpointManager::isAllowedOnPlantLoop() const
-//{
-  //return getImpl<detail::SetpointManager_Impl>()->isAllowedOnPlantLoop();
-//}
+bool SetpointManager::isAllowedOnPlantLoop() const
+{
+  return getImpl<detail::SetpointManager_Impl>()->isAllowedOnPlantLoop();
+}
 
 
 

--- a/openstudiocore/src/model/SetpointManager.cpp
+++ b/openstudiocore/src/model/SetpointManager.cpp
@@ -97,6 +97,8 @@ namespace detail{
       return false;
     }
 
+    // Erase any existing setpoint manager that has the same control variable
+    // eg you can't have two temperature ones. But Humidity ones can be MaximumHumidityRatio or MinimumHumidityRatio so you can have a Min and Max
     std::vector<SetpointManager> _setpointManagers = node.setpointManagers();
     if( !_setpointManagers.empty() )
     {
@@ -113,6 +115,7 @@ namespace detail{
 
     if( OptionalAirLoopHVAC airLoop = node.airLoopHVAC() )
     {
+      // If this is one of the regular nodes of the supply path (eg not in the AirLoopHVACOASys)
       if( airLoop->supplyComponent(node.handle()) )
       {
         return this->setSetpointNode(node);
@@ -121,7 +124,10 @@ namespace detail{
 
     if(OptionalAirLoopHVACOutdoorAirSystem oaSystem = node.airLoopHVACOutdoorAirSystem())
     {
-      return this->setSetpointNode(node);
+      // We only accept it if it's neither the relief or the OA node (doesn't make sense to place one there)
+      if ( (node != oaSystem->reliefAirNode()) && (node != oaSystem->outdoorAirNode()) ) {
+        return this->setSetpointNode(node);
+      }
     }
 
     return false;

--- a/openstudiocore/src/model/SetpointManager.hpp
+++ b/openstudiocore/src/model/SetpointManager.hpp
@@ -64,6 +64,10 @@ class MODEL_API SetpointManager : public HVACComponent {
   /** Returns the Control Variable **/
   std::string controlVariable() const;
 
+  /** Returns whether this SPM is allowed to be placed on a PlantLoop
+   * (*all* SPMs are allowed on an AirLoopHVAC, *some* are allowed on a PlantLoop) **/
+  // bool isAllowedOnPlantLoop() const;
+
   //@}
   /** @name Setters */
   //@{

--- a/openstudiocore/src/model/SetpointManager.hpp
+++ b/openstudiocore/src/model/SetpointManager.hpp
@@ -66,7 +66,7 @@ class MODEL_API SetpointManager : public HVACComponent {
 
   /** Returns whether this SPM is allowed to be placed on a PlantLoop
    * (*all* SPMs are allowed on an AirLoopHVAC, *some* are allowed on a PlantLoop) **/
-  // bool isAllowedOnPlantLoop() const;
+  bool isAllowedOnPlantLoop() const;
 
   //@}
   /** @name Setters */

--- a/openstudiocore/src/model/SetpointManagerFollowGroundTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowGroundTemperature.cpp
@@ -75,18 +75,9 @@ namespace detail {
     return SetpointManagerFollowGroundTemperature::iddObjectType();
   }
 
-  bool SetpointManagerFollowGroundTemperature_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerFollowGroundTemperature_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   std::string SetpointManagerFollowGroundTemperature_Impl::controlVariable() const {

--- a/openstudiocore/src/model/SetpointManagerFollowGroundTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowGroundTemperature.cpp
@@ -76,11 +76,15 @@ namespace detail {
   }
 
   bool SetpointManagerFollowGroundTemperature_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      return this->setSetpointNode(node);
+      if( plantLoop->supplyComponent(node.handle()) ) {
+        return this->setSetpointNode(node);
+      }
     }
     return added;
   }

--- a/openstudiocore/src/model/SetpointManagerFollowGroundTemperature_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerFollowGroundTemperature_Impl.hpp
@@ -68,7 +68,9 @@ namespace detail {
 
     virtual IddObjectType iddObjectType() const override;
 
-    virtual bool addToNode(Node & node) override;
+    // virtual bool addToNode(Node & node) override;
+
+    virtual bool isAllowedOnPlantLoop() const override;
 
     //@}
     /** @name Getters */

--- a/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature.cpp
@@ -81,11 +81,15 @@ namespace detail{
   }
 
   bool SetpointManagerFollowOutdoorAirTemperature_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      return this->setSetpointNode(node);
+      if( plantLoop->supplyComponent(node.handle()) ) {
+        return this->setSetpointNode(node);
+      }
     }
     return added;
   }

--- a/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature.cpp
@@ -80,18 +80,9 @@ namespace detail{
     return SetpointManagerFollowOutdoorAirTemperature::iddObjectType();
   }
 
-  bool SetpointManagerFollowOutdoorAirTemperature_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerFollowOutdoorAirTemperature_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   boost::optional<Node> SetpointManagerFollowOutdoorAirTemperature_Impl::setpointNode() const

--- a/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerFollowOutdoorAirTemperature_Impl.hpp
@@ -66,7 +66,9 @@ namespace detail {
 
     virtual IddObjectType iddObjectType() const override;
 
-    virtual bool addToNode(Node & node) override;
+    // virtual bool addToNode(Node & node) override;
+
+    virtual bool isAllowedOnPlantLoop() const override;
 
     //@}
     /** @name Getters and Setters */

--- a/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature.cpp
@@ -77,18 +77,9 @@ namespace detail {
     return SetpointManagerFollowSystemNodeTemperature::iddObjectType();
   }
 
-  bool SetpointManagerFollowSystemNodeTemperature_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerFollowSystemNodeTemperature_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   ModelObject SetpointManagerFollowSystemNodeTemperature_Impl::clone(Model model) const

--- a/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature.cpp
+++ b/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature.cpp
@@ -78,11 +78,15 @@ namespace detail {
   }
 
   bool SetpointManagerFollowSystemNodeTemperature_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      return this->setSetpointNode(node);
+      if( plantLoop->supplyComponent(node.handle()) ) {
+        return this->setSetpointNode(node);
+      }
     }
     return added;
   }

--- a/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerFollowSystemNodeTemperature_Impl.hpp
@@ -70,7 +70,9 @@ namespace detail {
 
     virtual ModelObject clone(Model model) const override;
 
-    virtual bool addToNode(Node & node) override;
+    // virtual bool addToNode(Node & node) override;
+
+    virtual bool isAllowedOnPlantLoop() const override;
 
     //@}
     /** @name Getters */

--- a/openstudiocore/src/model/SetpointManagerOutdoorAirReset.cpp
+++ b/openstudiocore/src/model/SetpointManagerOutdoorAirReset.cpp
@@ -83,18 +83,9 @@ namespace detail {
     return SetpointManagerOutdoorAirReset::iddObjectType();
   }
 
-  bool SetpointManagerOutdoorAirReset_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerOutdoorAirReset_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   std::vector<ScheduleTypeKey> SetpointManagerOutdoorAirReset_Impl::getScheduleTypeKeys(const Schedule& schedule) const

--- a/openstudiocore/src/model/SetpointManagerOutdoorAirReset.cpp
+++ b/openstudiocore/src/model/SetpointManagerOutdoorAirReset.cpp
@@ -84,9 +84,11 @@ namespace detail {
   }
 
   bool SetpointManagerOutdoorAirReset_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
       if( plantLoop->supplyComponent(node.handle()) ) {
         return this->setSetpointNode(node);
@@ -97,7 +99,6 @@ namespace detail {
 
   std::vector<ScheduleTypeKey> SetpointManagerOutdoorAirReset_Impl::getScheduleTypeKeys(const Schedule& schedule) const
   {
-    // TODO: Check schedule display names.
     std::vector<ScheduleTypeKey> result;
     UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
     UnsignedVector::const_iterator b(fieldIndices.begin()), e(fieldIndices.end());
@@ -780,4 +781,4 @@ SetpointManagerOutdoorAirReset::SetpointManagerOutdoorAirReset(std::shared_ptr<d
 /// @endcond
 
 } // model
-} // openstudio
+} // openstudio

--- a/openstudiocore/src/model/SetpointManagerOutdoorAirReset_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerOutdoorAirReset_Impl.hpp
@@ -47,44 +47,6 @@ namespace detail {
   /** SetpointManagerOutdoorAirReset_Impl is a SetpointManager_Impl that is the implementation class for SetpointManagerOutdoorAirReset.*/
   class MODEL_API SetpointManagerOutdoorAirReset_Impl : public SetpointManager_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -113,7 +75,9 @@ namespace detail {
 
     virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
-    virtual bool addToNode(Node & node) override;
+    // virtual bool addToNode(Node & node) override;
+
+    virtual bool isAllowedOnPlantLoop() const override;
 
     //@}
     /** @name Getters */
@@ -256,4 +220,4 @@ namespace detail {
 } // model
 } // openstudio
 
-#endif // MODEL_SETPOINTMANAGEROUTDOORAIRRESET_IMPL_HPP
+#endif // MODEL_SETPOINTMANAGEROUTDOORAIRRESET_IMPL_HPP

--- a/openstudiocore/src/model/SetpointManagerScheduled.cpp
+++ b/openstudiocore/src/model/SetpointManagerScheduled.cpp
@@ -86,11 +86,15 @@ namespace detail{
   }
 
   bool SetpointManagerScheduled_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      return this->setSetpointNode(node);
+      if( plantLoop->supplyComponent(node.handle()) ) {
+        return this->setSetpointNode(node);
+      }
     }
     return added;
   }

--- a/openstudiocore/src/model/SetpointManagerScheduled.cpp
+++ b/openstudiocore/src/model/SetpointManagerScheduled.cpp
@@ -85,18 +85,9 @@ namespace detail{
     return SetpointManagerScheduled::iddObjectType();
   }
 
-  bool SetpointManagerScheduled_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerScheduled_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   std::vector<ScheduleTypeKey> SetpointManagerScheduled_Impl::getScheduleTypeKeys(const Schedule& schedule) const

--- a/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint.cpp
+++ b/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint.cpp
@@ -99,11 +99,15 @@ namespace detail {
   }
 
   bool SetpointManagerScheduledDualSetpoint_Impl::addToNode(Node & node) {
+    // Call the base class method, which will check for AirLoopHVAC
     bool added = SetpointManager_Impl::addToNode( node );
     if( added ) {
       return added;
+    // If that failed, then accept it only on the supply side of a plantLoop
     } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      return this->setSetpointNode(node);
+      if( plantLoop->supplyComponent(node.handle()) ) {
+        return this->setSetpointNode(node);
+      }
     }
     return added;
   }

--- a/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint.cpp
+++ b/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint.cpp
@@ -98,18 +98,9 @@ namespace detail {
     return result;
   }
 
-  bool SetpointManagerScheduledDualSetpoint_Impl::addToNode(Node & node) {
-    // Call the base class method, which will check for AirLoopHVAC
-    bool added = SetpointManager_Impl::addToNode( node );
-    if( added ) {
-      return added;
-    // If that failed, then accept it only on the supply side of a plantLoop
-    } else if( boost::optional<PlantLoop> plantLoop = node.plantLoop() ) {
-      if( plantLoop->supplyComponent(node.handle()) ) {
-        return this->setSetpointNode(node);
-      }
-    }
-    return added;
+  /** This SPM is allowed on a PlantLoop */
+  bool SetpointManagerScheduledDualSetpoint_Impl::isAllowedOnPlantLoop() const {
+    return true;
   }
 
   std::string SetpointManagerScheduledDualSetpoint_Impl::controlVariable() const {

--- a/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerScheduledDualSetpoint_Impl.hpp
@@ -71,7 +71,9 @@ namespace detail {
 
     virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
-    virtual bool addToNode(Node & node) override;
+    // virtual bool addToNode(Node & node) override;
+
+    virtual bool isAllowedOnPlantLoop() const override;
 
     //@}
     /** @name Getters */

--- a/openstudiocore/src/model/SetpointManagerScheduled_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManagerScheduled_Impl.hpp
@@ -42,11 +42,6 @@ namespace detail {
 
 class MODEL_API SetpointManagerScheduled_Impl : public SetpointManager_Impl {
 
-
-
-
-
-
  public:
   /** @name Constructors and Destructors */
   //@{
@@ -73,7 +68,9 @@ class MODEL_API SetpointManagerScheduled_Impl : public SetpointManager_Impl {
 
   virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
-  virtual bool addToNode(Node & node) override;
+  // virtual bool addToNode(Node & node) override;
+
+  virtual bool isAllowedOnPlantLoop() const override;
 
   //@}
   /** @name Getters */

--- a/openstudiocore/src/model/SetpointManager_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManager_Impl.hpp
@@ -53,6 +53,12 @@ namespace detail {
 
     virtual ~SetpointManager_Impl();
 
+    /** This method will delete any existing SPM with the same controlVariable
+     * as well as disallow placing the SPM anywhere else than the supply side of an AirLoopHVAC
+     * and EXCEPTING on the outdoorAirNode or reliefAirNode of an AirLoopHVAC
+     * All child classes will normally call this method first (all SPMs are potentially allowed on an AirLoopHVAC, only a subset for PlantLoops),
+     * and if failed AND the SPM is appropriate for a plantLoop, then it'll check if it can connect it to the PlantLoop.
+     */
     virtual bool addToNode(Node & node) override;
 
     virtual std::vector<openstudio::IdfObject> remove() override;

--- a/openstudiocore/src/model/SetpointManager_Impl.hpp
+++ b/openstudiocore/src/model/SetpointManager_Impl.hpp
@@ -53,11 +53,13 @@ namespace detail {
 
     virtual ~SetpointManager_Impl();
 
-    /** This method will delete any existing SPM with the same controlVariable
-     * as well as disallow placing the SPM anywhere else than the supply side of an AirLoopHVAC
-     * and EXCEPTING on the outdoorAirNode or reliefAirNode of an AirLoopHVAC
-     * All child classes will normally call this method first (all SPMs are potentially allowed on an AirLoopHVAC, only a subset for PlantLoops),
-     * and if failed AND the SPM is appropriate for a plantLoop, then it'll check if it can connect it to the PlantLoop.
+    /** This method will delete any existing SPM with the same controlVariable, and check if placing the SPM is allowed:
+     * <ul>
+     *  <li>Airside: only allows placement of the SPM on the supply side of an AirLoopHVAC,
+     *      or the node of an AirLoopHVACOutdoorAirSystem EXCEPT on the outdoorAirNode or reliefAirNode</li>
+     *  <li>Waterside: if isAllowedOnPlantLoop() returns true, it will allow connection on the supply side,
+     *  or the demand side EXCEPT between the demand splitter and demand mixer (i.e. not allowed on a demand branch)</li>
+     * </ul>.
      */
     virtual bool addToNode(Node & node) override;
 
@@ -84,6 +86,10 @@ namespace detail {
     virtual boost::optional<Loop> loop() const override;
 
     virtual boost::optional<AirLoopHVACOutdoorAirSystem> airLoopHVACOutdoorAirSystem() const override;
+
+    /** Defaults to false. Must be overriden by derived classes that can be actually placed on a PlantLoop to return true.
+     * If true, addToNode will allow connection on a PlantLoop (supply side, or demand side EXCEPT between splitter and mixer) */
+    virtual bool isAllowedOnPlantLoop() const;
 
    private:
 

--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -118,16 +118,16 @@ namespace openstudio {
 
 bool hasSPM(model::Node & node)
 {
+  /* // Previously was only allowing temperature
+   *auto spms = node.setpointManagers();
+   *for( auto & spm: spms ) {
+   *  if ( spm.controlVariable().find( "Temperature" ) != std::string::npos ) {
+   *    return true;
+   *  }
+   *}
+   */
   auto spms = node.setpointManagers();
-  for( auto & spm: spms ) {
-    if ( spm.controlVariable().find( "Temperature" ) != std::string::npos ) {
-      return true;
-    } else {
-      // This captures the Humidity SPMs essentially.
-      return true;
-    }
-  }
-  return false;
+  return !(spms.empty());
 }
 
 // Begin move these

--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -122,6 +122,9 @@ bool hasSPM(model::Node & node)
   for( auto & spm: spms ) {
     if ( spm.controlVariable().find( "Temperature" ) != std::string::npos ) {
       return true;
+    } else {
+      // This captures the Humidity SPMs essentially.
+      return true;
     }
   }
   return false;
@@ -2544,31 +2547,32 @@ void OneThreeNodeItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *
           }
           break;
         } else {
-          // if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_humidity_max.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_humidity_min.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_singlezone_humidity_max.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_singlezone_humidity_min.png"));
-          // }
-          //break;
+           // These are the Humidty SPMs
+           if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_humidity_max.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_humidity_min.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_singlezone_humidity_max.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(37,13,25,25,QPixmap(":images/setpoint_singlezone_humidity_min.png"));
+           }
+          break;
         }
       }
     }
@@ -2786,31 +2790,32 @@ void TwoFourNodeItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
           }
           break;
         } else {
-          // if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_max_right.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_min_right.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg_right.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg_right.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_max_right.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_min_right.png"));
-          // }
-          //break;
+           // These are the humidity ones
+           if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_max_right.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_min_right.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg_right.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg_right.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_max_right.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_min_right.png"));
+           }
+          break;
         }
       }
     }
@@ -2956,31 +2961,32 @@ void OAStraightNodeItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
           }
           break;
         } else {
-          // if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_max.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_min.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_max.png"));
-          // }
-          // else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
-          // {
-          //   painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_min.png"));
-          // }
-          //break;
+           // These are the humidity ones
+           if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_max.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_humidity_min.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMaximumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_maxhumidity_avg.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerMultiZoneMinimumHumidityAverage::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_multizone_minhumidity_avg.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMaximum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_max.png"));
+           }
+           else if( it->iddObjectType() == SetpointManagerSingleZoneHumidityMinimum::iddObjectType() )
+           {
+             painter->drawPixmap(62,37,25,25,QPixmap(":images/setpoint_singlezone_humidity_min.png"));
+           }
+          break;
         }
       }
     }
@@ -4026,6 +4032,9 @@ void NodeContextButtonItem::onRemoveSPMActionTriggered()
       {
         if( istringEqual("Temperature", it->controlVariable()) )
         {
+          emit removeModelObjectClicked( *it );
+          break;
+        } else {
           emit removeModelObjectClicked( *it );
           break;
         }


### PR DESCRIPTION
Fix #1465 and Fix #2220 

Changelog:

* Previous behavior was to only draw (and make removable) the SPMs with a `controlVariable`  that is "Temperature", now allows the other too (=the humidity ones basically)
* Implemented the `AirLoopHVAC::outdoorAirNode` and `AirLoopHVAC::returnAirNode`: since 2011 they were just throwing a "Not implemented" currently.
* Made  `AirLoopHVAC::mixedAirNode` and `AirLoopHVAC::reliefAirNode` const (const-correctness)
* `SetpointManager_Impl::addToNode` now doesn't allow SPMs to be placed on the `reliefAirNode` nor the `outdoorAirNode` of an AirLoopHVACOutdoorAirSYstem
* All SPMs that are allowed on a plantLoop now can only be placed on the supply side (I disallowed placing them on the demand side of a PlantLoop)


Original issue assignee: @kbenne. Could you review this one please?
