### PR TITLE
Fix #2814 and #2176: Problem with Humidity Indicating type

### DIFF
--- a/openstudiocore/src/shared_gui_components/OSConcepts.hpp
+++ b/openstudiocore/src/shared_gui_components/OSConcepts.hpp
@@ -541,8 +541,23 @@ class RequiredChoiceConceptImpl : public ChoiceConcept {
       // Oops, we forgot to update the choices
       this->choices();
     }
-    OS_ASSERT(m_choicesMap.find(result) != m_choicesMap.end());
-    return result;
+
+    // If we can find the result in choicesMap, just use that
+    if (m_choicesMap.find(result) != m_choicesMap.end()) {
+      return result;
+    // Otherwise, it's likely a casing problem
+    } else {
+      for (auto const& x: m_choicesMap) {
+        // Case insensitive match
+        if (openstudio::istringEqual(result, x.first)) {
+          // Return it with proper casing
+          return x.first;
+        }
+      }
+      // We shouldn't get here...
+      OS_ASSERT(false);
+      return "";
+    }
   }
 
   virtual bool set(std::string value) override {


### PR DESCRIPTION
Fix #2814 (and #2176)

setString doesn't enforce casing to match the possible `\key` for a `\type choice` IDDfield. Most DDY files have Humdity Indicating Type set as `Wetbulb` whereas the IDD has `WetBulb` (capital "B"); so it can't find it, and either displays a blank string or if in Debug hits an OS_ASSERT and crash.

Changelog: In OSComboBox2, if you can't find it in the possible keys, then match case insentitive, and return the appropriately-cased value.

Note: I've been explicitly told to handle it on the OS App side only, rather than enforce casing when calling setString on a `\type choice` field.

----

Original issue assignee: @kbenne. Could you review this one please?
