### PR TITLE
Fix #2059 - change Fan Efficiency field to Fan Total Efficiency

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -19299,7 +19299,7 @@ OS:Fan:ConstantVolume,
        \type object-list
        \required-field
        \object-list ScheduleNames
-  N1, \field Fan Efficiency
+  N1, \field Fan Total Efficiency
        \type real
        \minimum> 0
        \maximum 1
@@ -19356,7 +19356,7 @@ OS:Fan:VariableVolume,
        \type object-list
        \required-field
        \object-list ScheduleNames
-  N1, \field Fan Efficiency
+  N1, \field Fan Total Efficiency
        \type real
        \minimum> 0
        \maximum 1
@@ -19441,7 +19441,7 @@ OS:Fan:OnOff,
        \type object-list
        \required-field
        \object-list ScheduleNames
-  N1, \field Fan Efficiency
+  N1, \field Fan Total Efficiency
        \type real
        \minimum> 0
        \maximum 1
@@ -19503,7 +19503,7 @@ OS:Fan:ZoneExhaust,
        \note If this field is blank, the system is always available.
        \type object-list
        \object-list ScheduleNames
-  N1, \field Fan Efficiency
+  N1, \field Fan Total Efficiency
        \type real
        \minimum> 0.0
        \maximum 1.0
@@ -30656,7 +30656,7 @@ OS:PlantComponent:UserDefined,
       \min-fields 6
   A1, \field Handle
       \type handle
-      \required-field    
+      \required-field
   A2, \field Name
       \required-field
       \type alpha
@@ -30666,7 +30666,7 @@ OS:PlantComponent:UserDefined,
       \object-list ErlProgramCallingManagerNames
   A4, \field Main Model Program Name
       \type object-list
-      \object-list ErlProgramNames    
+      \object-list ErlProgramNames
   A5, \field Plant Inlet Node Name
       \type object-list
       \object-list ConnectionNames
@@ -30694,13 +30694,13 @@ OS:PlantComponent:UserDefined,
       \object-list ErlProgramCallingManagerNames
   A10, \field Plant Initialization Program Name
       \type object-list
-      \object-list ErlProgramNames      
+      \object-list ErlProgramNames
   A11, \field Plant Simulation Program Calling Manager Name
       \type object-list
       \object-list ErlProgramCallingManagerNames
   A12, \field Plant Simulation Program Name
       \type object-list
-      \object-list ErlProgramNames      
+      \object-list ErlProgramNames
   A13, \field Design Volume Flow Rate Actuator
        \type object-list
        \object-list ErlActuatorNames
@@ -30724,9 +30724,9 @@ OS:PlantComponent:UserDefined,
        \object-list ErlActuatorNames
   A20, \field Mass Flow Rate Actuator
        \type object-list
-       \object-list ErlActuatorNames       
+       \object-list ErlActuatorNames
   A21; \field Ambient Zone Name
        \type object-list
        \object-list ThermalZoneNames
        \note Used for modeling device losses to surrounding zone
-      
+

--- a/openstudiocore/src/model/FanConstantVolume.cpp
+++ b/openstudiocore/src/model/FanConstantVolume.cpp
@@ -152,14 +152,14 @@ namespace detail {
   }
 
 
-  double FanConstantVolume_Impl::fanEfficiency() const
+  double FanConstantVolume_Impl::fanTotalEfficiency() const
   {
-    return this->getDouble(OS_Fan_ConstantVolumeFields::FanEfficiency,true).get();
+    return this->getDouble(OS_Fan_ConstantVolumeFields::FanTotalEfficiency,true).get();
   }
 
-  bool FanConstantVolume_Impl::setFanEfficiency(double val)
+  bool FanConstantVolume_Impl::setFanTotalEfficiency(double val)
   {
-    return this->setDouble(OS_Fan_ConstantVolumeFields::FanEfficiency,val);
+    return this->setDouble(OS_Fan_ConstantVolumeFields::FanTotalEfficiency,val);
   }
 
   double FanConstantVolume_Impl::pressureRise() const
@@ -546,14 +546,24 @@ bool FanConstantVolume::setAvailabilitySchedule(Schedule& s)
   return getImpl<detail::FanConstantVolume_Impl>()->setAvailabilitySchedule(s);
 }
 
+double FanConstantVolume::fanTotalEfficiency() const
+{
+  return getImpl<detail::FanConstantVolume_Impl>()->fanTotalEfficiency();
+}
+
+bool FanConstantVolume::setFanTotalEfficiency(double val)
+{
+  return getImpl<detail::FanConstantVolume_Impl>()->setFanTotalEfficiency(val);
+}
+
 double FanConstantVolume::fanEfficiency() const
 {
-  return getImpl<detail::FanConstantVolume_Impl>()->fanEfficiency();
+  return getImpl<detail::FanConstantVolume_Impl>()->fanTotalEfficiency();
 }
 
 bool FanConstantVolume::setFanEfficiency(double val)
 {
-  return getImpl<detail::FanConstantVolume_Impl>()->setFanEfficiency(val);
+  return getImpl<detail::FanConstantVolume_Impl>()->setFanTotalEfficiency(val);
 }
 
 double FanConstantVolume::pressureRise() const

--- a/openstudiocore/src/model/FanConstantVolume.hpp
+++ b/openstudiocore/src/model/FanConstantVolume.hpp
@@ -69,7 +69,10 @@ class MODEL_API FanConstantVolume : public StraightComponent {
 
   Schedule availabilitySchedule() const;
 
-  /** Returns the value of the FanEfficiency field. **/
+  /** Returns the value of the Fan Total Efficiency field **/
+  double fanTotalEfficiency() const;
+
+  /** Returns the value of the Fan Total Efficiency field. Deprecated, forwards to fanTotalEfficiency **/
   double fanEfficiency() const;
 
   /** Returns the value of the PressureRise field. **/
@@ -90,7 +93,10 @@ class MODEL_API FanConstantVolume : public StraightComponent {
 
   bool setAvailabilitySchedule(Schedule& s);
 
-  /** Sets the value of the FanEfficiency field. **/
+  /** Sets the value of the Fan Total Efficiency field. **/
+  bool setFanTotalEfficiency(double value);
+
+  /** Sets the value of the Fan Total Efficiency field. Deprecated, forwards to setFanTotalEfficiency. **/
   bool setFanEfficiency(double value);
 
   /** Sets the value of the PressureRise field. **/

--- a/openstudiocore/src/model/FanConstantVolume_Impl.hpp
+++ b/openstudiocore/src/model/FanConstantVolume_Impl.hpp
@@ -93,11 +93,11 @@ namespace detail {
     Schedule availabilitySchedule() const;
     bool setAvailabilitySchedule(Schedule& s);
 
-    // Get FanEfficiency
-    double fanEfficiency() const;
+    // Get FanTotalEfficiency
+    double fanTotalEfficiency() const;
 
-    // Set fanEfficiency
-    bool setFanEfficiency(double val);
+    // Set fanTotalEfficiency
+    bool setFanTotalEfficiency(double val);
 
     // Get PressureRise
     double pressureRise() const;

--- a/openstudiocore/src/model/FanOnOff.cpp
+++ b/openstudiocore/src/model/FanOnOff.cpp
@@ -175,16 +175,16 @@ namespace detail {
     return result;
   }
 
-  double FanOnOff_Impl::fanEfficiency() const
+  double FanOnOff_Impl::fanTotalEfficiency() const
   {
-    boost::optional<double> value = getDouble(OS_Fan_OnOffFields::FanEfficiency,true);
+    boost::optional<double> value = getDouble(OS_Fan_OnOffFields::FanTotalEfficiency,true);
     OS_ASSERT(value);
     return value.get();
   }
 
-  bool FanOnOff_Impl::isFanEfficiencyDefaulted() const
+  bool FanOnOff_Impl::isFanTotalEfficiencyDefaulted() const
   {
-    return isEmpty(OS_Fan_OnOffFields::FanEfficiency);
+    return isEmpty(OS_Fan_OnOffFields::FanTotalEfficiency);
   }
 
   double FanOnOff_Impl::pressureRise() const
@@ -239,15 +239,15 @@ namespace detail {
     return isEmpty(OS_Fan_OnOffFields::EndUseSubcategory);
   }
 
-  bool FanOnOff_Impl::setFanEfficiency(double fanEfficiency)
+  bool FanOnOff_Impl::setFanTotalEfficiency(double fanTotalEfficiency)
   {
-    bool result = setDouble(OS_Fan_OnOffFields::FanEfficiency, fanEfficiency);
+    bool result = setDouble(OS_Fan_OnOffFields::FanTotalEfficiency, fanTotalEfficiency);
     return result;
   }
 
-  void FanOnOff_Impl::resetFanEfficiency()
+  void FanOnOff_Impl::resetFanTotalEfficiency()
   {
-    bool result = setString(OS_Fan_OnOffFields::FanEfficiency, "");
+    bool result = setString(OS_Fan_OnOffFields::FanTotalEfficiency, "");
     OS_ASSERT(result);
   }
 
@@ -567,7 +567,7 @@ FanOnOff::FanOnOff(const Model& model)
     auto availabilitySchedule = model.alwaysOnDiscreteSchedule();
     setAvailabilitySchedule(availabilitySchedule);
 
-    bool ok = setFanEfficiency(0.6);
+    bool ok = setFanTotalEfficiency(0.6);
     OS_ASSERT(ok);
     setPressureRise(300);
     autosizeMaximumFlowRate();
@@ -601,7 +601,7 @@ FanOnOff::FanOnOff(const Model& model, Schedule& availabilitySchedule)
 
     setAvailabilitySchedule(availabilitySchedule);
 
-    bool ok = setFanEfficiency(0.6);
+    bool ok = setFanTotalEfficiency(0.6);
     OS_ASSERT(ok);
     setPressureRise(300);
     autosizeMaximumFlowRate();
@@ -640,7 +640,7 @@ FanOnOff::FanOnOff(const Model& model,
 
     setAvailabilitySchedule(availabilitySchedule);
 
-    bool ok = setFanEfficiency(0.6);
+    bool ok = setFanTotalEfficiency(0.6);
     OS_ASSERT(ok);
     setPressureRise(300);
     autosizeMaximumFlowRate();
@@ -675,24 +675,44 @@ bool FanOnOff::setAvailabilitySchedule(Schedule& schedule)
 
 // Field Fan Efficiency
 
+double FanOnOff::fanTotalEfficiency() const
+{
+  return getImpl<detail::FanOnOff_Impl>()->fanTotalEfficiency();
+}
+
+bool FanOnOff::isFanTotalEfficiencyDefaulted() const
+{
+  return getImpl<detail::FanOnOff_Impl>()->isFanTotalEfficiencyDefaulted();
+}
+
+bool FanOnOff::setFanTotalEfficiency(double fanTotalEfficiency)
+{
+  return getImpl<detail::FanOnOff_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+void FanOnOff::resetFanTotalEfficiency()
+{
+  getImpl<detail::FanOnOff_Impl>()->resetFanTotalEfficiency();
+}
+
 double FanOnOff::fanEfficiency() const
 {
-  return getImpl<detail::FanOnOff_Impl>()->fanEfficiency();
+  return getImpl<detail::FanOnOff_Impl>()->fanTotalEfficiency();
 }
 
 bool FanOnOff::isFanEfficiencyDefaulted() const
 {
-  return getImpl<detail::FanOnOff_Impl>()->isFanEfficiencyDefaulted();
+  return getImpl<detail::FanOnOff_Impl>()->isFanTotalEfficiencyDefaulted();
 }
 
-bool FanOnOff::setFanEfficiency(double fanEfficiency)
+bool FanOnOff::setFanEfficiency(double fanTotalEfficiency)
 {
-  return getImpl<detail::FanOnOff_Impl>()->setFanEfficiency(fanEfficiency);
+  return getImpl<detail::FanOnOff_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
 }
 
 void FanOnOff::resetFanEfficiency()
 {
-  getImpl<detail::FanOnOff_Impl>()->resetFanEfficiency();
+  getImpl<detail::FanOnOff_Impl>()->resetFanTotalEfficiency();
 }
 
 // Field Pressure Rise

--- a/openstudiocore/src/model/FanOnOff.hpp
+++ b/openstudiocore/src/model/FanOnOff.hpp
@@ -75,8 +75,11 @@ class MODEL_API FanOnOff : public StraightComponent {
 
   Schedule availabilitySchedule() const;
 
-  double fanEfficiency() const;
+  double fanTotalEfficiency() const;
+  bool isFanTotalEfficiencyDefaulted() const;
 
+  /** Deprecrated in favor of fanTotalEfficiency **/
+  double fanEfficiency() const;
   bool isFanEfficiencyDefaulted() const;
 
   double pressureRise() const;
@@ -100,8 +103,11 @@ class MODEL_API FanOnOff : public StraightComponent {
 
   bool setAvailabilitySchedule(Schedule& schedule);
 
-  bool setFanEfficiency(double fanEfficiency);
 
+  bool setFanTotalEfficiency(double fanTotalEfficiency);
+  void resetFanTotalEfficiency();
+
+  bool setFanEfficiency(double fanTotalEfficiency);
   void resetFanEfficiency();
 
   bool setPressureRise(double pressureRise);

--- a/openstudiocore/src/model/FanOnOff_Impl.hpp
+++ b/openstudiocore/src/model/FanOnOff_Impl.hpp
@@ -97,13 +97,13 @@ namespace detail {
 
     // Field Fan Efficiency
 
-    double fanEfficiency() const;
+    double fanTotalEfficiency() const;
 
-    bool isFanEfficiencyDefaulted() const;
+    bool isFanTotalEfficiencyDefaulted() const;
 
-    bool setFanEfficiency(double fanEfficiency);
+    bool setFanTotalEfficiency(double fanTotalEfficiency);
 
-    void resetFanEfficiency();
+    void resetFanTotalEfficiency();
 
     // Field Pressure Rise
 
@@ -196,4 +196,4 @@ namespace detail {
 } // model
 } // openstudio
 
-#endif // MODEL_FANONOFF_IMPL_HPP
+#endif // MODEL_FANONOFF_IMPL_HPP

--- a/openstudiocore/src/model/FanVariableVolume.cpp
+++ b/openstudiocore/src/model/FanVariableVolume.cpp
@@ -117,21 +117,21 @@ namespace detail {
     return value.get();
   }
 
-  double FanVariableVolume_Impl::fanEfficiency() const {
-    boost::optional<double> value = getDouble(OS_Fan_VariableVolumeFields::FanEfficiency,true);
+  double FanVariableVolume_Impl::fanTotalEfficiency() const {
+    boost::optional<double> value = getDouble(OS_Fan_VariableVolumeFields::FanTotalEfficiency,true);
     OS_ASSERT(value);
     return value.get();
   }
 
-  Quantity FanVariableVolume_Impl::getFanEfficiency(bool returnIP) const {
-    OptionalDouble value = fanEfficiency();
-    OSOptionalQuantity result = getQuantityFromDouble(OS_Fan_VariableVolumeFields::FanEfficiency, value, returnIP);
+  Quantity FanVariableVolume_Impl::getFanTotalEfficiency(bool returnIP) const {
+    OptionalDouble value = fanTotalEfficiency();
+    OSOptionalQuantity result = getQuantityFromDouble(OS_Fan_VariableVolumeFields::FanTotalEfficiency, value, returnIP);
     OS_ASSERT(result.isSet());
     return result.get();
   }
 
-  bool FanVariableVolume_Impl::isFanEfficiencyDefaulted() const {
-    return isEmpty(OS_Fan_VariableVolumeFields::FanEfficiency);
+  bool FanVariableVolume_Impl::isFanTotalEfficiencyDefaulted() const {
+    return isEmpty(OS_Fan_VariableVolumeFields::FanTotalEfficiency);
   }
 
   double FanVariableVolume_Impl::pressureRise() const {
@@ -298,21 +298,21 @@ namespace detail {
     return result;
   }
 
-  bool FanVariableVolume_Impl::setFanEfficiency(double fanEfficiency) {
-    bool result = setDouble(OS_Fan_VariableVolumeFields::FanEfficiency, fanEfficiency);
+  bool FanVariableVolume_Impl::setFanTotalEfficiency(double fanTotalEfficiency) {
+    bool result = setDouble(OS_Fan_VariableVolumeFields::FanTotalEfficiency, fanTotalEfficiency);
     return result;
   }
 
-  bool FanVariableVolume_Impl::setFanEfficiency(const Quantity& fanEfficiency) {
-    OptionalDouble value = getDoubleFromQuantity(OS_Fan_VariableVolumeFields::FanEfficiency,fanEfficiency);
+  bool FanVariableVolume_Impl::setFanTotalEfficiency(const Quantity& fanTotalEfficiency) {
+    OptionalDouble value = getDoubleFromQuantity(OS_Fan_VariableVolumeFields::FanTotalEfficiency,fanTotalEfficiency);
     if (!value) {
       return false;
     }
-    return setFanEfficiency(value.get());
+    return setFanTotalEfficiency(value.get());
   }
 
-  void FanVariableVolume_Impl::resetFanEfficiency() {
-    bool result = setString(OS_Fan_VariableVolumeFields::FanEfficiency, "");
+  void FanVariableVolume_Impl::resetFanTotalEfficiency() {
+    bool result = setString(OS_Fan_VariableVolumeFields::FanTotalEfficiency, "");
     OS_ASSERT(result);
   }
 
@@ -685,12 +685,12 @@ namespace detail {
     return false;
   }
 
-  openstudio::Quantity FanVariableVolume_Impl::fanEfficiency_SI() const {
-    return getFanEfficiency(false);
+  openstudio::Quantity FanVariableVolume_Impl::fanTotalEfficiency_SI() const {
+    return getFanTotalEfficiency(false);
   }
 
-  openstudio::Quantity FanVariableVolume_Impl::fanEfficiency_IP() const {
-    return getFanEfficiency(true);
+  openstudio::Quantity FanVariableVolume_Impl::fanTotalEfficiency_IP() const {
+    return getFanTotalEfficiency(true);
   }
 
   openstudio::Quantity FanVariableVolume_Impl::pressureRise_SI() const {
@@ -926,7 +926,7 @@ FanVariableVolume::FanVariableVolume(const Model& model, Schedule & schedule)
                   << schedule.briefDescription() << ".");
   }
   setEndUseSubcategory("");
-  setFanEfficiency(0.6045);
+  setFanTotalEfficiency(0.6045);
   setPressureRise(1017.592);
   autosizeMaximumFlowRate();
   setFanPowerMinimumFlowRateInputMethod("FixedFlowRate");
@@ -950,7 +950,7 @@ FanVariableVolume::FanVariableVolume(const Model& model)
   setAvailabilitySchedule(schedule);
 
   setEndUseSubcategory("");
-  setFanEfficiency(0.6045);
+  setFanTotalEfficiency(0.6045);
   setPressureRise(1017.592);
   autosizeMaximumFlowRate();
   setFanPowerMinimumFlowRateInputMethod("FixedFlowRate");
@@ -983,17 +983,57 @@ Schedule FanVariableVolume::availabilitySchedule() const {
   return getImpl<detail::FanVariableVolume_Impl>()->availabilitySchedule();
 }
 
+
+// New Fan Total Efficiency
+double FanVariableVolume::fanTotalEfficiency() const {
+  return getImpl<detail::FanVariableVolume_Impl>()->fanTotalEfficiency();
+}
+
+Quantity FanVariableVolume::getFanTotalEfficiency(bool returnIP) const {
+  return getImpl<detail::FanVariableVolume_Impl>()->getFanTotalEfficiency(returnIP);
+}
+
+bool FanVariableVolume::isFanTotalEfficiencyDefaulted() const {
+  return getImpl<detail::FanVariableVolume_Impl>()->isFanTotalEfficiencyDefaulted();
+}
+
+bool FanVariableVolume::setFanTotalEfficiency(double fanTotalEfficiency) {
+  return getImpl<detail::FanVariableVolume_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+bool FanVariableVolume::setFanTotalEfficiency(const Quantity& fanTotalEfficiency) {
+  return getImpl<detail::FanVariableVolume_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+void FanVariableVolume::resetFanTotalEfficiency() {
+  getImpl<detail::FanVariableVolume_Impl>()->resetFanTotalEfficiency();
+}
+
+// Deprecrated methods
 double FanVariableVolume::fanEfficiency() const {
-  return getImpl<detail::FanVariableVolume_Impl>()->fanEfficiency();
+  return getImpl<detail::FanVariableVolume_Impl>()->fanTotalEfficiency();
 }
 
 Quantity FanVariableVolume::getFanEfficiency(bool returnIP) const {
-  return getImpl<detail::FanVariableVolume_Impl>()->getFanEfficiency(returnIP);
+  return getImpl<detail::FanVariableVolume_Impl>()->getFanTotalEfficiency(returnIP);
 }
 
 bool FanVariableVolume::isFanEfficiencyDefaulted() const {
-  return getImpl<detail::FanVariableVolume_Impl>()->isFanEfficiencyDefaulted();
+  return getImpl<detail::FanVariableVolume_Impl>()->isFanTotalEfficiencyDefaulted();
 }
+
+bool FanVariableVolume::setFanEfficiency(double fanTotalEfficiency) {
+  return getImpl<detail::FanVariableVolume_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+bool FanVariableVolume::setFanEfficiency(const Quantity& fanTotalEfficiency) {
+  return getImpl<detail::FanVariableVolume_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+void FanVariableVolume::resetFanEfficiency() {
+  getImpl<detail::FanVariableVolume_Impl>()->resetFanTotalEfficiency();
+}
+
 
 double FanVariableVolume::pressureRise() const {
   return getImpl<detail::FanVariableVolume_Impl>()->pressureRise();
@@ -1117,18 +1157,6 @@ bool FanVariableVolume::isEndUseSubcategoryDefaulted() const {
 
 bool FanVariableVolume::setAvailabilitySchedule(Schedule& schedule) {
   return getImpl<detail::FanVariableVolume_Impl>()->setAvailabilitySchedule(schedule);
-}
-
-bool FanVariableVolume::setFanEfficiency(double fanEfficiency) {
-  return getImpl<detail::FanVariableVolume_Impl>()->setFanEfficiency(fanEfficiency);
-}
-
-bool FanVariableVolume::setFanEfficiency(const Quantity& fanEfficiency) {
-  return getImpl<detail::FanVariableVolume_Impl>()->setFanEfficiency(fanEfficiency);
-}
-
-void FanVariableVolume::resetFanEfficiency() {
-  getImpl<detail::FanVariableVolume_Impl>()->resetFanEfficiency();
 }
 
 bool FanVariableVolume::setPressureRise(double pressureRise) {

--- a/openstudiocore/src/model/FanVariableVolume.hpp
+++ b/openstudiocore/src/model/FanVariableVolume.hpp
@@ -75,10 +75,13 @@ class MODEL_API FanVariableVolume : public StraightComponent {
 
   Schedule availabilitySchedule() const;
 
+  double fanTotalEfficiency() const;
   double fanEfficiency() const;
 
+  Quantity getFanTotalEfficiency(bool returnIP=false) const;
   Quantity getFanEfficiency(bool returnIP=false) const;
 
+  bool isFanTotalEfficiencyDefaulted() const;
   bool isFanEfficiencyDefaulted() const;
 
   double pressureRise() const;
@@ -147,10 +150,12 @@ class MODEL_API FanVariableVolume : public StraightComponent {
 
   bool setAvailabilitySchedule(Schedule& schedule);
 
-  bool setFanEfficiency(double fanEfficiency);
+  bool setFanTotalEfficiency(double fanTotalEfficiency);
+  bool setFanTotalEfficiency(const Quantity& fanTotalEfficiency);
+  void resetFanTotalEfficiency();
 
-  bool setFanEfficiency(const Quantity& fanEfficiency);
-
+  bool setFanEfficiency(double fanTotalEfficiency);
+  bool setFanEfficiency(const Quantity& fanTotalEfficiency);
   void resetFanEfficiency();
 
   bool setPressureRise(double pressureRise);

--- a/openstudiocore/src/model/FanVariableVolume_Impl.hpp
+++ b/openstudiocore/src/model/FanVariableVolume_Impl.hpp
@@ -86,11 +86,11 @@ namespace detail {
 
     Schedule availabilitySchedule() const;
 
-    double fanEfficiency() const;
+    double fanTotalEfficiency() const;
 
-    Quantity getFanEfficiency(bool returnIP=false) const;
+    Quantity getFanTotalEfficiency(bool returnIP=false) const;
 
-    bool isFanEfficiencyDefaulted() const;
+    bool isFanTotalEfficiencyDefaulted() const;
 
     double pressureRise() const;
 
@@ -168,11 +168,11 @@ namespace detail {
 
     bool setAvailabilitySchedule(Schedule& schedule);
 
-    bool setFanEfficiency(double fanEfficiency);
+    bool setFanTotalEfficiency(double fanTotalEfficiency);
 
-    bool setFanEfficiency(const Quantity& fanEfficiency);
+    bool setFanTotalEfficiency(const Quantity& fanTotalEfficiency);
 
-    void resetFanEfficiency();
+    void resetFanTotalEfficiency();
 
     bool setPressureRise(double pressureRise);
 
@@ -256,8 +256,8 @@ namespace detail {
   private:
     REGISTER_LOGGER("openstudio.model.FanVariableVolume");
 
-    openstudio::Quantity fanEfficiency_SI() const;
-    openstudio::Quantity fanEfficiency_IP() const;
+    openstudio::Quantity fanTotalEfficiency_SI() const;
+    openstudio::Quantity fanTotalEfficiency_IP() const;
     openstudio::Quantity pressureRise_SI() const;
     openstudio::Quantity pressureRise_IP() const;
     openstudio::OSOptionalQuantity maximumFlowRate_SI() const;

--- a/openstudiocore/src/model/FanZoneExhaust.cpp
+++ b/openstudiocore/src/model/FanZoneExhaust.cpp
@@ -191,8 +191,8 @@ namespace detail {
     return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_Fan_ZoneExhaustFields::AvailabilityScheduleName);
   }
 
-  double FanZoneExhaust_Impl::fanEfficiency() const {
-    boost::optional<double> value = getDouble(OS_Fan_ZoneExhaustFields::FanEfficiency,true);
+  double FanZoneExhaust_Impl::fanTotalEfficiency() const {
+    boost::optional<double> value = getDouble(OS_Fan_ZoneExhaustFields::FanTotalEfficiency,true);
     OS_ASSERT(value);
     return value.get();
   }
@@ -254,8 +254,8 @@ namespace detail {
     OS_ASSERT(result);
   }
 
-  bool FanZoneExhaust_Impl::setFanEfficiency(double fanEfficiency) {
-    bool result = setDouble(OS_Fan_ZoneExhaustFields::FanEfficiency, fanEfficiency);
+  bool FanZoneExhaust_Impl::setFanTotalEfficiency(double fanTotalEfficiency) {
+    bool result = setDouble(OS_Fan_ZoneExhaustFields::FanTotalEfficiency, fanTotalEfficiency);
     return result;
   }
 
@@ -346,7 +346,7 @@ namespace detail {
                                    "Fan Nominal Total Efficiency"};
     return types;
   }
-  
+
   AirflowNetworkZoneExhaustFan FanZoneExhaust_Impl::getAirflowNetworkZoneExhaustFan(const AirflowNetworkCrack& crack)
   {
     boost::optional<AirflowNetworkZoneExhaustFan> opt = airflowNetworkZoneExhaustFan();
@@ -382,7 +382,7 @@ FanZoneExhaust::FanZoneExhaust(const Model& model)
 {
   OS_ASSERT(getImpl<detail::FanZoneExhaust_Impl>());
 
-  setFanEfficiency(0.60);
+  setFanTotalEfficiency(0.60);
   setPressureRise(0);
   setEndUseSubcategory("General");
   setSystemAvailabilityManagerCouplingMode("Decoupled");
@@ -401,8 +401,13 @@ boost::optional<Schedule> FanZoneExhaust::availabilitySchedule() const {
   return getImpl<detail::FanZoneExhaust_Impl>()->availabilitySchedule();
 }
 
+
+double FanZoneExhaust::fanTotalEfficiency() const {
+  return getImpl<detail::FanZoneExhaust_Impl>()->fanTotalEfficiency();
+}
+
 double FanZoneExhaust::fanEfficiency() const {
-  return getImpl<detail::FanZoneExhaust_Impl>()->fanEfficiency();
+  return getImpl<detail::FanZoneExhaust_Impl>()->fanTotalEfficiency();
 }
 
 double FanZoneExhaust::pressureRise() const {
@@ -441,8 +446,12 @@ void FanZoneExhaust::resetAvailabilitySchedule() {
   getImpl<detail::FanZoneExhaust_Impl>()->resetAvailabilitySchedule();
 }
 
-bool FanZoneExhaust::setFanEfficiency(double fanEfficiency) {
-  return getImpl<detail::FanZoneExhaust_Impl>()->setFanEfficiency(fanEfficiency);
+bool FanZoneExhaust::setFanTotalEfficiency(double fanTotalEfficiency) {
+  return getImpl<detail::FanZoneExhaust_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
+}
+
+bool FanZoneExhaust::setFanEfficiency(double fanTotalEfficiency) {
+  return getImpl<detail::FanZoneExhaust_Impl>()->setFanTotalEfficiency(fanTotalEfficiency);
 }
 
 bool FanZoneExhaust::setPressureRise(double pressureRise) {

--- a/openstudiocore/src/model/FanZoneExhaust.hpp
+++ b/openstudiocore/src/model/FanZoneExhaust.hpp
@@ -68,6 +68,10 @@ class MODEL_API FanZoneExhaust : public ZoneHVACComponent {
 
   boost::optional<Schedule> availabilitySchedule() const;
 
+
+  double fanTotalEfficiency() const;
+
+  /** Deprecated, forwards to fanTotalEfficiency */
   double fanEfficiency() const;
 
   double pressureRise() const;
@@ -92,7 +96,10 @@ class MODEL_API FanZoneExhaust : public ZoneHVACComponent {
 
   void resetAvailabilitySchedule();
 
-  bool setFanEfficiency(double fanEfficiency);
+  bool setFanTotalEfficiency(double fanTotalEfficiency);
+
+  /** Deprecated, forwards to setFanTotalEfficiency */
+  bool setFanEfficiency(double fanTotalEfficiency);
 
   bool setPressureRise(double pressureRise);
 
@@ -148,4 +155,4 @@ typedef std::vector<FanZoneExhaust> FanZoneExhaustVector;
 } // model
 } // openstudio
 
-#endif // MODEL_FANZONEEXHAUST_HPP
+#endif // MODEL_FANZONEEXHAUST_HPP

--- a/openstudiocore/src/model/FanZoneExhaust_Impl.hpp
+++ b/openstudiocore/src/model/FanZoneExhaust_Impl.hpp
@@ -86,7 +86,7 @@ namespace detail {
 
     boost::optional<Schedule> availabilitySchedule() const;
 
-    double fanEfficiency() const;
+    double fanTotalEfficiency() const;
 
     double pressureRise() const;
 
@@ -114,7 +114,7 @@ namespace detail {
 
     void resetAvailabilitySchedule();
 
-    bool setFanEfficiency(double fanEfficiency);
+    bool setFanTotalEfficiency(double fanTotalEfficiency);
 
     bool setPressureRise(double pressureRise);
 
@@ -156,4 +156,4 @@ namespace detail {
 } // model
 } // openstudio
 
-#endif // MODEL_FANZONEEXHAUST_IMPL_HPP
+#endif // MODEL_FANZONEEXHAUST_IMPL_HPP

--- a/openstudiocore/src/model/test/FanOnOff_GTest.cpp
+++ b/openstudiocore/src/model/test/FanOnOff_GTest.cpp
@@ -181,7 +181,7 @@ TEST_F(ModelFixture, FanOnOff_CloneOneModelWithDefaultData)
     EXPECT_TRUE(it->parent());
   }
 
-  EXPECT_DOUBLE_EQ(0.6, testObjectClone.fanEfficiency());
+  EXPECT_DOUBLE_EQ(0.6, testObjectClone.fanTotalEfficiency());
   EXPECT_DOUBLE_EQ(300, testObjectClone.pressureRise());
   EXPECT_DOUBLE_EQ(0.8, testObjectClone.motorEfficiency());
   EXPECT_TRUE(testObjectClone.isMaximumFlowRateAutosized());
@@ -204,7 +204,7 @@ TEST_F(ModelFixture, FanOnOff_CloneOneModelWithCustomData)
   Schedule s = m.alwaysOnDiscreteSchedule();
   FanOnOff testObject = FanOnOff(m, s);
   testObject.setPressureRise(999.0);
-  testObject.setFanEfficiency(0.99);
+  testObject.setFanTotalEfficiency(0.99);
   testObject.setMaximumFlowRate(999.0);
 
   CurveExponent fanPowerFuncSpeedCurve(m);
@@ -215,7 +215,7 @@ TEST_F(ModelFixture, FanOnOff_CloneOneModelWithCustomData)
 
   FanOnOff testObjectClone = testObject.clone(m).cast<FanOnOff>();
   EXPECT_DOUBLE_EQ(999.0, testObjectClone.pressureRise());
-  EXPECT_DOUBLE_EQ(0.99, testObjectClone.fanEfficiency());
+  EXPECT_DOUBLE_EQ(0.99, testObjectClone.fanTotalEfficiency());
   EXPECT_DOUBLE_EQ(999.0, testObjectClone.maximumFlowRate().get());
   EXPECT_EQ(testObject.fanPowerRatioFunctionofSpeedRatioCurve().handle(), testObjectClone.fanPowerRatioFunctionofSpeedRatioCurve().handle());
   EXPECT_EQ(fanPowerFuncSpeedCurve.handle(), testObjectClone.fanPowerRatioFunctionofSpeedRatioCurve().handle());
@@ -266,7 +266,7 @@ TEST_F(ModelFixture, FanOnOff_CloneTwoModelsWithDefaultData)
     EXPECT_TRUE(it->parent());
   }
 
-  EXPECT_DOUBLE_EQ(0.6, testObjectClone2.fanEfficiency());
+  EXPECT_DOUBLE_EQ(0.6, testObjectClone2.fanTotalEfficiency());
   EXPECT_DOUBLE_EQ(300, testObjectClone2.pressureRise());
   EXPECT_DOUBLE_EQ(0.8, testObjectClone2.motorEfficiency());
   EXPECT_TRUE(testObjectClone2.isMaximumFlowRateAutosized());
@@ -283,7 +283,7 @@ TEST_F(ModelFixture, FanOnOff_CloneTwoModelsWithCustomData)
   Schedule s = m.alwaysOnDiscreteSchedule();
   FanOnOff testObject = FanOnOff(m, s);
   testObject.setPressureRise(999.0);
-  testObject.setFanEfficiency(0.99);
+  testObject.setFanTotalEfficiency(0.99);
   testObject.setMaximumFlowRate(999.0);
 
   CurveExponent fanPowerFuncSpeedCurve(m);
@@ -346,7 +346,7 @@ TEST_F(ModelFixture, FanOnOff_CloneTwoModelsWithCustomData)
   }
 
   EXPECT_DOUBLE_EQ(999.0, testObjectClone2.pressureRise());
-  EXPECT_DOUBLE_EQ(0.99, testObjectClone2.fanEfficiency());
+  EXPECT_DOUBLE_EQ(0.99, testObjectClone2.fanTotalEfficiency());
   EXPECT_DOUBLE_EQ(999.0, testObjectClone2.maximumFlowRate().get());
   EXPECT_NE(testObject.fanPowerRatioFunctionofSpeedRatioCurve().handle(), testObjectClone2.fanPowerRatioFunctionofSpeedRatioCurve().handle());
   EXPECT_NE(fanPowerFuncSpeedCurve.handle(), testObjectClone2.fanPowerRatioFunctionofSpeedRatioCurve().handle());
@@ -369,12 +369,22 @@ TEST_F(ModelFixture,FanOnOff_Test_Setters_and_Getters)
   EXPECT_EQ(test_sched, testObject.availabilitySchedule());
 
   // Field Fan Efficiency
+  EXPECT_TRUE(testObject.setFanTotalEfficiency(0.8));
+  EXPECT_DOUBLE_EQ(0.8, testObject.fanTotalEfficiency());
+  EXPECT_FALSE(testObject.isFanTotalEfficiencyDefaulted());
+
+  testObject.resetFanTotalEfficiency();
+  EXPECT_TRUE(testObject.isFanTotalEfficiencyDefaulted());
+
+  // Test the deprecated older name
+
   EXPECT_TRUE(testObject.setFanEfficiency(0.7));
   EXPECT_DOUBLE_EQ(0.7, testObject.fanEfficiency());
   EXPECT_FALSE(testObject.isFanEfficiencyDefaulted());
 
   testObject.resetFanEfficiency();
   EXPECT_TRUE(testObject.isFanEfficiencyDefaulted());
+
 
   // Field Pressure Rise
 


### PR DESCRIPTION
Fix #2059 - change Fan Efficiency field to Fan Total Efficiency.

Changelog:
* Change Fan Efficiency to Fan Total Efficiency in IDD (which now matches E+)
* Rename the private (_Impl) methods to `fanTotalEfficiency`
* Public interface now that `fanTotalEfficiency` and the old `fanEfficiency` that forwards to the Impl one.

Note: I was told to not explicitly deprecate the old `fanEfficiency` methods (that is put an `OS_DEPRECATED` in front)


Original issue assignee: @kbenne. Could you review this one please?