### PR TITLE
Fix #297 - populate SaveAs with current filename

### DIFF
--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -1490,7 +1490,9 @@ namespace openstudio {
   {
     bool fileSaved = false;
 
-    QString defaultDir = savePath().isEmpty() ? mainWindow()->lastPath() : QFileInfo(savePath()).path();
+    // Defaults to the current savePath is there is one (will populate the filename too)
+    // Or the lastPath (directory) if not.
+    QString defaultDir = savePath().isEmpty() ? mainWindow()->lastPath() : savePath();
 
     QString filePath = QFileDialog::getSaveFileName(this->mainWindow(),
       tr("Save"),


### PR DESCRIPTION
Fix #297 - populate SaveAs with current filename

Very minor change, @macumber could you review please?
