### PR TITLE
Fix #2832  (and #2567) - OS App Cannot Open File Path with spaces or special characters on windows

### DIFF
--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -227,11 +227,13 @@ void OpenStudioApp::onMeasureManagerAndLibraryReady() {
       osversion::VersionTranslator versionTranslator;
       versionTranslator.setAllowNewerVersions(false);
 
-      boost::optional<openstudio::model::Model> model = versionTranslator.loadModel(toPath(fileName));
+      // Handle special chars by creating the path from a wstring
+      openstudio::path filePath(fileName.toStdWString());
+      boost::optional<openstudio::model::Model> model = versionTranslator.loadModel(filePath);
       if( model ){
 
-        m_osDocument = std::shared_ptr<OSDocument>( new OSDocument(componentLibrary(), 
-                                                                   resourcesPath(), 
+        m_osDocument = std::shared_ptr<OSDocument>( new OSDocument(componentLibrary(),
+                                                                   resourcesPath(),
                                                                    model,
                                                                    fileName) );
 
@@ -1166,12 +1168,12 @@ void OpenStudioApp::startMeasureManagerProcess(){
 void OpenStudioApp::loadLibrary() {
   if ( this->currentDocument() ) {
     QWidget * parent = this->currentDocument()->mainWindow();
-  
+
     QString fileName = QFileDialog::getOpenFileName( parent,
                                                     tr("Select Library"),
                                                     toQString(resourcesPath()),
                                                     tr("(*.osm)") );
-  
+
     if( ! (fileName == "") ) {
       QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
 
@@ -1202,7 +1204,7 @@ void OpenStudioApp::changeDefaultLibraries() {
   auto defaultPaths = defaultLibraryPaths();
   auto paths = libraryPaths();
 
-  auto resources = resourcesPath(); 
+  auto resources = resourcesPath();
   LibraryDialog dialog(paths, defaultPaths, resources);
   auto code = dialog.exec();
   auto newPaths = dialog.paths();

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -227,9 +227,7 @@ void OpenStudioApp::onMeasureManagerAndLibraryReady() {
       osversion::VersionTranslator versionTranslator;
       versionTranslator.setAllowNewerVersions(false);
 
-      // Handle special chars by creating the path from a wstring
-      openstudio::path filePath(fileName.toStdWString());
-      boost::optional<openstudio::model::Model> model = versionTranslator.loadModel(filePath);
+      boost::optional<openstudio::model::Model> model = versionTranslator.loadModel(toPath(fileName));
       if( model ){
 
         m_osDocument = std::shared_ptr<OSDocument>( new OSDocument(componentLibrary(),

--- a/openstudiocore/src/openstudio_app/install_operations.qs
+++ b/openstudiocore/src/openstudio_app/install_operations.qs
@@ -27,7 +27,8 @@ function Component()
 
     if( kernel == "winnt" ) {
       component.addElevatedOperation("CreateShortcut", "@TargetDir@/bin/OpenStudioApp.exe", "@StartMenuDir@/OpenStudio.lnk");
-      component.addElevatedOperation("RegisterFileType", "osm", "@TargetDir@/bin/OpenStudioApp.exe %1", "OpenStudio Model File", "text/plain", "@TargetDir@/bin/OpenStudioApp.exe,1");
+      // Note JM: you have to quote the %1 which represents the file path, otherwise any space in the path will think there are multiple args
+      component.addElevatedOperation("RegisterFileType", "osm", "@TargetDir@/bin/OpenStudioApp.exe \"%1\"", "OpenStudio Model File", "text/plain", "@TargetDir@/bin/OpenStudioApp.exe,1");
     }
   }
 }

--- a/openstudiocore/src/utilities/core/Path.cpp
+++ b/openstudiocore/src/utilities/core/Path.cpp
@@ -70,8 +70,9 @@ std::ostream& operator<<(std::ostream& os, const path& p)
 /** QString to path*/
 path toPath(const QString& q)
 {
-  std::string s = toString(q);
-  return path(s);
+  // std::string s = toString(q);
+  // Construct from a wstring to avoid messes with special characters
+  return path(q.toStdWString());
 }
 
 /** path to a temporary directory. */


### PR DESCRIPTION
Fix #2832 - Cannot Open File Path with spaces on windows

Basically just quote the filepath so that if there are spaces, it's still captured as a single argument and not several.


If I double click on `C:\Users\julien\2832_CannotLoadSpaces\a file with spaces.osm`, here are the content of argv:

**Before**:

```
arg 0: C:\Users\julien\Software\Others\OS-build\Products\Debug\OpenStudioApp.exe
arg 1: C:\Users\julien\2832_CannotLoadSpaces\a
arg 2: file
arg 3: with
arg 4: spaces.osm
```

**After:** It is correctly identified as a single argument.

```
arg 0: C:\openstudio-2.6.1/bin/OpenStudioApp.exe
arg 1: C:\Users\julien\2832_CannotLoadSpaces\a file with spaces.osm
```

Review assignee: @macumber 