### PR TITLE
Fix #1554 - Always enable Revert to Saved 

### DIFF
--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -691,12 +691,11 @@ bool OpenStudioApp::closeDocument()
 
     auto messageBox = new QMessageBox(parent);
 
+    messageBox->setWindowTitle("New OpenStudio Document");
     messageBox->setText("The document has been modified.");
-
     messageBox->setInformativeText("Do you want to save your changes?");
 
     messageBox->setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
-
     messageBox->setDefaultButton(QMessageBox::Save);
 
     messageBox->button(QMessageBox::Save)->setShortcut(QKeySequence(Qt::Key_S));
@@ -1069,13 +1068,12 @@ void OpenStudioApp::revertToSaved()
   QFile testFile(fileName);
   if( !testFile.exists() ) {
     // Tell the user the file has never been saved, and ask them if they want to create a new file
-
     QMessageBox::StandardButton reply;
     reply = QMessageBox::question(mainWidget(), QString("Revert to Saved"), QString("This model has never been saved.\nDo you want to create a New Model?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
     if (reply == QMessageBox::Yes)
     {
       // JM: copied DLM's hack below so we do not trigger prompt to save in call to closeDocument during newModel()
-      this->currentDocument()->markAsUnmodified();
+      // this->currentDocument()->markAsUnmodified();
 
       newModel();
     }

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -1067,16 +1067,30 @@ void OpenStudioApp::revertToSaved()
   QString fileName = this->currentDocument()->mainWindow()->windowFilePath();
 
   QFile testFile(fileName);
-  if(!testFile.exists()) return;
+  if( !testFile.exists() ) {
+    // Tell the user the file has never been saved, and ask them if they want to create a new file
 
-  QMessageBox::StandardButton reply;
-  reply = QMessageBox::question(mainWidget(), QString("Revert to Saved"), QString("Are you sure you want to revert to the last saved version?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
-  if (reply == QMessageBox::Yes)
-  {
-    // DLM: quick hack so we do not trigger prompt to save in call to closeDocument during openFile
-    this->currentDocument()->markAsUnmodified();
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::question(mainWidget(), QString("Revert to Saved"), QString("This model has never been saved.\nDo you want to create a New Model?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+    if (reply == QMessageBox::Yes)
+    {
+      // JM: copied DLM's hack below so we do not trigger prompt to save in call to closeDocument during newModel()
+      this->currentDocument()->markAsUnmodified();
 
-    openFile(fileName, true);
+      newModel();
+    }
+
+  } else {
+    // Ask for confirmation
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::question(mainWidget(), QString("Revert to Saved"), QString("Are you sure you want to revert to the last saved version?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+    if (reply == QMessageBox::Yes)
+    {
+      // DLM: quick hack so we do not trigger prompt to save in call to closeDocument during openFile
+      this->currentDocument()->markAsUnmodified();
+
+      openFile(fileName, true);
+    }
   }
 
 }

--- a/openstudiocore/src/openstudio_lib/MainMenu.cpp
+++ b/openstudiocore/src/openstudio_lib/MainMenu.cpp
@@ -67,7 +67,8 @@ MainMenu::MainMenu(bool isIP, bool isPlugin, QWidget *parent) :
   m_fileMenu->addSeparator();
 
   m_revertToSavedAction = new QAction(tr("&Revert to Saved"), this);
-  m_revertToSavedAction->setDisabled(true);
+  // m_revertToSavedAction->setDisabled(true);
+  m_revertToSavedAction->setDisabled(false);
   m_fileMenu->addAction(m_revertToSavedAction);
   connect(m_revertToSavedAction, &QAction::triggered, this, &MainMenu::revertFileClicked, Qt::QueuedConnection);
 
@@ -247,7 +248,17 @@ void MainMenu::displayIPUnitsClicked()
 
 void MainMenu::enableRevertToSavedAction(bool enable)
 {
-  m_revertToSavedAction->setEnabled(enable);
+  // We no longer switch the action ON/OFF
+  // m_revertToSavedAction->setEnabled(enable);
+
+  // Instead, we display an asterisk to indicate whether we think the model is dirty or not
+  // Note: (The MainWindow also displays an asterisk, so perhaps it's not needed)
+  if( enable ) {
+    m_revertToSavedAction->setText(tr("&Revert to Saved *"));
+
+  } else {
+    m_revertToSavedAction->setText(tr("&Revert to Saved"));
+  }
 }
 
 void MainMenu::enableFileImportActions(bool enable)


### PR DESCRIPTION
Fix #1554 - Always enable Revert to Saved 

Changelog:
* Always Enable Revert to Saved: if we think the model is dirty, I just display an asterisk next to "Revert to Saved" (which may not be needed since the MainWindow title also does)

![revert_to_saved](https://user-images.githubusercontent.com/5479063/44577455-73d16780-a791-11e8-9f7b-24c7496552a1.png)

* Per @macumber's comment on the issue, Revert to Saved now will create a brand new model when it was never saved.

![image](https://user-images.githubusercontent.com/5479063/44577604-d75b9500-a791-11e8-8c88-36842b50ccc3.png)


Question here is whether after this dialog box, we should also show the standard one (I think there's some value there).

![image](https://user-images.githubusercontent.com/5479063/44577615-de82a300-a791-11e8-9616-db4975bc1da1.png)


Review assignee: @macumber 
