### PR TITLE
Fix #114 - orphaned colors

### DIFF
--- a/openstudiocore/src/model/BuildingStory.cpp
+++ b/openstudiocore/src/model/BuildingStory.cpp
@@ -54,7 +54,7 @@ namespace model {
 namespace detail {
 
   BuildingStory_Impl::BuildingStory_Impl(const IdfObject& idfObject, Model_Impl* model, bool keepHandle)
-    : ModelObject_Impl(idfObject,model,keepHandle)
+    : ParentObject_Impl(idfObject,model,keepHandle)
   {
     OS_ASSERT(idfObject.iddObject().type() == BuildingStory::iddObjectType());
   }
@@ -62,7 +62,7 @@ namespace detail {
   BuildingStory_Impl::BuildingStory_Impl(const openstudio::detail::WorkspaceObject_Impl& other,
                                          Model_Impl* model,
                                          bool keepHandle)
-    : ModelObject_Impl(other,model,keepHandle)
+    : ParentObject_Impl(other,model,keepHandle)
   {
     OS_ASSERT(other.iddObject().type() == BuildingStory::iddObjectType());
   }
@@ -70,7 +70,7 @@ namespace detail {
   BuildingStory_Impl::BuildingStory_Impl(const BuildingStory_Impl& other,
                                          Model_Impl* model,
                                          bool keepHandle)
-    : ModelObject_Impl(other,model,keepHandle)
+    : ParentObject_Impl(other,model,keepHandle)
   {}
 
   const std::vector<std::string>& BuildingStory_Impl::outputVariableNames() const
@@ -81,6 +81,20 @@ namespace detail {
 
   IddObjectType BuildingStory_Impl::iddObjectType() const {
     return BuildingStory::iddObjectType();
+  }
+
+  std::vector<ModelObject> BuildingStory_Impl::children() const {
+    std::vector<ModelObject> result;
+    if( boost::optional<RenderingColor> r = this->renderingColor() ) {
+      result.push_back(*r);
+    }
+    return result;
+  }
+
+  std::vector<IddObjectType> BuildingStory_Impl::allowableChildTypes() const {
+    IddObjectTypeVector result;
+    result.push_back(RenderingColor::iddObjectType());
+    return result;
   }
 
   boost::optional<double> BuildingStory_Impl::nominalZCoordinate() const {
@@ -256,7 +270,7 @@ namespace detail {
 } // detail
 
 BuildingStory::BuildingStory(const Model& model)
-  : ModelObject(BuildingStory::iddObjectType(), model)
+  : ParentObject(BuildingStory::iddObjectType(), model)
 {
   OS_ASSERT(getImpl<detail::BuildingStory_Impl>());
 }
@@ -354,7 +368,7 @@ std::vector<Space> BuildingStory::spaces() const
 
 /// @cond
 BuildingStory::BuildingStory(std::shared_ptr<detail::BuildingStory_Impl> impl)
-  : ModelObject(std::move(impl))
+  : ParentObject(std::move(impl))
 {}
 /// @endcond
 

--- a/openstudiocore/src/model/BuildingStory.hpp
+++ b/openstudiocore/src/model/BuildingStory.hpp
@@ -31,7 +31,7 @@
 #define MODEL_BUILDINGSTORY_HPP
 
 #include "ModelAPI.hpp"
-#include "ModelObject.hpp"
+#include "ParentObject.hpp"
 
 namespace openstudio {
 
@@ -49,8 +49,8 @@ namespace detail {
 
 } // detail
 
-/** BuildingStory is a ModelObject that wraps the OpenStudio IDD object 'OS_BuildingStory'. */
-class MODEL_API BuildingStory : public ModelObject {
+/** BuildingStory is a ParentObject that wraps the OpenStudio IDD object 'OS_BuildingStory'. */
+class MODEL_API BuildingStory : public ParentObject {
  public:
   /** @name Constructors and Destructors */
   //@{

--- a/openstudiocore/src/model/BuildingStory_Impl.hpp
+++ b/openstudiocore/src/model/BuildingStory_Impl.hpp
@@ -30,7 +30,7 @@
 #ifndef MODEL_BUILDINGSTORY_IMPL_HPP
 #define MODEL_BUILDINGSTORY_IMPL_HPP
 
-#include "ModelObject_Impl.hpp"
+#include "ParentObject_Impl.hpp"
 
 namespace openstudio {
 namespace model {
@@ -44,12 +44,8 @@ class BuildingStory;
 
 namespace detail {
 
-  /** BuildingStory_Impl is a ModelObject_Impl that is the implementation class for BuildingStory.*/
-  class MODEL_API BuildingStory_Impl : public ModelObject_Impl {
-
-
-
-
+  /** BuildingStory_Impl is a ParentObject_Impl that is the implementation class for BuildingStory.*/
+  class MODEL_API BuildingStory_Impl : public ParentObject_Impl {
 
    public:
     /** @name Constructors and Destructors */
@@ -72,6 +68,12 @@ namespace detail {
     virtual const std::vector<std::string>& outputVariableNames() const override;
 
     virtual IddObjectType iddObjectType() const override;
+
+    // return any children objects in the hierarchy
+    virtual std::vector<ModelObject> children() const override;
+
+    // get a vector of allowable children types
+    virtual std::vector<IddObjectType> allowableChildTypes() const override;
 
     /** @name Getters */
     //@{

--- a/openstudiocore/src/model/BuildingUnit.cpp
+++ b/openstudiocore/src/model/BuildingUnit.cpp
@@ -51,7 +51,7 @@ namespace model {
 namespace detail {
 
   BuildingUnit_Impl::BuildingUnit_Impl(const IdfObject &idfObject, Model_Impl *model, bool keepHandle)
-    : ModelObject_Impl(idfObject, model, keepHandle)
+    : ParentObject_Impl(idfObject, model, keepHandle)
   {
     OS_ASSERT(idfObject.iddObject().type() == BuildingUnit::iddObjectType());
   }
@@ -59,7 +59,7 @@ namespace detail {
   BuildingUnit_Impl::BuildingUnit_Impl(const openstudio::detail::WorkspaceObject_Impl &other,
                                        Model_Impl *model,
                                        bool keepHandle)
-    : ModelObject_Impl(other, model, keepHandle)
+    : ParentObject_Impl(other, model, keepHandle)
   {
     OS_ASSERT(other.iddObject().type() == BuildingUnit::iddObjectType());
   }
@@ -67,7 +67,7 @@ namespace detail {
   BuildingUnit_Impl::BuildingUnit_Impl(const BuildingUnit_Impl &other,
                                        Model_Impl *model,
                                        bool keepHandle)
-    : ModelObject_Impl(other, model, keepHandle)
+    : ParentObject_Impl(other, model, keepHandle)
   {}
 
   const std::vector<std::string>& BuildingUnit_Impl::outputVariableNames() const
@@ -78,6 +78,20 @@ namespace detail {
 
   IddObjectType BuildingUnit_Impl::iddObjectType() const {
     return BuildingUnit::iddObjectType();
+  }
+
+  std::vector<ModelObject> BuildingUnit_Impl::children() const {
+    std::vector<ModelObject> result;
+    if( boost::optional<RenderingColor> r = this->renderingColor() ) {
+      result.push_back(*r);
+    }
+    return result;
+  }
+
+  std::vector<IddObjectType> BuildingUnit_Impl::allowableChildTypes() const {
+    IddObjectTypeVector result;
+    result.push_back(RenderingColor::iddObjectType());
+    return result;
   }
 
   boost::optional<RenderingColor> BuildingUnit_Impl::renderingColor() const
@@ -197,7 +211,7 @@ namespace detail {
 } //detail
 
 BuildingUnit::BuildingUnit(const Model &model)
-  : ModelObject(BuildingUnit::iddObjectType(), model)
+  : ParentObject(BuildingUnit::iddObjectType(), model)
 {
   OS_ASSERT(getImpl<detail::BuildingUnit_Impl>());
 }
@@ -326,7 +340,7 @@ bool BuildingUnit::resetFeature(const std::string& name)
 
 /// @cond
 BuildingUnit::BuildingUnit(std::shared_ptr<detail::BuildingUnit_Impl> impl)
-  : ModelObject(std::move(impl))
+  : ParentObject(std::move(impl))
 {}
 /// @endcond
 

--- a/openstudiocore/src/model/BuildingUnit.hpp
+++ b/openstudiocore/src/model/BuildingUnit.hpp
@@ -31,7 +31,7 @@
 #define MODEL_BUILDINGUNIT_HPP
 
 #include "ModelAPI.hpp"
-#include "ModelObject.hpp"
+#include "ParentObject.hpp"
 
 namespace openstudio {
 
@@ -46,7 +46,8 @@ namespace detail {
 
 } // detail
 
-class MODEL_API BuildingUnit : public ModelObject {
+/** BuildingUnit is a ParentObject that wraps the OpenStudio IDD object 'OS_BuildingUnit'. */
+class MODEL_API BuildingUnit : public ParentObject {
  public:
   /** @name Constructors and Destructors */
   //@{

--- a/openstudiocore/src/model/BuildingUnit_Impl.hpp
+++ b/openstudiocore/src/model/BuildingUnit_Impl.hpp
@@ -30,7 +30,7 @@
 #ifndef MODEL_BUILDINGUNIT_IMPL_HPP
 #define MODEL_BUILDINGUNIT_IMPL_HPP
 
-#include "ModelObject_Impl.hpp"
+#include "ParentObject_Impl.hpp"
 
 namespace openstudio {
 namespace model {
@@ -41,7 +41,9 @@ class BuildingUnit;
 
 namespace detail {
 
-class MODEL_API BuildingUnit_Impl : public ModelObject_Impl {
+/** BuildingUnit_Impl is a ParentObject_Impl that wraps the OpenStudio IDD object 'OS_BuildingUnit'. */
+class MODEL_API BuildingUnit_Impl : public ParentObject_Impl {
+
  public:
 
   /** @name Constructors and Destructors */
@@ -68,6 +70,12 @@ class MODEL_API BuildingUnit_Impl : public ModelObject_Impl {
   virtual const std::vector<std::string>& outputVariableNames() const override;
 
   virtual IddObjectType iddObjectType() const override;
+
+  // return any children objects in the hierarchy
+  virtual std::vector<ModelObject> children() const override;
+
+  // get a vector of allowable children types
+  virtual std::vector<IddObjectType> allowableChildTypes() const override;
 
   /** @name Getters */
   //@{

--- a/openstudiocore/src/model/ConstructionBase.cpp
+++ b/openstudiocore/src/model/ConstructionBase.cpp
@@ -164,13 +164,16 @@ namespace detail {
   std::vector<ModelObject> ConstructionBase_Impl::children() const {
 
     vector<ModelObject> results(castVector<ModelObject>(getObject<ConstructionBase>().getModelObjectSources<StandardsInformationConstruction>()));
-
+    if( boost::optional<RenderingColor> r = this->renderingColor() ) {
+      results.push_back(*r);
+    }
     return results;
   }
 
   std::vector<IddObjectType> ConstructionBase_Impl::allowableChildTypes() const {
     IddObjectTypeVector result;
     result.push_back(StandardsInformationConstruction::iddObjectType());
+    result.push_back(RenderingColor::iddObjectType());
     return result;
   }
 

--- a/openstudiocore/src/model/RenderingColor.cpp
+++ b/openstudiocore/src/model/RenderingColor.cpp
@@ -46,7 +46,7 @@ namespace model {
 namespace detail {
 
   RenderingColor_Impl::RenderingColor_Impl(const IdfObject& idfObject, Model_Impl* model, bool keepHandle)
-    : ResourceObject_Impl(idfObject,model,keepHandle)
+    : ModelObject_Impl(idfObject,model,keepHandle)
   {
     OS_ASSERT(idfObject.iddObject().type() == RenderingColor::iddObjectType());
 
@@ -71,7 +71,7 @@ namespace detail {
   RenderingColor_Impl::RenderingColor_Impl(const openstudio::detail::WorkspaceObject_Impl& other,
                                            Model_Impl* model,
                                            bool keepHandle)
-    : ResourceObject_Impl(other,model,keepHandle)
+    : ModelObject_Impl(other,model,keepHandle)
   {
     OS_ASSERT(other.iddObject().type() == RenderingColor::iddObjectType());
   }
@@ -79,7 +79,7 @@ namespace detail {
   RenderingColor_Impl::RenderingColor_Impl(const RenderingColor_Impl& other,
                                            Model_Impl* model,
                                            bool keepHandle)
-    : ResourceObject_Impl(other,model,keepHandle)
+    : ModelObject_Impl(other,model,keepHandle)
   {}
 
   const std::vector<std::string>& RenderingColor_Impl::outputVariableNames() const
@@ -176,7 +176,7 @@ namespace detail {
 } // detail
 
 RenderingColor::RenderingColor(const Model& model)
-  : ResourceObject(RenderingColor::iddObjectType(),model)
+  : ModelObject(RenderingColor::iddObjectType(),model)
 {
   OS_ASSERT(getImpl<detail::RenderingColor_Impl>());
 }
@@ -250,7 +250,7 @@ std::string RenderingColor::colorString() const
 
 /// @cond
 RenderingColor::RenderingColor(std::shared_ptr<detail::RenderingColor_Impl> impl)
-  : ResourceObject(std::move(impl))
+  : ModelObject(std::move(impl))
 {}
 
 QColor RenderingColor::randomColor()

--- a/openstudiocore/src/model/RenderingColor.hpp
+++ b/openstudiocore/src/model/RenderingColor.hpp
@@ -44,8 +44,9 @@ namespace detail {
 
 } // detail
 
-/** RenderingColor is a ResourceObject that wraps the OpenStudio IDD object 'OS_Rendering_Color'. */
-class MODEL_API RenderingColor : public ResourceObject {
+/** RenderingColor is a ModelObject that wraps the OpenStudio IDD object 'OS_Rendering_Color'. */
+class MODEL_API RenderingColor : public ModelObject {
+
  public:
   /** @name Constructors and Destructors */
   //@{

--- a/openstudiocore/src/model/RenderingColor_Impl.hpp
+++ b/openstudiocore/src/model/RenderingColor_Impl.hpp
@@ -40,13 +40,8 @@ class RenderingColor;
 
 namespace detail {
 
-  /** RenderingColor_Impl is a ResourceObject_Impl that is the implementation class for RenderingColor.*/
-  class MODEL_API RenderingColor_Impl : public ResourceObject_Impl {
-
-
-
-
-
+  /** RenderingColor_Impl is a ModelObject_Impl that is the implementation class for RenderingColor.*/
+  class MODEL_API RenderingColor_Impl : public ModelObject_Impl {
 
    public:
     /** @name Constructors and Destructors */

--- a/openstudiocore/src/model/SpaceType.cpp
+++ b/openstudiocore/src/model/SpaceType.cpp
@@ -178,6 +178,10 @@ namespace detail {
     SpaceInfiltrationEffectiveLeakageAreaVector spaceInfiltrationEffectiveLeakageAreas = this->spaceInfiltrationEffectiveLeakageAreas();
     result.insert(result.end(), spaceInfiltrationEffectiveLeakageAreas.begin(), spaceInfiltrationEffectiveLeakageAreas.end());
 
+    if( boost::optional<RenderingColor> r = this->renderingColor() ) {
+      result.push_back(*r);
+    }
+
     return result;
   }
 

--- a/openstudiocore/src/model/ThermalZone.cpp
+++ b/openstudiocore/src/model/ThermalZone.cpp
@@ -173,6 +173,10 @@ namespace detail {
       result.push_back(afnz.get());
     }
 
+    if( boost::optional<RenderingColor> r = this->renderingColor() ) {
+      result.push_back(*r);
+    }
+
     return result;
   }
 
@@ -191,6 +195,7 @@ namespace detail {
     // DLM: this does not seem to agree with implementation of children()
     result.push_back(IddObjectType::OS_ThermostatSetpoint_DualSetpoint);
     result.push_back(IddObjectType::OS_ZoneControl_Thermostat_StagedDualSetpoint);
+    result.push_back(IddObjectType::OS_Rendering_Color);
     return result;
   }
 
@@ -2359,6 +2364,11 @@ namespace detail {
     if( auto t_controller = zoneControlContaminantController() ) {
       auto controllerClone = t_controller->clone(model).cast<ZoneControlContaminantController>();
       tz.setZoneControlContaminantController(controllerClone);
+    }
+
+    if( auto t_color = renderingColor() ) {
+      auto colorClone = t_color->clone(model).cast<RenderingColor>();
+      tz.setRenderingColor(colorClone);
     }
 
     // DLM: do not clone zone mixing objects

--- a/openstudiocore/src/model/test/BuildingStory_GTest.cpp
+++ b/openstudiocore/src/model/test/BuildingStory_GTest.cpp
@@ -33,6 +33,8 @@
 
 #include "../BuildingStory.hpp"
 #include "../BuildingStory_Impl.hpp"
+#include "../RenderingColor.hpp"
+#include "../RenderingColor_Impl.hpp"
 
 #include "../../utilities/units/Quantity.hpp"
 #include "../../utilities/units/Unit.hpp"
@@ -65,4 +67,35 @@ TEST_F(ModelFixture,BuildingStory_NominalFloortoFloorHeight) {
   ASSERT_TRUE(result);
   EXPECT_NEAR(value, *result, 1.0E-8);
 }
+
+
+TEST_F(ModelFixture, BuildingStory_RenderingColor) {
+  Model m;
+
+  BuildingStory buildingStory(m);
+  RenderingColor renderingColor(m);
+  EXPECT_TRUE(buildingStory.setRenderingColor(renderingColor));
+
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+
+  // Delete BuildingStory, since the color is referenced, it should be deleted too
+  EXPECT_EQ(2u, buildingStory.remove().size());
+  EXPECT_EQ(0u, m.getModelObjects<BuildingStory>().size());
+  EXPECT_EQ(0u, m.getModelObjects<RenderingColor>().size());
+
+
+  // Clone
+  BuildingStory buildingStory2(m);
+  RenderingColor renderingColor2(m);
+  EXPECT_TRUE(buildingStory2.setRenderingColor(renderingColor2));
+
+  buildingStory2.clone(m);
+  EXPECT_EQ(2u, m.getModelObjects<BuildingStory>().size());
+  EXPECT_EQ(2u, m.getModelObjects<RenderingColor>().size());
+
+  EXPECT_EQ(2u, buildingStory2.remove().size());
+  EXPECT_EQ(1u, m.getModelObjects<BuildingStory>().size());
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+}
+
 

--- a/openstudiocore/src/model/test/BuildingUnit_GTest.cpp
+++ b/openstudiocore/src/model/test/BuildingUnit_GTest.cpp
@@ -51,7 +51,7 @@
 using namespace openstudio;
 using namespace openstudio::model;
 
-TEST_F(ModelFixture, BuildingUnit_RenderingColor)
+TEST_F(ModelFixture, BuildingUnit_RenderingColor_SettersGetters)
 {
 
   Model model;
@@ -250,4 +250,33 @@ TEST_F(ModelFixture, BuildingUnit_Features)
   ASSERT_NE(std::find(suggestedFeatures.begin(), suggestedFeatures.end(), "NumberOfBathrooms"), suggestedFeatures.end());
   ASSERT_NE(std::find(suggestedFeatures.begin(), suggestedFeatures.end(), "MyUniqueFeature"), suggestedFeatures.end());
 
+}
+
+TEST_F(ModelFixture, BuildingUnit_RenderingColor_Clone) {
+  Model m;
+
+  BuildingUnit buildingUnit(m);
+  RenderingColor renderingColor(m);
+  EXPECT_TRUE(buildingUnit.setRenderingColor(renderingColor));
+
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+
+  // Delete BuildingUnit, since the color is referenced, it should be deleted too
+  EXPECT_EQ(2u, buildingUnit.remove().size());
+  EXPECT_EQ(0u, m.getModelObjects<BuildingUnit>().size());
+  EXPECT_EQ(0u, m.getModelObjects<RenderingColor>().size());
+
+
+  // Clone
+  BuildingUnit buildingUnit2(m);
+  RenderingColor renderingColor2(m);
+  EXPECT_TRUE(buildingUnit2.setRenderingColor(renderingColor2));
+
+  buildingUnit2.clone(m);
+  EXPECT_EQ(2u, m.getModelObjects<BuildingUnit>().size());
+  EXPECT_EQ(2u, m.getModelObjects<RenderingColor>().size());
+
+  EXPECT_EQ(2u, buildingUnit2.remove().size());
+  EXPECT_EQ(1u, m.getModelObjects<BuildingUnit>().size());
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
 }

--- a/openstudiocore/src/model/test/Construction_GTest.cpp
+++ b/openstudiocore/src/model/test/Construction_GTest.cpp
@@ -54,6 +54,8 @@
 #include "../WindowDataFile_Impl.hpp"
 #include "../StandardsInformationConstruction.hpp"
 #include "../StandardsInformationConstruction_Impl.hpp"
+#include "../RenderingColor.hpp"
+#include "../RenderingColor_Impl.hpp"
 
 #include "../Material.hpp"
 #include "../Material_Impl.hpp"
@@ -1009,4 +1011,34 @@ TEST_F(ModelFixture, Construction_NumLayers)
       }
     }
   }
+}
+
+
+TEST_F(ModelFixture, Construction_RenderingColor) {
+  Model m;
+
+  Construction construction(m);
+  RenderingColor renderingColor(m);
+  EXPECT_TRUE(construction.setRenderingColor(renderingColor));
+
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+
+  // Delete Construction, since the color is referenced, it should be deleted too
+  EXPECT_EQ(2u, construction.remove().size());
+  EXPECT_EQ(0u, m.getModelObjects<Construction>().size());
+  EXPECT_EQ(0u, m.getModelObjects<RenderingColor>().size());
+
+
+  // Clone
+  Construction construction2(m);
+  RenderingColor renderingColor2(m);
+  EXPECT_TRUE(construction2.setRenderingColor(renderingColor2));
+
+  construction2.clone(m);
+  EXPECT_EQ(2u, m.getModelObjects<Construction>().size());
+  EXPECT_EQ(2u, m.getModelObjects<RenderingColor>().size());
+
+  EXPECT_EQ(2u, construction2.remove().size());
+  EXPECT_EQ(1u, m.getModelObjects<Construction>().size());
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
 }

--- a/openstudiocore/src/model/test/SpaceType_GTest.cpp
+++ b/openstudiocore/src/model/test/SpaceType_GTest.cpp
@@ -43,6 +43,8 @@
 #include "../ThermalZone.hpp"
 #include "../ScheduleRuleset.hpp"
 #include "../ScheduleRuleset_Impl.hpp"
+#include "../RenderingColor.hpp"
+#include "../RenderingColor_Impl.hpp"
 
 #include "../../utilities/data/Attribute.hpp"
 #include "../../utilities/geometry/Point3d.hpp"
@@ -306,3 +308,31 @@ TEST_F(ModelFixture, SpaceType_Clone_Plenum) {
   ASSERT_NE(m3.plenumSpaceType().handle(), m3_stClone.handle());
 }
 
+TEST_F(ModelFixture, SpaceType_RenderingColor) {
+  Model m;
+
+  SpaceType spaceType(m);
+  RenderingColor renderingColor(m);
+  EXPECT_TRUE(spaceType.setRenderingColor(renderingColor));
+
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+
+  // Delete SpaceType, since the color is referenced, it should be deleted too
+  EXPECT_EQ(2u, spaceType.remove().size());
+  EXPECT_EQ(0u, m.getModelObjects<SpaceType>().size());
+  EXPECT_EQ(0u, m.getModelObjects<RenderingColor>().size());
+
+
+  // Clone
+  SpaceType spaceType2(m);
+  RenderingColor renderingColor2(m);
+  EXPECT_TRUE(spaceType2.setRenderingColor(renderingColor2));
+
+  spaceType2.clone(m);
+  EXPECT_EQ(2u, m.getModelObjects<SpaceType>().size());
+  EXPECT_EQ(2u, m.getModelObjects<RenderingColor>().size());
+
+  EXPECT_EQ(2u, spaceType2.remove().size());
+  EXPECT_EQ(1u, m.getModelObjects<SpaceType>().size());
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+}

--- a/openstudiocore/src/model/test/ThermalZone_GTest.cpp
+++ b/openstudiocore/src/model/test/ThermalZone_GTest.cpp
@@ -69,7 +69,8 @@
 #include "../ZoneControlContaminantController.hpp"
 #include "../ZoneControlContaminantController_Impl.hpp"
 #include "../ZoneHVACPackagedTerminalAirConditioner.hpp"
-
+#include "../RenderingColor.hpp"
+#include "../RenderingColor_Impl.hpp"
 
 #include "../ScheduleConstant.hpp"
 #include "../ZoneHVACUnitHeater.hpp"
@@ -807,5 +808,34 @@ TEST_F(ModelFixture, ThermalZone_ZoneControlHumidistat)
     EXPECT_NE(zone.zoneControlHumidistat()->handle(), zone2.zoneControlHumidistat()->handle());
     EXPECT_EQ(2u,m.getModelObjects<model::ZoneControlHumidistat>().size());
   }
+}
+
+TEST_F(ModelFixture, ThermalZone_RenderingColor) {
+  Model m;
+
+  ThermalZone thermalZone(m);
+  RenderingColor renderingColor(m);
+  EXPECT_TRUE(thermalZone.setRenderingColor(renderingColor));
+
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
+
+  // Delete ThermalZone, since the color is referenced, it should be deleted too
+  EXPECT_EQ(3u, thermalZone.remove().size()); // Zone + ZoneHVACEquipmentList + Color
+  EXPECT_EQ(0u, m.getModelObjects<ThermalZone>().size());
+  EXPECT_EQ(0u, m.getModelObjects<RenderingColor>().size());
+
+
+  // Clone
+  ThermalZone thermalZone2(m);
+  RenderingColor renderingColor2(m);
+  EXPECT_TRUE(thermalZone2.setRenderingColor(renderingColor2));
+
+  thermalZone2.clone(m);
+  EXPECT_EQ(2u, m.getModelObjects<ThermalZone>().size());
+  EXPECT_EQ(2u, m.getModelObjects<RenderingColor>().size());
+
+  EXPECT_EQ(3u, thermalZone2.remove().size()); // Zone + ZoneHVACEquipmentList + Color
+  EXPECT_EQ(1u, m.getModelObjects<ThermalZone>().size());
+  EXPECT_EQ(1u, m.getModelObjects<RenderingColor>().size());
 }
 


### PR DESCRIPTION
Fix #114 - orphaned colors

`RenderingColor` was a `ResourceObject` before.

Now it is a child, achieved by making it a `ModelObject` and having the Parent as a `ParentObject` (or one of its child classes).

Wrote Gtests too.

Review assignee: @macumber please
