### PR TITLE
Fix #2000 - Allow dropping BCL construction on Surface subtab

### DIFF
--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -1598,6 +1598,7 @@ namespace openstudio {
         return m_compLibrary.getModelObject<model::ModelObject>(handle);
       }
     }
+    // TODO: should we handle BCL objects here?
 
     return boost::none;
   }


### PR DESCRIPTION
Fix #2000 - Allow dropping BCL construction on Surface subtab

I implemented the fix in `OSDropZone2::dropEvent` where I check if it's a BCL thing and then load it appropriately, else continue to call `OSDocument::getModelObject `.

I'm not sure if this fix shouldn't be in `OSDocument::getModelObject` instead...

Review assignee: @macumber 
