### PR TITLE
Fix #2934 - Fix qt warnings in app

### DIFF
--- a/openstudiocore/src/openstudio_lib/EMSInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/EMSInspectorView.cpp
@@ -69,7 +69,7 @@ class EMSInspectorActuator : public QWidget {
 
   public:
 
-  EMSInspectorActuator(const model::EMSActuatorNames & names, const model::ModelObject & modelObject) : 
+  EMSInspectorActuator(const model::EMSActuatorNames & names, const model::ModelObject & modelObject) :
     QWidget(),
     m_names(names),
     m_modelObject(modelObject)
@@ -115,12 +115,12 @@ class EMSInspectorActuator : public QWidget {
       }
     } else {
       for( auto & actuator : actuators ) {
-        std::cout << "m_names.controlTypeName: " << m_names.controlTypeName() << std::endl;
-        std::cout << "m_names.componentTypeName: " << m_names.componentTypeName() << std::endl;
-        std::cout << "actuator.actuatedComponentControlType: " << actuator.actuatedComponentControlType() << std::endl;
-        std::cout << "actuator.actuatedComponentType: " << actuator.actuatedComponentType() << std::endl;
+        // std::cout << "m_names.controlTypeName: " << m_names.controlTypeName() << std::endl;
+        // std::cout << "m_names.componentTypeName: " << m_names.componentTypeName() << std::endl;
+        // std::cout << "actuator.actuatedComponentControlType: " << actuator.actuatedComponentControlType() << std::endl;
+        // std::cout << "actuator.actuatedComponentType: " << actuator.actuatedComponentType() << std::endl;
         if( m_isMatchingActuator(actuator) ) {
-          std::cout << "removing" << std::endl;
+          // std::cout << "removing" << std::endl;
           actuator.remove();
         }
       }
@@ -138,7 +138,7 @@ class EMSInspectorSensor : public QWidget {
 
   public:
 
-  EMSInspectorSensor(const std::string & name, const model::ModelObject & modelObject) : 
+  EMSInspectorSensor(const std::string & name, const model::ModelObject & modelObject) :
     QWidget(),
     m_name(name),
     m_modelObject(modelObject)
@@ -199,7 +199,7 @@ class EMSInspectorSensor : public QWidget {
   model::ModelObject m_modelObject;
 };
 
-EMSInspectorView::EMSInspectorView(QWidget* parent, EMSInspectorView::Type type) : 
+EMSInspectorView::EMSInspectorView(QWidget* parent, EMSInspectorView::Type type) :
   QWidget(parent),
   m_type(type)
 {

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -170,9 +170,12 @@ namespace openstudio {
 
     openstudio::path modelTempDir;
     if (!m_savePath.isEmpty()){
-      modelTempDir = model::initializeModel(*model, toPath(m_savePath));
+      auto p = toPath(m_savePath);
+      modelTempDir = model::initializeModel(*model, p);
+      m_mainWindow->setWindowTitle(toQString(p.filename()) + "[*]");
     } else{
       modelTempDir = model::initializeModel(*model);
+      m_mainWindow->setWindowTitle("Untitled[*]");
     }
     m_modelTempDir = toQString(modelTempDir);
 
@@ -1731,11 +1734,17 @@ namespace openstudio {
 
   void OSDocument::updateWindowFilePath()
   {
-    if (m_savePath.isEmpty()){
-      m_mainWindow->setWindowFilePath("Untitled");
+    if( m_savePath.isEmpty() ) {
+      // Because we use the setWindowModified, we need to set the WindowTitle with a "[*]" placeholder where the '*' should appear
+      // m_mainWindow->setWindowFilePath("Untitled");
+      m_mainWindow->setWindowTitle("Untitled[*]");
     }
     else{
+      // m_mainWindow->setWindowTitle();
       m_mainWindow->setWindowFilePath(m_savePath);
+      QFileInfo fi(m_savePath);
+      QString fileName = fi.fileName();
+      m_mainWindow->setWindowTitle(fileName +"[*]");
     }
   }
 

--- a/openstudiocore/src/openstudio_lib/SchedulesView.cpp
+++ b/openstudiocore/src/openstudio_lib/SchedulesView.cpp
@@ -1828,7 +1828,7 @@ ScheduleRuleView::ScheduleRuleView(bool isIP,
 
 void ScheduleRuleView::onRemoveClicked()
 {
-  std::cout << "ScheduleRuleView::onRemoveClicked: " << m_scheduleRule << std::endl;
+  // std::cout << "ScheduleRuleView::onRemoveClicked: " << m_scheduleRule << std::endl;
 
   //m_scheduleRule.remove();
   m_scheduleRule.getImpl<openstudio::model::detail::ScheduleRule_Impl>();

--- a/openstudiocore/src/openstudio_lib/VRFController.cpp
+++ b/openstudiocore/src/openstudio_lib/VRFController.cpp
@@ -167,7 +167,7 @@ void VRFController::onVRFSystemViewDrop(const OSItemId & itemid)
       if( auto terminal = component->primaryObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>() ) {
         // Ugly hack to avoid the component being treated as a resource.
         component->componentData().setString(OS_ComponentDataFields::UUID, toString(createUUID()));
-        std::cout << component->componentData().getString(OS_ComponentDataFields::UUID) << std::endl;;
+        // std::cout << component->componentData().getString(OS_ComponentDataFields::UUID) << std::endl;;
         if( auto componentData = m_currentSystem->model().insertComponent(component.get()) ) {
           terminal = componentData->primaryComponentObject().optionalCast<model::ZoneHVACTerminalUnitVariableRefrigerantFlow>();
           OS_ASSERT(terminal);

--- a/openstudiocore/src/shared_gui_components/OSGridView.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridView.cpp
@@ -88,6 +88,10 @@ OSGridView::OSGridView(OSGridController * gridController,
     m_CollapsibleView(nullptr),
     m_gridController(gridController)
 {
+  /** Set up buttons for Categories: eg: SpaceTypes tab: that's the dropzone "Drop Space Type", "General", "Loads", "Measure Tags", "Custom"
+   * QHBoxLayout manages the visual representation: they are placed side by side
+   * QButtonGroup manages the state of the buttons in the group. By default a QButtonGroup is exclusive (only one button can be checked at one time)
+   */
   auto buttonGroup = new QButtonGroup();
   connect(buttonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &OSGridView::selectCategory);
 
@@ -113,14 +117,22 @@ OSGridView::OSGridView(OSGridController * gridController,
     buttonGroup->addButton(button,buttonGroup->buttons().size());
   }
 
+  /** QVBoxLayout is the main gridview layout, it's where we'll place vertically the different elements:
+   * * buttonLayout at the top
+   * * Filter
+   * * Then the model-dependent data, such as Space Type Name, All, Rendering Color, Default Construction set, etc
+   */
   auto layout = new QVBoxLayout();
   layout->setSpacing(0);
   layout->setContentsMargins(0,0,0,0);
   setLayout(layout);
 
+  // Add the header first
   auto widget = new QWidget;
 
   if (useHeader) {
+    // If we use the header, we place a blue to dark blue header with for eg: 'Space Types' as text
+    // Its content is widget
     auto header = new DarkGradientHeader();
     header->label->setText(headerText);
     auto collabsibleView = new OSCollapsibleView(true);
@@ -129,19 +141,25 @@ OSGridView::OSGridView(OSGridController * gridController,
     collabsibleView->setExpanded(true);
     layout->addWidget(collabsibleView);
   } else {
+    // Otherwise we only place widget
     layout->addWidget(widget);
   }
-
-  m_contentLayout = new QVBoxLayout();
+  // Create a QLayout object with a parent of widget: This will set widget's layout to this QVBoxLayout already.
+  // widget has a layout that is a QVBoxLayout
+  m_contentLayout = new QVBoxLayout(widget);
   m_contentLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
   m_contentLayout->setSpacing(0);
   m_contentLayout->setContentsMargins(0,0,0,0);
-  widget->setLayout(m_contentLayout);
+  // widget->setLayout(m_contentLayout);
+  //
+  // We place the button Layout at the top
   m_contentLayout->addLayout(buttonLayout);
   widget->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Fixed);
 
+  // This should have been done in the Ctor
   setGridController(m_gridController);
 
+  // Make the first button checked by default
   std::vector<QAbstractButton *> buttons = buttonGroup->buttons().toVector().toStdVector();
   if(buttons.size() > 0){
     QPushButton * button = qobject_cast<QPushButton *>(buttons.at(0));

--- a/openstudiocore/src/shared_gui_components/OSGridView.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridView.cpp
@@ -173,7 +173,7 @@ void OSGridView::setGridController(OSGridController * gridController)
 
 void OSGridView::requestAddRow(int row)
 {
-  std::cout << "REQUEST ADDROW CALLED " << std::endl;
+  // std::cout << "REQUEST ADDROW CALLED " << std::endl;
   setEnabled(false);
 
   m_timer.start();
@@ -185,7 +185,7 @@ void OSGridView::requestAddRow(int row)
 
 void OSGridView::requestRemoveRow(int row)
 {
-  std::cout << "REQUEST REMOVEROW CALLED " << std::endl;
+  // std::cout << "REQUEST REMOVEROW CALLED " << std::endl;
   setEnabled(false);
 
   m_timer.start();
@@ -289,7 +289,7 @@ void OSGridView::deleteAll()
 
 void OSGridView::requestRefreshAll()
 {
-  std::cout << "REQUEST REFRESHALL CALLED " << std::endl;
+  // std::cout << "REQUEST REFRESHALL CALLED " << std::endl;
   setEnabled(false);
 
   m_timer.start();
@@ -299,7 +299,7 @@ void OSGridView::requestRefreshAll()
 
 void OSGridView::requestRefreshGrid()
 {
-  std::cout << "REQUEST REFRESHGRID CALLED " << std::endl;
+  // std::cout << "REQUEST REFRESHGRID CALLED " << std::endl;
   setEnabled(false);
 
   m_timer.start();
@@ -318,7 +318,7 @@ void OSGridView::requestRefreshGrid()
 
 void OSGridView::doRefresh()
 {
-  std::cout << " DO REFRESH CALLED " << m_queueRequests.size() << std::endl;
+  // std::cout << " DO REFRESH CALLED " << m_queueRequests.size() << std::endl;
 
   if (m_queueRequests.empty())
   {
@@ -364,7 +364,7 @@ void OSGridView::doRefresh()
 
 void OSGridView::refreshAll()
 {
-  std::cout << " REFRESHALL CALLED " << std::endl;
+  // std::cout << " REFRESHALL CALLED " << std::endl;
   m_queueRequests.clear();
   deleteAll();
 

--- a/openstudiocore/src/shared_gui_components/OSGridView.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridView.cpp
@@ -88,6 +88,10 @@ OSGridView::OSGridView(OSGridController * gridController,
     m_CollapsibleView(nullptr),
     m_gridController(gridController)
 {
+
+  // We use the headerText as the object name, will help in indentifying objects for any warnings
+  setObjectName(headerText);
+
   /** Set up buttons for Categories: eg: SpaceTypes tab: that's the dropzone "Drop Space Type", "General", "Loads", "Measure Tags", "Custom"
    * QHBoxLayout manages the visual representation: they are placed side by side
    * QButtonGroup manages the state of the buttons in the group. By default a QButtonGroup is exclusive (only one button can be checked at one time)

--- a/openstudiocore/src/shared_gui_components/OSViewSwitcher.cpp
+++ b/openstudiocore/src/shared_gui_components/OSViewSwitcher.cpp
@@ -42,6 +42,7 @@ OSViewSwitcher::OSViewSwitcher(QWidget * parent)
   : QWidget(parent),
     m_view(nullptr)
 {
+  // This is weird. A QWidget with a QVBoxLayout that has a QStackedWidget (which is a convenience Widget that exposes a QStackedLayout)
   auto layout = new QVBoxLayout();
   layout->setContentsMargins(0,0,0,0);
   setLayout(layout);
@@ -62,6 +63,7 @@ void OSViewSwitcher::setView(QWidget * view)
   if (!view) {
     //return;
   }
+  // If the QStackWidget already has a widget, we remove it
   if( QWidget * widget = m_stack->currentWidget() )
   {
     m_stack->removeWidget( widget );
@@ -71,8 +73,16 @@ void OSViewSwitcher::setView(QWidget * view)
   }
   OS_ASSERT(m_stack->count() == 0);
 
+  // Store the view
   m_view = view;
 
+  // TODO: this line triggers all of the warnings
+  // Warning: QLayout: Attempting to add QLayout "" to openstudio::OSGridView "", which already has a layout ((null):0, (null))
+  // qDebug() << m_view << "\n\n";
+  // When this happens: m_view => openstudio::SpaceTypesTabView(0x7560610, name="BlueGradientWidget"
+
+  // The QStackedWidget is empty before this function is called, so currentWidget() becomes the current widget.
+  // Ownership of widget is passed on to the QStackedWidget.
   m_stack->addWidget(m_view);
 }
 


### PR DESCRIPTION
Fix #2934 - Fix qt warnings in app

Removed all std::cout statements I could find, and fixed the Qt warning about no placeholder in window title (see Qt docs about [windowModified](https://doc.qt.io/qt-5/qwidget.html#windowModified-prop)).
There aren't any warnings in Release mode anymore.

 In Debug mode, there's this Qt warning that will keep poping up 16 times each time you switch to a tab that has an OSGridController in it:
```
Warning: QLayout: Attempting to add QLayout "" to openstudio::OSGridView "", which already has a layout ((null):0, (null))
```

I haven't been able to pinpoint the root cause of this one. Refer to #2934 for more info.

Review assignee: @macumber 
