### PR TITLE
Fix #1406 - Connect AirLoopHVAC components to PlantLoop like original + Implement PlantLoop::clone

### DIFF
--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -907,12 +907,12 @@ namespace detail {
     return result;
   }
 
-  Splitter AirLoopHVAC_Impl::demandSplitter()
+  Splitter AirLoopHVAC_Impl::demandSplitter() const
   {
     return this->zoneSplitter();
   }
 
-  Mixer AirLoopHVAC_Impl::demandMixer()
+  Mixer AirLoopHVAC_Impl::demandMixer() const
   {
     return this->zoneMixer();
   }

--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -757,6 +757,13 @@ namespace detail {
       } else {
         auto compClone = comp.clone(model).cast<HVACComponent>();
         compClone.addToNode(outletNodeClone);
+        // If the original component was also on a PlantLoop
+        if( boost::optional<HVACComponent> hvacComp = comp.optionalCast<HVACComponent>() ) {
+          if( boost::optional<PlantLoop> pl = hvacComp->plantLoop() ) {
+            // Connect the clone to the plantLoop too
+            pl->addDemandBranchForComponent(compClone);
+          }
+        }
       }
     }
 

--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -344,7 +344,7 @@ namespace detail {
                 return hvacComponent;
               }
             }
-               
+
           }
         }
       } else if ( ! upstreamComp->optionalCast<Splitter>() && ! upstreamComp->optionalCast<Mixer>() && ! upstreamComp->optionalCast<Node>() ) {
@@ -368,7 +368,7 @@ namespace detail {
 
     if( (optAirTerminal && _model != optAirTerminal->model()) ||
          _model != splitter.model() ||
-         _model != mixer.model() ) 
+         _model != mixer.model() )
     {
       return false;
     }
@@ -731,6 +731,9 @@ namespace detail {
     airLoopClone.setString(demandInletPortB(),"");
     airLoopClone.setString(demandOutletPort(),"");
 
+    // Sizing:System was already cloned because it is declared as a child
+    // And because it has the setParent method overriden, no need to do anything
+
     {
       auto clone = availabilitySchedule().clone(model).cast<Schedule>();
       airLoopClone.setPointer(OS_AirLoopHVACFields::AvailabilitySchedule,clone.handle());
@@ -740,12 +743,6 @@ namespace detail {
       AvailabilityManagerAssignmentList avmListClone = availabilityManagerAssignmentList().clone(model).cast<AvailabilityManagerAssignmentList>();
       avmListClone.setName(airLoopClone.name().get() + " AvailabilityManagerAssigmentList");
       airLoopClone.setPointer(OS_AirLoopHVACFields::AvailabilityManagerListName, avmListClone.handle());
-    }
-
-    {
-      auto sizing = sizingSystem();
-      auto sizingClone = sizing.clone(model).cast<SizingSystem>();
-      sizingClone.setAirLoopHVAC(airLoopClone);
     }
 
     airLoopClone.getImpl<detail::AirLoopHVAC_Impl>()->createTopology();
@@ -792,7 +789,7 @@ namespace detail {
         return (type ==  comp.iddObjectType());
       });
       if ( it != terms.end() ) {
-        uniqueterms.push_back(*it); 
+        uniqueterms.push_back(*it);
       }
     }
 
@@ -922,7 +919,7 @@ namespace detail {
     auto splitter = thisloop.zoneSplitter();
     auto mixer = thisloop.zoneMixer();
     auto result = addBranchForZoneImpl(thermalZone, thisloop, splitter, mixer, true, comp);
-    
+
     //if ( result ) {
     //  for ( auto & loop : loops ) {
     //    loop.removeBranchForZone(thermalZone);

--- a/openstudiocore/src/model/AirLoopHVAC.cpp
+++ b/openstudiocore/src/model/AirLoopHVAC.cpp
@@ -788,6 +788,8 @@ namespace detail {
       termtypes.push_back(comp.iddObjectType());
     });
 
+    // std::unique only works on sorted vectors, need to sort
+    std::sort(termtypes.begin(), termtypes.end());
     auto uniquetypes = std::vector<IddObjectType>(termtypes.begin(), std::unique(termtypes.begin(), termtypes.end()));
     std::vector<HVACComponent> uniqueterms;
 

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -142,9 +142,9 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
-  Splitter demandSplitter() override;
+  virtual Splitter demandSplitter() const override;
 
-  Mixer demandMixer() override;
+  virtual Mixer demandMixer() const override;
 
   boost::optional<HVACComponent> supplyFan() const;
 

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -134,6 +134,14 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   virtual std::vector<openstudio::IdfObject> remove() override;
 
+  /**
+   * This method will clone an AirLoopHVAC with the following rationale:
+   * - Handle all non-branch components from both the supply and the demand side
+   * - On the demand side branches, place one terminal of each IddObjectType that is present on the original AirLoopHVAC
+   * - Clone any SetpointManagers and add them to the correct location
+   * - If the supply component that is cloned is connected to a PlantLoop,
+   *   we try to the connect the clone to the same PlantLoop by adding a demand branch
+   */
   virtual ModelObject clone(Model model) const override;
 
   virtual const std::vector<std::string>& outputVariableNames() const override;

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -263,6 +263,14 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   std::vector<HVACComponent> terminals() const;
 
+  /**
+   * This method creates the basic, barebone, AirLoopHVAC topology:
+   * - Supply inlet & oulet nodes,
+   * - Demand inlet & outlet nodes,
+   * - Demand splitter & mixer,
+   * - A demand branch with a node
+   * - A Demand branch with a node (Branch Node)
+   */
   virtual void createTopology() override;
 
   virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;

--- a/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVAC_Impl.hpp
@@ -263,7 +263,7 @@ class MODEL_API AirLoopHVAC_Impl : public Loop_Impl {
 
   std::vector<HVACComponent> terminals() const;
 
-  void createTopology();
+  virtual void createTopology() override;
 
   virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;
 

--- a/openstudiocore/src/model/Loop_Impl.hpp
+++ b/openstudiocore/src/model/Loop_Impl.hpp
@@ -62,6 +62,8 @@ namespace detail {
 
     virtual ~Loop_Impl() {}
 
+    /** This pure virtual method is intended to be overriden by child classes (namely PlantLoop and AirLoopHVAC) to create the basic topology of the
+     * loop, that is to create the supply/demand inlet/outlet nodes, splitters and mixers as appropriate */
     virtual void createTopology() = 0;
 
     virtual Node supplyInletNode() const = 0;

--- a/openstudiocore/src/model/Loop_Impl.hpp
+++ b/openstudiocore/src/model/Loop_Impl.hpp
@@ -62,6 +62,8 @@ namespace detail {
 
     virtual ~Loop_Impl() {}
 
+    virtual void createTopology() = 0;
+
     virtual Node supplyInletNode() const = 0;
 
     virtual Node supplyOutletNode() const = 0;

--- a/openstudiocore/src/model/Loop_Impl.hpp
+++ b/openstudiocore/src/model/Loop_Impl.hpp
@@ -120,9 +120,9 @@ namespace detail {
 
     virtual ModelObject clone(Model model) const override;
 
-    virtual Splitter demandSplitter() = 0;
+    virtual Splitter demandSplitter() const = 0;
 
-    virtual Mixer demandMixer() = 0;
+    virtual Mixer demandMixer() const = 0;
 
     virtual void autosize();
 

--- a/openstudiocore/src/model/PlantLoop.cpp
+++ b/openstudiocore/src/model/PlantLoop.cpp
@@ -755,7 +755,7 @@ bool PlantLoop_Impl::setSupplySplitter(Splitter const & splitter)
   return result;
 }
 
-Mixer PlantLoop_Impl::demandMixer()
+Mixer PlantLoop_Impl::demandMixer() const
 {
   auto result = getObject<ModelObject>().getModelObjectTarget<Mixer>(OS_PlantLoopFields::DemandMixerName);
   if (result) return result.get();
@@ -769,7 +769,7 @@ bool PlantLoop_Impl::setDemandMixer(Mixer const & mixer)
   return result;
 }
 
-Splitter PlantLoop_Impl::demandSplitter()
+Splitter PlantLoop_Impl::demandSplitter() const
 {
   auto result = getObject<ModelObject>().getModelObjectTarget<Splitter>(OS_PlantLoopFields::DemandSplitterName);
   if (result) return result.get();

--- a/openstudiocore/src/model/PlantLoop.hpp
+++ b/openstudiocore/src/model/PlantLoop.hpp
@@ -337,11 +337,12 @@ class MODEL_API PlantLoop : public Loop {
   OS_DEPRECATED void resetAvailabilityManager();
   // END DEPRECATED
 
-  protected:
+ protected:
 
   friend class Model;
 
   friend class openstudio::IdfObject;
+  friend class openstudio::detail::IdfObject_Impl;
 
   /// @cond
 
@@ -349,7 +350,7 @@ class MODEL_API PlantLoop : public Loop {
 
   explicit PlantLoop(std::shared_ptr<ImplType> impl);
 
-  private:
+ private:
 
   unsigned supplyInletPort() const;
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -208,11 +208,11 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   bool setSupplySplitter(Splitter const & splitter);
 
-  Mixer demandMixer() override;
+  virtual Mixer demandMixer() const override;
 
   bool setDemandMixer(Mixer const & mixer);
 
-  Splitter demandSplitter() override;
+  virtual Splitter demandSplitter() const override;
 
   bool setDemandSplitter(Splitter const & splitter);
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -73,6 +73,15 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   virtual IddObjectType iddObjectType() const override;
 
+  /**
+   * This method creates the basic, barebone, PlantLoop topology:
+   * - Supply inlet & oulet nodes,
+   * - Supply splitter & mixer,
+   * - A Suply branch with a node (Connector Node)
+   * - Demand inlet & outlet nodes,
+   * - Demand splitter & mixer,
+   * - A Demand branch with a node (Branch Node)
+   */
   virtual void createTopology() override;
 
   std::string loadDistributionScheme();

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -73,7 +73,7 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   virtual IddObjectType iddObjectType() const override;
 
-
+  virtual void createTopology() override;
 
   std::string loadDistributionScheme();
 

--- a/openstudiocore/src/model/PlantLoop_Impl.hpp
+++ b/openstudiocore/src/model/PlantLoop_Impl.hpp
@@ -178,6 +178,14 @@ class MODEL_API PlantLoop_Impl : public Loop_Impl {
 
   virtual std::vector<openstudio::IdfObject> remove() override;
 
+  /**
+   * This method will clone a Plant Loop with the following rationale:
+   * - Handle all non-branch components from both the supply and the demand side
+   * - Handle branch components on the supply side (between supply splitter and mixer)
+   * - Clone any SetpointManagers and add them to the correct location
+   * - If the component that is cloned is connected to another PlantLoop, we try to connect the clone
+   *   to the same other PlantLoop (if comp is on the supply side, we add a demand branch to the other plantloop)
+   */
   virtual ModelObject clone(Model model) const override;
 
   unsigned supplyInletPort() const;

--- a/openstudiocore/src/model/SizingPlant.cpp
+++ b/openstudiocore/src/model/SizingPlant.cpp
@@ -75,6 +75,15 @@ namespace detail {
     return SizingPlant::iddObjectType();
   }
 
+  bool SizingPlant_Impl::setParent(ParentObject& newParent)
+  {
+    bool result = false;
+    if( boost::optional<PlantLoop> plantLoop = newParent.optionalCast<PlantLoop>()){
+      result = this->setPlantLoop(plantLoop.get());
+    }
+    return result;
+  }
+
   PlantLoop SizingPlant_Impl::plantLoop() const {
     boost::optional<PlantLoop> value = optionalPlantLoop();
     if (!value) {

--- a/openstudiocore/src/model/SizingPlant_Impl.hpp
+++ b/openstudiocore/src/model/SizingPlant_Impl.hpp
@@ -45,20 +45,6 @@ namespace detail {
   /** SizingPlant_Impl is a ModelObject_Impl that is the implementation class for SizingPlant.*/
   class MODEL_API SizingPlant_Impl : public ModelObject_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     public:
 
     SizingPlant_Impl(const IdfObject& idfObject,
@@ -78,6 +64,8 @@ namespace detail {
     virtual const std::vector<std::string>& outputVariableNames() const override;
 
     virtual IddObjectType iddObjectType() const override;
+
+    virtual bool setParent(ParentObject& newParent) override;
 
     PlantLoop plantLoop() const;
 

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -80,6 +80,15 @@ IddObjectType SizingSystem_Impl::iddObjectType() const {
   return SizingSystem::iddObjectType();
 }
 
+bool SizingSystem_Impl::setParent(ParentObject& newParent)
+{
+  bool result = false;
+  if( boost::optional<AirLoopHVAC> airLoopHVAC = newParent.optionalCast<AirLoopHVAC>()){
+    result = this->setAirLoopHVAC(airLoopHVAC.get());
+  }
+  return result;
+}
+
 std::string SizingSystem_Impl::typeofLoadtoSizeOn() const {
   boost::optional<std::string> value = getString(OS_Sizing_SystemFields::TypeofLoadtoSizeOn,true);
   OS_ASSERT(value);

--- a/openstudiocore/src/model/SizingSystem_Impl.hpp
+++ b/openstudiocore/src/model/SizingSystem_Impl.hpp
@@ -63,6 +63,9 @@ class MODEL_API SizingSystem_Impl : public ModelObject_Impl
 
   virtual IddObjectType iddObjectType() const override;
 
+  virtual bool setParent(ParentObject& newParent) override;
+
+
   std::string typeofLoadtoSizeOn() const;
 
   bool isTypeofLoadtoSizeOnDefaulted() const;


### PR DESCRIPTION
Fix #1406 

Changelog:
* Connect AirLoopHVAC components to PlantLoop like original 
* Implemented `PlantLoop::clone` as well.

Side Notes:
* I made Loop_Impl::demandMixer and demandSplitter const
* I made Impl `createTopology` (function was already defined in AirLoopHVAC) a pure virtual method of `Loop_Impl` and override in both `AirLoopHVAC_Impl` and `PlantLoop_Impl`

Review assignee: @kbenne 