### PR TITLE
Fix #749 - Warn when mismatched "Part of Total Floor Area" flags in zone

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -204,7 +204,8 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
   }
 
   // Spaces
-
+  // Note, when you reach this point of the forward translator thermalZone.combineSpaces() has already been called,
+  // This happens in ForwardTranslator::translateModelPrivate. As a result, each zone has 0 or 1 space only
   std::vector<Space> spaces = modelObject.spaces();
   if (spaces.empty()){
     LOG(Warn, "ThermalZone " << modelObject.name().get() << " does not have any geometry or loads associated with it.");
@@ -225,30 +226,6 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
 
     if (!spaces[0].isZOriginDefaulted()){
       idfObject.setDouble(openstudio::ZoneFields::ZOrigin, spaces[0].zOrigin());
-    }
-
-    bool has_yes_flag = false;
-    bool has_no_flag = false;
-    for( const Space& s: spaces ) {
-      if( ! s.isPartofTotalFloorAreaDefaulted() ) {
-        if( s.partofTotalFloorArea() ) {
-          has_yes_flag = true;
-        } else {
-          has_no_flag = true;
-        }
-      }
-    }
-    if( has_yes_flag && has_no_flag ) {
-      LOG(Warn, "ThermalZone " << modelObject.name().get() << " has spaces with mis-matched 'Part of Total Floor Area' flags, will default to 'Yes'");
-      idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"Yes");
-    } else if( has_yes_flag ) {
-      // Only yes
-      idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"Yes");
-    } else if( has_no_flag ) {
-      // Only no
-      idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"No");
-    } else {
-      // There aren't any that aren't defaulted, we do nothing (leave field empty)
     }
 
     // translate the space now

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -228,6 +228,14 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
       idfObject.setDouble(openstudio::ZoneFields::ZOrigin, spaces[0].zOrigin());
     }
 
+    if (!spaces[0].isPartofTotalFloorAreaDefaulted()){
+      if (spaces[0].partofTotalFloorArea()){
+        idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"Yes");
+      }else{
+        idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"No");
+      }
+    }
+
     // translate the space now
     translateAndMapModelObject(spaces[0]);
 

--- a/openstudiocore/src/model/ThermalZone.cpp
+++ b/openstudiocore/src/model/ThermalZone.cpp
@@ -1578,7 +1578,12 @@ namespace detail {
 
       // don't override if user provided zone floor area
       if (isEmpty(OS_ThermalZoneFields::FloorArea)){
+        LOG(Info, "ThermalZone " << this->name().get() << " has spaces with mis-matched 'Part of Total Floor Area' flags."
+               << "Setting set the flag to 'Yes', but hard-coding the total floor area to only take into account the spaces"
+               << "that are part of total Floor Area");
         this->setDouble(OS_ThermalZoneFields::FloorArea, totalFloorArea);
+      } else {
+        LOG(Info, "ThermalZone " << this->name().get() << " has a user-specified Floor Area, using this number");
       }
     }
 

--- a/openstudiocore/src/model/ThermalZone.cpp
+++ b/openstudiocore/src/model/ThermalZone.cpp
@@ -1578,8 +1578,8 @@ namespace detail {
 
       // don't override if user provided zone floor area
       if (isEmpty(OS_ThermalZoneFields::FloorArea)){
-        LOG(Info, "ThermalZone " << this->name().get() << " has spaces with mis-matched 'Part of Total Floor Area' flags."
-               << "Setting set the flag to 'Yes', but hard-coding the total floor area to only take into account the spaces"
+        LOG(Info, "ThermalZone '" << this->name().get() << "' has spaces with mis-matched 'Part of Total Floor Area' flags. "
+               << "Setting set the flag to 'Yes', but hard-coding the total floor area to only take into account the spaces "
                << "that are part of total Floor Area");
         this->setDouble(OS_ThermalZoneFields::FloorArea, totalFloorArea);
       } else {


### PR DESCRIPTION
Fix #749 - Warn when mismatched "Part of Total Floor Area" flags in zone

I initially put code in ForwardTranslateThermalZone.cpp, then I remembered that prior to getting there, thermalZone.combineSpaces() is called first, so the zone has zero or one space only. So I moved the message into that method, and made it an Info rather than a Warning since it's doing the right thing (see my comment https://github.com/NREL/OpenStudio/issues/749#issuecomment-416897214 for more info)


Review assignee: @macumber 
