### PR TITLE
Fix #3249 - path problems

### DIFF
--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -338,8 +338,7 @@ QString longPathName(const QString& path)
       }
 
       // Copy all files from existing resources dir into temp dir when opening
-      // osmPath.stem() removes the file extension
-      openstudio::path sourceDir = osmPath.parent_path() / osmPath.stem();
+      openstudio::path sourceDir = getCompanionFolder(osmPath);
       openstudio::path destDir = modelTempDir / toPath("resources");
       if (openstudio::filesystem::exists(sourceDir)){
         LOG_FREE(Debug, "initializeModelTempDir", "Copying '" << toString(sourceDir) << "' to '" << toString(destDir) << "'");
@@ -505,8 +504,8 @@ QString longPathName(const QString& path)
 
       // copy resources
       openstudio::path srcDir = modelTempDir / toPath("resources");
-      // Creates the companion directory
-      openstudio::path dstDir = osmPath.parent_path() / osmPath.stem();
+      // Get the companion directory
+      openstudio::path dstDir = getCompanionFolder(osmPath);
 
       LOG_FREE(Debug, "saveModelTempDir", "Copying " << toString(srcDir) << " to " << toString(dstDir));
 

--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -338,6 +338,7 @@ QString longPathName(const QString& path)
       }
 
       // Copy all files from existing resources dir into temp dir when opening
+      // osmPath.stem() removes the file extension
       openstudio::path sourceDir = osmPath.parent_path() / osmPath.stem();
       openstudio::path destDir = modelTempDir / toPath("resources");
       if (openstudio::filesystem::exists(sourceDir)){
@@ -504,6 +505,7 @@ QString longPathName(const QString& path)
 
       // copy resources
       openstudio::path srcDir = modelTempDir / toPath("resources");
+      // Creates the companion directory
       openstudio::path dstDir = osmPath.parent_path() / osmPath.stem();
 
       LOG_FREE(Debug, "saveModelTempDir", "Copying " << toString(srcDir) << " to " << toString(dstDir));

--- a/openstudiocore/src/model/Model.cpp
+++ b/openstudiocore/src/model/Model.cpp
@@ -1134,6 +1134,7 @@ boost::optional<Model> Model::load(const path& p) {
   }
 
   if (result){
+    // Load the workflow.osw in the model's companion folder
     path workflowJSONPath = p.parent_path() / p.stem() / toPath("workflow.osw");
     if (exists(workflowJSONPath)){
       boost::optional<WorkflowJSON> workflowJSON = WorkflowJSON::load(workflowJSONPath);
@@ -2563,7 +2564,7 @@ void Model::applySizingValues() {
 
 std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> detail::Model_Impl::ModelObjectCreator::getNew(
   Model_Impl * model,
-  const IdfObject& obj, 
+  const IdfObject& obj,
   bool keepHandle) const
 {
   auto typeToCreate = obj.iddObject().type();
@@ -2576,7 +2577,7 @@ std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> detail::Model_Impl::Mo
 }
 
 std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> detail::Model_Impl::ModelObjectCreator::getCopy(
-  Model_Impl * model, 
+  Model_Impl * model,
   const std::shared_ptr<openstudio::detail::WorkspaceObject_Impl>& obj,
   bool keepHandle) const
 {

--- a/openstudiocore/src/model/Model.cpp
+++ b/openstudiocore/src/model/Model.cpp
@@ -1123,9 +1123,9 @@ Model::Model(const openstudio::Workspace& workspace)
   getImpl<detail::Model_Impl>()->createComponentWatchers();
 }
 
-boost::optional<Model> Model::load(const path& p) {
+boost::optional<Model> Model::load(const path& osmPath) {
   OptionalModel result;
-  OptionalIdfFile oIdfFile = IdfFile::load(p,IddFileType::OpenStudio);
+  OptionalIdfFile oIdfFile = IdfFile::load(osmPath,IddFileType::OpenStudio);
   if (oIdfFile) {
     try {
       result = Model(*oIdfFile);
@@ -1135,7 +1135,7 @@ boost::optional<Model> Model::load(const path& p) {
 
   if (result){
     // Load the workflow.osw in the model's companion folder
-    path workflowJSONPath = p.parent_path() / p.stem() / toPath("workflow.osw");
+    path workflowJSONPath = getCompanionFolder(osmPath) / toPath("workflow.osw");
     if (exists(workflowJSONPath)){
       boost::optional<WorkflowJSON> workflowJSON = WorkflowJSON::load(workflowJSONPath);
       if (workflowJSON){

--- a/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
@@ -314,7 +314,8 @@ void ApplyMeasureNowDialog::displayMeasure()
     m_tempWorkflowJSON.resetMeasurePaths();
     m_tempWorkflowJSON.addMeasurePath(m_bclMeasure->directory().parent_path());
 
-    MeasureStep step(toString(m_bclMeasure->directory().stem()));
+    // We already have a directory, so we take filename() to return the name of the last level directory
+    MeasureStep step(toString(m_bclMeasure->directory().filename()));
     std::vector<WorkflowStep> steps;
     steps.push_back(step);
     m_tempWorkflowJSON.setWorkflowSteps(steps);

--- a/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
@@ -314,8 +314,9 @@ void ApplyMeasureNowDialog::displayMeasure()
     m_tempWorkflowJSON.resetMeasurePaths();
     m_tempWorkflowJSON.addMeasurePath(m_bclMeasure->directory().parent_path());
 
-    // We already have a directory, so we take filename() to return the name of the last level directory
-    MeasureStep step(toString(m_bclMeasure->directory().filename()));
+    // Since we set the measure_paths, we only neeed to reference the name of the directory (=last level directory name)
+    // eg: /path/to/measure_folder => measure_folder
+    MeasureStep step(toString( getLastLevelDirectoryName( m_bclMeasure->directory() ) ));
     std::vector<WorkflowStep> steps;
     steps.push_back(step);
     m_tempWorkflowJSON.setWorkflowSteps(steps);

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -992,22 +992,7 @@ namespace openstudio {
       // relative weather file path
       epwPathAbsolute = false;
 
-      if (!m_savePath.isEmpty()){
-        openstudio::path osmPath = toPath(m_savePath);
-        openstudio::path searchResourcesDir = osmPath.parent_path() / osmPath.stem();
-        openstudio::path searchFilesDir = osmPath.parent_path() / toPath("files") / osmPath.stem();
-
-        epwInUserPath = searchResourcesDir / *weatherFilePath;
-        if (boost::filesystem::exists(epwInUserPath)){
-          epwInUserPathChecksum = checksum(epwInUserPath);
-        } else{
-          epwInUserPath = searchFilesDir / *weatherFilePath;
-          if (boost::filesystem::exists(epwInUserPath)){
-            epwInUserPathChecksum = checksum(epwInUserPath);
-          }
-        }
-      }
-
+      // Look in temp model "resources" and "resources/files"
       epwInTempPath = tempResourcesDir / *weatherFilePath;
       if (boost::filesystem::exists(epwInTempPath)){
         epwInTempPathChecksum = checksum(epwInTempPath);
@@ -1015,6 +1000,28 @@ namespace openstudio {
         epwInTempPath = tempFilesDir / *weatherFilePath;
         if (boost::filesystem::exists(epwInTempPath)){
           epwInTempPathChecksum = checksum(epwInTempPath);
+        }
+      }
+
+      if (!m_savePath.isEmpty()){
+        // We look where the actual model is saved on disk (non temp folder)
+        // eg: /path/to/model.osm
+        openstudio::path osmPath = toPath(m_savePath);
+        // eg: /path/to/model/
+        openstudio::path searchCompanionDir = getCompanionFolder(osmPath);
+        // eg: /path/to/model/files/
+        openstudio::path searchFilesDir = searchCompanionDir / toPath("files");
+
+        // Expected location is companion_folder/files
+        epwInUserPath = searchFilesDir / *weatherFilePath;
+        if (boost::filesystem::exists(epwInUserPath)){
+          epwInUserPathChecksum = checksum(epwInUserPath);
+        } else{
+          // Just in case, we look in the companion_folder
+          epwInUserPath = searchCompanionDir / *weatherFilePath;
+          if (boost::filesystem::exists(epwInUserPath)){
+            epwInUserPathChecksum = checksum(epwInUserPath);
+          }
         }
       }
 

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
@@ -45,6 +45,7 @@
 #include <QWebEnginePage>
 #include <QWebEngineSettings>
 #include "../utilities/core/Assert.hpp"
+#include "../utilities/core/PathHelpers.hpp"
 
 namespace openstudio {
 
@@ -59,8 +60,9 @@ ResultsTabView::ResultsTabView(const QString & tabLabel,
 
   auto savePath = OSAppBase::instance()->currentDocument()->savePath();
   if( ! savePath.isEmpty() ) {
-    openstudio::path runPath = toPath(savePath).parent_path() / toPath(savePath).stem() / openstudio::toPath("run");
-    openstudio::path reportsPath = toPath(savePath).parent_path() / toPath(savePath).stem() / openstudio::toPath("reports");
+    openstudio::path companionFolder = getCompanionFolder( toPath(savePath) );
+    openstudio::path runPath = companionFolder / toPath("run");
+    openstudio::path reportsPath = companionFolder / toPath("reports");
     m_resultsView->searchForExistingResults(runPath, reportsPath);
   }
 }

--- a/openstudiocore/src/openstudio_lib/RunTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/RunTabView.cpp
@@ -54,6 +54,7 @@
 
 #include "../utilities/core/Application.hpp"
 #include "../utilities/core/ApplicationPathHelpers.hpp"
+#include "../utilities/core/PathHelpers.hpp"
 #include "../utilities/sql/SqlFile.hpp"
 #include "../utilities/core/Assert.hpp"
 
@@ -173,7 +174,7 @@ RunView::RunView()
 void RunView::onOpenSimDirClicked()
 {
   std::shared_ptr<OSDocument> osdocument = OSAppBase::instance()->currentDocument();
-  QString url = QString::fromStdString((resourcePath(toPath(osdocument->savePath())) / "run").string());
+  QString url = QString::fromStdString(( getCompanionFolder( toPath(osdocument->savePath()) ) / toPath("run") ).string());
   QUrl qurl = QUrl::fromLocalFile(url);
   if( ! QDesktopServices::openUrl(qurl) ) {
     QMessageBox::critical(this, "Unable to open simulation", "Please save the OpenStudio Model to view the simulation.");
@@ -196,14 +197,6 @@ void RunView::onRunProcessFinished(int exitCode, QProcess::ExitStatus status)
     delete m_runSocket;
   }
   m_runSocket = nullptr;
-}
-
-openstudio::path RunView::resourcePath(const openstudio::path & osmPath) const
-{
-  auto baseName = osmPath.stem();
-  auto parentPath = osmPath.parent_path();
-  auto resourcePath = parentPath / baseName;
-  return resourcePath;
 }
 
 void RunView::playButtonClicked(bool t_checked)
@@ -230,7 +223,7 @@ void RunView::playButtonClicked(bool t_checked)
     auto openstudioExePath = QStandardPaths::findExecutable("openstudio", paths);
 
     // run in save dir
-    //auto basePath = resourcePath(toPath(osdocument->savePath()));
+    //auto basePath = getCompanionFolder( toPath(osdocument->savePath()) );
 
     // run in temp dir
     auto basePath = toPath(osdocument->modelTempDir()) / toPath("resources");

--- a/openstudiocore/src/openstudio_lib/RunTabView.hpp
+++ b/openstudiocore/src/openstudio_lib/RunTabView.hpp
@@ -83,9 +83,6 @@ namespace openstudio {
 
     void onRunDataReady();
 
-    // Given an osm file, return the companion directory
-    path resourcePath(const path & osmPath) const;
-
     QToolButton * m_playButton;
     QProgressBar * m_progressBar;
     QLabel * m_statusLabel;

--- a/openstudiocore/src/shared_gui_components/MeasureManager.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureManager.cpp
@@ -340,7 +340,8 @@ std::pair<bool,std::string> MeasureManager::updateMeasure(const BCLMeasure &t_me
     boost::optional<BCLMeasure> measure = workflowJSON.addMeasure(t_measure);
 
     if (measure){
-      result = std::pair<bool, std::string>(true, toString(measure->directory().stem()));
+      // We already have a directory, so we take filename() to return the name of the last level directory
+      result = std::pair<bool, std::string>(true, toString(measure->directory().filename()));
     } else{
       std::stringstream ss;
       ss << "An error occurred while adding measure '" << t_measure.displayName() << "' to the project.";

--- a/openstudiocore/src/shared_gui_components/MeasureManager.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureManager.cpp
@@ -340,8 +340,9 @@ std::pair<bool,std::string> MeasureManager::updateMeasure(const BCLMeasure &t_me
     boost::optional<BCLMeasure> measure = workflowJSON.addMeasure(t_measure);
 
     if (measure){
-      // We already have a directory, so we take filename() to return the name of the last level directory
-      result = std::pair<bool, std::string>(true, toString(measure->directory().filename()));
+      // Since we set the measure_paths, we only neeed to reference the name of the directory (=last level directory name)
+      // eg: /path/to/measure_folder => measure_folder
+      result = std::pair<bool, std::string>(true, toString( getLastLevelDirectoryName( measure->directory() ) ));
     } else{
       std::stringstream ss;
       ss << "An error occurred while adding measure '" << t_measure.displayName() << "' to the project.";

--- a/openstudiocore/src/shared_gui_components/WorkflowController.cpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.cpp
@@ -44,6 +44,7 @@
 #include "../utilities/core/Compare.hpp"
 #include "../utilities/core/Containers.hpp"
 #include "../utilities/core/RubyException.hpp"
+#include "../utilities/core/PathHelpers.hpp"
 #include "../utilities/bcl/BCLMeasure.hpp"
 #include "../utilities/filetypes/WorkflowStep_Impl.hpp"
 #include "../utilities/plot/ProgressBar.hpp"
@@ -281,9 +282,9 @@ void MeasureStepController::addItemForDroppedMeasure(QDropEvent *event)
     return;
   }
 
-  // Note: JM 2018-09-04: Here we know we already have a directory, so taking filename() will return the name of the last level directory
-  // stem() would do weird things if the folder name had a "." in it
-  MeasureStep measureStep(toString(projectMeasure->directory().filename()));
+  // Since we set the measure_paths, we only neeed to reference the name of the directory (=last level directory name)
+  // eg: /path/to/measure_folder => measure_folder
+  MeasureStep measureStep(toString( getLastLevelDirectoryName( projectMeasure->directory() ) ));
   try{
     std::vector<measure::OSArgument> arguments = m_app->measureManager().getArguments(*projectMeasure);
   } catch ( const RubyException&e ) {

--- a/openstudiocore/src/shared_gui_components/WorkflowController.cpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.cpp
@@ -281,7 +281,9 @@ void MeasureStepController::addItemForDroppedMeasure(QDropEvent *event)
     return;
   }
 
-  MeasureStep measureStep(toString(projectMeasure->directory().stem()));
+  // Note: JM 2018-09-04: Here we know we already have a directory, so taking filename() will return the name of the last level directory
+  // stem() would do weird things if the folder name had a "." in it
+  MeasureStep measureStep(toString(projectMeasure->directory().filename()));
   try{
     std::vector<measure::OSArgument> arguments = m_app->measureManager().getArguments(*projectMeasure);
   } catch ( const RubyException&e ) {

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -255,6 +255,28 @@ path relocatePath(const path& originalPath,
   return result;
 }
 
+path getCompanionFolder(const path& osmPath)
+{
+  // Note: JM 2018-09-05
+  // We could include a variety of checks (verify that we passed a file, that the file exists, that extension is osm)
+  // if( boost::filesystem::is_regular_file(osmPath) && (getFileExtension(osmPath) == "osm") && boost::filesystem::exists(osmPath) )
+  // Not doing it for speed, we assume we do only use this with the path to an OSM, so stem() will do the right thing, that is split on the last "."
+  return osmPath.parent_path() / osmPath.stem();
+}
+
+path getLastLevelDirectoryName(const path& directory)
+{
+  // Note: JM 2018-09-05
+  // We could do a variety of checks here to ensure that we did pass a directory and not a file, not doing it for speed
+  // (boost::filesystem::is_directory and boost::filesystem::exists)
+
+  // We are using filename() (badly named here) and not stem() because we passed a directory, and if there is a "." in the directory name
+  // stem() is going to think the part after the last '.' is the extension.
+  // filename() just strips out the parent_path which is exactly what we need
+  return directory.filename();
+
+}
+
 std::ostream& printPathInformation(std::ostream& os,const path& p) {
   os << "p.string() = " << toString(p.string()) << std::endl;
   os << "p.native() = " << toString(p.native()) << std::endl;

--- a/openstudiocore/src/utilities/core/PathHelpers.hpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.hpp
@@ -91,6 +91,10 @@ UTILITIES_API path relocatePath(const path& originalPath,
  * eg if /path/to/model.osm, returns the folder /path/to/model/ */
 UTILITIES_API path getCompanionFolder(const path& osmPath);
 
+/* Given the path to a **directory**, return the name of the last level directory
+ * eg if /path/to/folder, returns 'folder' */
+UTILITIES_API path getLastLevelDirectoryName(const path& directory);
+
 /** Print information about path p available through openstudio::filesystem. */
 UTILITIES_API std::ostream& printPathInformation(std::ostream& os,const path& p);
 

--- a/openstudiocore/src/utilities/core/PathHelpers.hpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.hpp
@@ -87,6 +87,10 @@ UTILITIES_API path relocatePath(const path& originalPath,
                                 const path& originalBase,
                                 const path& newBase);
 
+/* Given the path to an OSM file, get the companion folder in which files, measures, etc, are stored
+ * eg if /path/to/model.osm, returns the folder /path/to/model/ */
+UTILITIES_API path getCompanionFolder(const path& osmPath);
+
 /** Print information about path p available through openstudio::filesystem. */
 UTILITIES_API std::ostream& printPathInformation(std::ostream& os,const path& p);
 

--- a/openstudiocore/src/utilities/core/test/Path_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/Path_GTest.cpp
@@ -476,7 +476,7 @@ TEST_F(CoreFixture, Path_Conversions)
 
 TEST_F(CoreFixture, LastLevelDirectoryWithDot) {
   // We want to make sure that we don't end up with "A measure with 90" (test for #3249)
-  openstudio::path measure_directory = openstudio::toPath("C:/users/user name/OpenStudio/Measures/A measure with 90.1 dots/");
+  openstudio::path measure_directory = openstudio::toPath("C:/users/user name/OpenStudio/Measures/A measure with 90.1 dots");
   openstudio::path lastLevelDir = openstudio::getLastLevelDirectoryName(measure_directory);
   EXPECT_EQ("A measure with 90.1 dots", toString(lastLevelDir));
   EXPECT_EQ(measure_directory, measure_directory.parent_path() / lastLevelDir);

--- a/openstudiocore/src/utilities/core/test/Path_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/Path_GTest.cpp
@@ -473,3 +473,11 @@ TEST_F(CoreFixture, Path_Conversions)
   EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
 
 }
+
+TEST_F(CoreFixture, LastLevelDirectoryWithDot) {
+  // We want to make sure that we don't end up with "A measure with 90" (test for #3249)
+  openstudio::path measure_directory = openstudio::toPath("C:/users/user name/OpenStudio/Measures/A measure with 90.1 dots/");
+  openstudio::path lastLevelDir = openstudio::getLastLevelDirectoryName(measure_directory);
+  EXPECT_EQ("A measure with 90.1 dots", toString(lastLevelDir));
+  EXPECT_EQ(measure_directory, measure_directory.parent_path() / lastLevelDir);
+}

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -752,26 +752,27 @@ namespace detail{
     std::vector<openstudio::path> paths = absoluteMeasurePaths();
     OS_ASSERT(!paths.empty());
 
-    openstudio::path stem = bclMeasure.directory().stem();
-    if (!toUUID(toString(stem)).isNull()){
+    // We already have a directory, so we take filename() to return the name of the last level directory
+    openstudio::path lastLevelDirectoryName = bclMeasure.directory().filename();
+    if (!toUUID(toString(lastLevelDirectoryName)).isNull()){
       // directory name is convertible to uuid, use the class name
-      stem = toPath(bclMeasure.className());
+      lastLevelDirectoryName = toPath(bclMeasure.className());
     }
 
     int i = 1;
-    while (boost::filesystem::exists(paths[0] / stem)){
+    while (boost::filesystem::exists(paths[0] / lastLevelDirectoryName)){
       std::stringstream ss;
-      ss << toString(stem) << " " << i;
-      stem = toPath(ss.str());
+      ss << toString(lastLevelDirectoryName) << " " << i;
+      lastLevelDirectoryName = toPath(ss.str());
     }
-    openstudio::path newMeasureDirName = paths[0] / stem;
+    openstudio::path newMeasureDirName = paths[0] / lastLevelDirectoryName;
 
-    if (existingMeasureDirName && (existingMeasureDirName->stem() != newMeasureDirName.stem())){
+    if (existingMeasureDirName && (existingMeasureDirName->filename() != newMeasureDirName.filename())){
       // update steps
       for (auto& step : m_steps){
         if (auto measureStep = step.optionalCast<MeasureStep>()){
-          if (measureStep->measureDirName() == toString(existingMeasureDirName->stem())){
-            measureStep->setMeasureDirName(toString(newMeasureDirName.stem()));
+          if (measureStep->measureDirName() == toString(existingMeasureDirName->filename())){
+            measureStep->setMeasureDirName(toString(newMeasureDirName.filename()));
           }
         }
       }

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -752,8 +752,8 @@ namespace detail{
     std::vector<openstudio::path> paths = absoluteMeasurePaths();
     OS_ASSERT(!paths.empty());
 
-    // We already have a directory, so we take filename() to return the name of the last level directory
-    openstudio::path lastLevelDirectoryName = bclMeasure.directory().filename();
+    // Get the name of the directory (=last level directory name), eg: /path/to/measure_folder => measure_folder
+    openstudio::path lastLevelDirectoryName = getLastLevelDirectoryName( bclMeasure.directory() );
     if (!toUUID(toString(lastLevelDirectoryName)).isNull()){
       // directory name is convertible to uuid, use the class name
       lastLevelDirectoryName = toPath(bclMeasure.className());
@@ -767,12 +767,17 @@ namespace detail{
     }
     openstudio::path newMeasureDirName = paths[0] / lastLevelDirectoryName;
 
-    if (existingMeasureDirName && (existingMeasureDirName->filename() != newMeasureDirName.filename())){
-      // update steps
-      for (auto& step : m_steps){
-        if (auto measureStep = step.optionalCast<MeasureStep>()){
-          if (measureStep->measureDirName() == toString(existingMeasureDirName->filename())){
-            measureStep->setMeasureDirName(toString(newMeasureDirName.filename()));
+    // If we have an existing measure
+    if( existingMeasureDirName) {
+      openstudio::path lastLevelExistingDirectoryName = getLastLevelDirectoryName(*existingMeasureDirName);
+      // And the previous directory name isn't the same as the new one
+      if( lastLevelExistingDirectoryName != lastLevelDirectoryName ) {
+        // update steps
+        for (auto& step : m_steps){
+          if (auto measureStep = step.optionalCast<MeasureStep>()){
+            if (measureStep->measureDirName() == toString(lastLevelExistingDirectoryName) ) {
+              measureStep->setMeasureDirName(toString(lastLevelDirectoryName));
+            }
           }
         }
       }


### PR DESCRIPTION
Fix #3249 - path problems

More info on the issue.

Changelog:
* Do not use `.stem()` when trying to get the last level directory name because it won't work properly if you have a `.` in there, instead use `.filename()`
* Created two functions in PathHelpers for clarity (and easier to change later if need be / add checks): `getCompanionFolder(path& osmPath)` and `getLastLevelDirectoryName(path& directory)`
   * Note that we could include some tests in there, but I didn't because of speed (we assume we know when we pass an OSM file or a directory to the appropriate functions)
* Made various locations where file stuff is happening use these two functions

Warning: Please pay close attention to 8c6b8ed95a366fc7ca654f2bdb2891348b01fafc where I think I caught a problem and fixed it, thanks!

Review assignee: @macumber 