### PR TITLE
Fix #1877 non functional link subtab for HVACComponents

### DIFF
--- a/openstudiocore/src/openstudio_lib/InspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/InspectorView.cpp
@@ -1503,9 +1503,8 @@ void AirTerminalInspectorView::layoutModelObject( model::ModelObject & modelObje
 
   if( ! waterCoil )
   {
-    boost::optional<model::ModelObject> mo;
-
-    m_loopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_loopChooserView, true);
   }
 }
 
@@ -1613,19 +1612,15 @@ void AirTerminalSingleDuctConstantVolumeCooledBeamInspectorView::layoutModelObje
     if( boost::optional<model::HVACComponent> coil = terminal->coilCoolingCooledBeam() )
     {
         boost::optional<model::ModelObject> mo = coil.get();
-
         m_coolingLoopChooserView->layoutModelObject(mo);
-
         coolCoil = true;
-
     }
   }
 
   if( !coolCoil )
   {
-    boost::optional<model::ModelObject> mo;
-
-    m_coolingLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 }
 
@@ -1678,7 +1673,7 @@ void ZoneHVACBaseboardConvectiveWaterInspectorView::layoutModelObject( model::Mo
         modelObject.optionalCast<model::ZoneHVACBaseboardConvectiveWater>();
 
   if(baseboardConvtest){
-    //if it is, check if it has a heating coil
+    // if it is, check if has a heating coil (but we need to pass as an optional)
     boost::optional<model::ModelObject> coilheatingbb = baseboardConvtest->heatingCoil();
     m_heatingLoopChooserView->layoutModelObject(coilheatingbb);
     waterHeatingCoil = true;
@@ -1686,9 +1681,8 @@ void ZoneHVACBaseboardConvectiveWaterInspectorView::layoutModelObject( model::Mo
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
 }
 
@@ -1741,7 +1735,7 @@ void ZoneHVACBaseboardRadiantConvectiveWaterInspectorView::layoutModelObject( mo
         modelObject.optionalCast<model::ZoneHVACBaseboardRadiantConvectiveWater>();
 
   if(baseboardConvtest){
-    //if it is, check if it has a heating coil
+    // if it is, check if has a heating coil (but optional needed)
     boost::optional<model::ModelObject> coilheatingbb = baseboardConvtest->heatingCoil();
     m_heatingLoopChooserView->layoutModelObject(coilheatingbb);
     waterHeatingCoil = true;
@@ -1749,9 +1743,8 @@ void ZoneHVACBaseboardRadiantConvectiveWaterInspectorView::layoutModelObject( mo
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
 }
 
@@ -1843,15 +1836,13 @@ void ZoneHVACFourPipeFanCoilInspectorView::layoutModelObject( model::ModelObject
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> moCool;
-
-    m_coolingLoopChooserView->layoutModelObject(moCool);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 }
 
@@ -1945,15 +1936,13 @@ void ZoneHVACLowTempRadiantConstFlowInspectorView::layoutModelObject( model::Mod
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> moCool;
-
-    m_coolingLoopChooserView->layoutModelObject(moCool);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 
 }
@@ -2047,15 +2036,13 @@ void ZoneHVACLowTempRadiantVarFlowInspectorView::layoutModelObject( model::Model
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> moCool;
-
-    m_coolingLoopChooserView->layoutModelObject(moCool);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 
 }
@@ -2172,22 +2159,19 @@ void ZoneHVACWaterToAirHeatPumpInspectorView::layoutModelObject( model::ModelObj
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> moCool;
-
-    m_coolingLoopChooserView->layoutModelObject(moCool);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 
   if( ! supplementalHC )
   {
-    boost::optional<model::ModelObject> moSupplementalHeat;
-
-    m_supHeatingLoopChooserView->layoutModelObject(moSupplementalHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_supHeatingLoopChooserView, true);
   }
 }
 
@@ -2462,9 +2446,8 @@ void ZoneHVACUnitHeaterInspectorView::layoutModelObject( model::ModelObject & mo
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> moHeat;
-
-    m_heatingLoopChooserView->layoutModelObject(moHeat);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
 }
 
@@ -2548,12 +2531,12 @@ void ZoneHVACUnitVentilatorInspectorView::layoutModelObject( model::ModelObject 
   }
 
   if( ! waterHeatingCoil ) {
-    boost::optional<model::ModelObject> omo;
-    m_heatingLoopChooserView->layoutModelObject(omo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
   if( ! waterCoolingCoil ) {
-    boost::optional<model::ModelObject> omo;
-    m_coolingLoopChooserView->layoutModelObject(omo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 }
 
@@ -2662,20 +2645,20 @@ void AirLoopHVACUnitarySystemInspectorView::layoutModelObject( model::ModelObjec
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_heatingLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
 
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_coolingLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 
   if( ! waterSecondaryCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_secondaryLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_secondaryLoopChooserView, true);
   }
 }
 
@@ -2763,14 +2746,14 @@ void AirTerminalSingleDuctConstantVolumeFourPipeInductionInspectorView::layoutMo
 
   if( ! waterHeatingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_heatingLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);
   }
 
   if( ! waterCoolingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_coolingLoopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);
   }
 }
 
@@ -2856,15 +2839,13 @@ void AirTerminalSingleDuctConstantVolumeFourPipeBeamInspectorView::layoutModelOb
 
   if( ! heatingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_heatingLoopChooserView->layoutModelObject(mo);
-  }
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_heatingLoopChooserView, true);  }
 
   if( ! coolingCoil )
   {
-    boost::optional<model::ModelObject> mo;
-    m_coolingLoopChooserView->layoutModelObject(mo);
-  }
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_coolingLoopChooserView, true);  }
 }
 
 

--- a/openstudiocore/src/openstudio_lib/InspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/InspectorView.cpp
@@ -2239,9 +2239,8 @@ void ZoneHVACPackagedTerminalAirConditionerInspectorView::layoutModelObject( mod
 
   if( ! waterCoil )
   {
-    boost::optional<model::ModelObject> mo;
-
-    m_loopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_loopChooserView, true);
   }
 }
 
@@ -2309,9 +2308,8 @@ void ZoneHVACPackagedTerminalHeatPumpInspectorView::layoutModelObject( model::Mo
 
   if( ! waterCoil )
   {
-    boost::optional<model::ModelObject> mo;
-
-    m_loopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_loopChooserView, true);
   }
 }
 
@@ -2374,9 +2372,8 @@ void WaterHeaterHeatPumpInspectorView::layoutModelObject( model::ModelObject & m
 
   if( ! waterCoil )
   {
-    boost::optional<model::ModelObject> mo;
-
-    m_loopChooserView->layoutModelObject(mo);
+    // Hide the tab (by hiding the button)
+    m_libraryTabWidget->hideTab( m_loopChooserView, true);
   }
 }
 

--- a/openstudiocore/src/openstudio_lib/LibraryTabWidget.cpp
+++ b/openstudiocore/src/openstudio_lib/LibraryTabWidget.cpp
@@ -127,6 +127,36 @@ void LibraryTabWidget::addTab( QWidget * widget,
   setCurrentIndex(0);
 }
 
+void LibraryTabWidget::hideTab(QWidget * widget, bool hide)
+{
+  int index = m_pageStack->indexOf(widget);
+  OS_ASSERT(index >= 0);
+
+  int currentIndex = m_pageStack->currentIndex();
+  if(currentIndex == index){
+    if(currentIndex + 1 < m_pageStack->count()){
+      currentIndex++;
+    } else if (currentIndex != 0) {
+      currentIndex = 0;
+    } else {
+      // index and currentIndex are both 0
+      // can't hide both the tab and the page
+      return;
+    }
+  }
+
+  QPushButton * button = nullptr;
+  button = m_tabButtons.at(index);
+  OS_ASSERT(button);
+  if(hide){
+    button->hide();
+  } else {
+    button->show();
+  }
+
+  setCurrentIndex(currentIndex);
+}
+
 void LibraryTabWidget::select()
 {
   QPushButton * button = qobject_cast<QPushButton *>(sender());

--- a/openstudiocore/src/openstudio_lib/LibraryTabWidget.hpp
+++ b/openstudiocore/src/openstudio_lib/LibraryTabWidget.hpp
@@ -57,6 +57,11 @@ class LibraryTabWidget : public QWidget
                const QString & selectedImagePath,
                const QString & unSelectedImagePath );
 
+  /* This method, given a tab widget, will change the currentIndex to be the following if there is one, or zero otherwise
+   * It will hide the tab by hide the corresponding button.
+   * Useful to hide the LoopChooserView for components that don't have a water coil for eg. */
+  void hideTab(QWidget * widget, bool hide = true);
+
   signals:
 
   void removeButtonClicked(bool);


### PR DESCRIPTION
Fix #1877 non functional link subtab for HVACComponents

Changelog:
* Added `LibraryTabWidget::hideTab` function to hide the tab by hiding the link button and handle the currentIndex. Adapted from [HorizontalTabWidget::hideTab](https://github.com/jmarrec/OpenStudio/blob/develop/openstudiocore/src/openstudio_lib/HorizontalTabWidget.cpp#L225)
* For each component, instead of calling `LoopChooserView::layoutModelObject` with an empty optional, I call `hideTab`

eg: PTAC with an electric coil:

![image](https://user-images.githubusercontent.com/5479063/45150232-aafd3b00-b1cb-11e8-9f84-5bbf8cc11ef4.png)

PTAC with a HW coil:

![image](https://user-images.githubusercontent.com/5479063/45150265-b81a2a00-b1cb-11e8-93f1-acb2b2e26aac.png)


One thing I need to mention is that if you have a cooling coil (3rd tab) and no heating coil (2nd tab) it'll look like this, which I don't see as a problem:

![image](https://user-images.githubusercontent.com/5479063/45150291-c6684600-b1cb-11e8-9932-2dc0b2a14470.png)


Review assignee: @macumber 
