### PR TITLE
Fix #2712 Enable Apply to selected for checkboxes

### DIFF
--- a/openstudiocore/src/openstudio_lib/DesignDayGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/DesignDayGridView.cpp
@@ -286,21 +286,24 @@ void DesignDayGridController::addColumns(const QString &/*category*/, std::vecto
   for (const QString& field : fields) {
     // Evan note: addCheckBoxColumn does not yet handle reset and default
     if (field == DAYLIGHTSAVINGTIMEINDICATOR) {
-      addCheckBoxColumn(Heading(QString(DAYLIGHTSAVINGTIMEINDICATOR), true, false),
+      // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+      addCheckBoxColumn(Heading(QString(DAYLIGHTSAVINGTIMEINDICATOR), true, true),
         std::string("Check to enable daylight saving time indicator."),
         NullAdapter(&model::DesignDay::daylightSavingTimeIndicator),
         NullAdapter(&model::DesignDay::setDaylightSavingTimeIndicator)
         );
     }
     else if (field == RAININDICATOR) {
-      addCheckBoxColumn(Heading(QString(RAININDICATOR), true, false),
+      // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+      addCheckBoxColumn(Heading(QString(RAININDICATOR), true, true),
         std::string("Check to enable rain indicator."),
         NullAdapter(&model::DesignDay::rainIndicator),
         NullAdapter(&model::DesignDay::setRainIndicator)
         );
     }
     else if (field == SNOWINDICATOR) {
-      addCheckBoxColumn(Heading(QString(SNOWINDICATOR), true, false),
+      // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+      addCheckBoxColumn(Heading(QString(SNOWINDICATOR), true, true),
         std::string("Check to enable snow indicator."),
         NullAdapter(&model::DesignDay::snowIndicator),
         NullAdapter(&model::DesignDay::setSnowIndicator)

--- a/openstudiocore/src/openstudio_lib/SpacesInteriorPartitionsGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesInteriorPartitionsGridView.cpp
@@ -258,7 +258,8 @@ namespace openstudio {
             );
         }
         else if (field == CONVERTTOINTERNALMASS) {
-          addCheckBoxColumn(Heading(QString(CONVERTTOINTERNALMASS), true, false),
+          // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+          addCheckBoxColumn(Heading(QString(CONVERTTOINTERNALMASS), true, true),
             std::string("Check to enable convert to InternalMass."),
             NullAdapter(&model::InteriorPartitionSurface::converttoInternalMass),
             NullAdapter(&model::InteriorPartitionSurface::setConverttoInternalMass),

--- a/openstudiocore/src/openstudio_lib/SpacesSpacesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSpacesGridView.cpp
@@ -237,7 +237,8 @@ namespace openstudio {
           );
       }
       else if (field == PARTOFTOTALFLOORAREA) {
-        addCheckBoxColumn(Heading(QString(PARTOFTOTALFLOORAREA), true, false),
+        // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+        addCheckBoxColumn(Heading(QString(PARTOFTOTALFLOORAREA), true, true),
           std::string("Check to enable part of total floor area."),
           NullAdapter(&model::Space::partofTotalFloorArea),
           NullAdapter(&model::Space::setPartofTotalFloorArea)

--- a/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
@@ -231,9 +231,8 @@ struct ModelObjectNameSorter{
 
     Q_FOREACH(QString field, fields){
       if (field == IDEALAIRLOADS){
-        // Workaround to add "Apply Selected" button to this column
-        m_idealAirLoadsColumn = 2;
-        addCheckBoxColumn(Heading(QString(IDEALAIRLOADS), true, true), // Not that we pass 3rd arg, t_showColumnButton=true
+        // We add the "Apply Selected" button to this column by passing 3rd arg, t_showColumnButton=true
+        addCheckBoxColumn(Heading(QString(IDEALAIRLOADS), true, true),
           std::string("Check to enable ideal air loads."),
           NullAdapter(&model::ThermalZone::useIdealAirLoads),
           NullAdapter(&model::ThermalZone::setUseIdealAirLoads));

--- a/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/ThermalZonesGridView.cpp
@@ -231,7 +231,9 @@ struct ModelObjectNameSorter{
 
     Q_FOREACH(QString field, fields){
       if (field == IDEALAIRLOADS){
-        addCheckBoxColumn(Heading(QString(IDEALAIRLOADS), true, false),
+        // Workaround to add "Apply Selected" button to this column
+        m_idealAirLoadsColumn = 2;
+        addCheckBoxColumn(Heading(QString(IDEALAIRLOADS), true, true), // Not that we pass 3rd arg, t_showColumnButton=true
           std::string("Check to enable ideal air loads."),
           NullAdapter(&model::ThermalZone::useIdealAirLoads),
           NullAdapter(&model::ThermalZone::setUseIdealAirLoads));

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
@@ -110,6 +110,7 @@ namespace openstudio {
 
   void OSCheckBox3::onToggled(bool checked)
   {
+    emit inFocus(true, true); // fake that is has data
     if (m_modelObject && m_set) {
       if ((*m_get)() != checked) {
         (*m_set)(checked);

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
@@ -28,9 +28,12 @@
 ***********************************************************************************************************************/
 
 #include "OSCheckBox.hpp"
+
 #include "../model/ModelObject.hpp"
 #include "../model/ModelObject_Impl.hpp"
+
 #include <QString>
+#include <QFocusEvent>
 
 namespace openstudio {
 
@@ -138,6 +141,26 @@ namespace openstudio {
   {
     unbind();
   }
+
+  void OSCheckBox3::focusInEvent(QFocusEvent * e)
+  {
+    if (e->reason() == Qt::MouseFocusReason)
+    {
+      emit inFocus(true, true);
+    }
+    QWidget::focusInEvent(e);
+  }
+
+  void OSCheckBox3::focusOutEvent(QFocusEvent * e)
+  {
+    if (e->reason() == Qt::MouseFocusReason)
+    {
+      emit inFocus(false, false);
+    }
+    // Pass it on for further processing
+    QWidget::focusOutEvent(e);
+  }
+
 
 OSCheckBox2::OSCheckBox2( QWidget * parent )
   : QPushButton(parent)

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
@@ -146,6 +146,12 @@ namespace openstudio {
   {
     if (e->reason() == Qt::MouseFocusReason)
     {
+      // Switch to yellow background
+      QPalette p = this->palette();
+      QColor yellow("#ffc627");
+      p.setColor(QPalette::Base, yellow);
+      this->setPalette(p);
+
       emit inFocus(true, true);
     }
     QWidget::focusInEvent(e);
@@ -155,6 +161,8 @@ namespace openstudio {
   {
     if (e->reason() == Qt::MouseFocusReason)
     {
+      // Reset the style sheet
+      setStyleSheet("");
       emit inFocus(false, false);
     }
     // Pass it on for further processing

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.cpp
@@ -144,8 +144,7 @@ namespace openstudio {
 
   void OSCheckBox3::focusInEvent(QFocusEvent * e)
   {
-    if (e->reason() == Qt::MouseFocusReason)
-    {
+    if( (e->reason() == Qt::MouseFocusReason) && (this->focusPolicy() == Qt::ClickFocus) ) {
       // Switch to yellow background
       QPalette p = this->palette();
       QColor yellow("#ffc627");
@@ -159,8 +158,7 @@ namespace openstudio {
 
   void OSCheckBox3::focusOutEvent(QFocusEvent * e)
   {
-    if (e->reason() == Qt::MouseFocusReason)
-    {
+    if( (e->reason() == Qt::MouseFocusReason) && (this->focusPolicy() == Qt::ClickFocus) ) {
       // Reset the style sheet
       setStyleSheet("");
       emit inFocus(false, false);

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
@@ -63,7 +63,11 @@ namespace openstudio {
 
     void unbind();
 
-    private slots:
+  signals:
+
+    void inFocus(bool inFocus, bool hasData);
+
+  private slots:
 
     void onToggled(bool checked);
 

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
@@ -75,6 +75,11 @@ namespace openstudio {
 
     void inFocus(bool inFocus, bool hasData);
 
+  protected:
+    // We override these methods to emit inFocus as appropriate to enable/disable the header button
+    virtual void focusInEvent(QFocusEvent * e) override;
+    virtual void focusOutEvent(QFocusEvent * e) override;
+
   private slots:
 
     void onToggled(bool checked);

--- a/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
+++ b/openstudiocore/src/shared_gui_components/OSCheckBox.hpp
@@ -38,6 +38,10 @@
 #include <nano/nano_signal_slot.hpp> // Signal-Slot replacement
 #include <QPushButton>
 
+// Forward declaration
+class QFocusEvent;
+
+
 namespace openstudio {
 
   class OSCheckBox3 : public QCheckBox, public Nano::Observer {
@@ -48,6 +52,10 @@ namespace openstudio {
     OSCheckBox3(QWidget * parent = nullptr);
 
     virtual ~OSCheckBox3();
+
+    // This method will be called to enable the Checkbox to accept focus
+    // (typically by the OSGridController depending on whether the underlying BaseConcept allows it)
+    void enableClickFocus() { this->setFocusPolicy(Qt::ClickFocus); }
 
     void bind(model::ModelObject & modelObject,
       BoolGetter get,

--- a/openstudiocore/src/shared_gui_components/OSConcepts.hpp
+++ b/openstudiocore/src/shared_gui_components/OSConcepts.hpp
@@ -422,10 +422,10 @@ class CheckBoxConceptBoolReturn : public BaseConcept
 {
 public:
 
-  /* This concept will allow click focus */
+  /* This concept will allow click focus IIF Heading is passed with t_showColumnButton=true */
   CheckBoxConceptBoolReturn(const Heading &t_heading,
-    const std::string & t_tooltip, bool t_hasClickFocus = true)
-    : BaseConcept(t_heading, t_hasClickFocus),
+                            const std::string & t_tooltip)
+    : BaseConcept(t_heading, t_heading.showButton() ),
     m_tooltip(t_tooltip)
   {
   }

--- a/openstudiocore/src/shared_gui_components/OSConcepts.hpp
+++ b/openstudiocore/src/shared_gui_components/OSConcepts.hpp
@@ -422,9 +422,10 @@ class CheckBoxConceptBoolReturn : public BaseConcept
 {
 public:
 
+  /* This concept will allow click focus */
   CheckBoxConceptBoolReturn(const Heading &t_heading,
-    const std::string & t_tooltip)
-    : BaseConcept(t_heading),
+    const std::string & t_tooltip, bool t_hasClickFocus = true)
+    : BaseConcept(t_heading, t_hasClickFocus),
     m_tooltip(t_tooltip)
   {
   }

--- a/openstudiocore/src/shared_gui_components/OSGridController.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.cpp
@@ -58,6 +58,12 @@
 #include "../model/SpaceType.hpp"
 #include "../model/SpaceType_Impl.hpp"
 
+// Which is faster?
+#include "../model/ThermalZone.hpp"
+#include "../model/ThermalZone_Impl.hpp"
+// or
+// #include <utilities/idd/IddEnums.hxx>
+
 #include "../utilities/core/Assert.hpp"
 
 #include <QApplication>
@@ -672,6 +678,7 @@ namespace openstudio {
 
     if (QSharedPointer<CheckBoxConcept> checkBoxConcept = t_baseConcept.dynamicCast<CheckBoxConcept>()){
 
+      // This is basically for the "Select All" column
       auto checkBox = new OSCheckBox3(this->gridView()); // OSCheckBox3 is derived from QCheckBox, whereas OSCheckBox2 is derived from QPushButton
       if (checkBoxConcept->tooltip().size()) {
         checkBox->setToolTip(checkBoxConcept->tooltip().c_str());
@@ -690,7 +697,7 @@ namespace openstudio {
       widget = checkBox;
 
   } else if (auto checkBoxConceptBoolReturn = t_baseConcept.dynamicCast<CheckBoxConceptBoolReturn>()){
-
+      // This is for a proper setter **that returns a bool**, such as Ideal Air Loads column
       auto checkBoxBoolReturn = new OSCheckBox3(this->gridView());
       if (checkBoxConceptBoolReturn->tooltip().size()) {
         checkBoxBoolReturn->setToolTip(checkBoxConceptBoolReturn->tooltip().c_str());
@@ -700,11 +707,12 @@ namespace openstudio {
         BoolGetter(std::bind(&CheckBoxConceptBoolReturn::get, checkBoxConceptBoolReturn.data(), t_mo)),
         boost::optional<BoolSetterBoolReturn>(std::bind(&CheckBoxConceptBoolReturn::set, checkBoxConceptBoolReturn.data(), t_mo, std::placeholders::_1)));
 
-      isConnected = connect(checkBoxBoolReturn, SIGNAL(stateChanged(int)), gridView(), SLOT(requestRefreshGrid()));
-      OS_ASSERT(isConnected);
+      // We don't need to refresh the whole grid, since we do not have to color the rows blue like the "Select All" checkboc
+      // isConnected = connect(checkBoxBoolReturn, SIGNAL(stateChanged(int)), gridView(), SLOT(requestRefreshGrid()));
+      // OS_ASSERT(isConnected);
 
-      isConnected = connect(checkBoxBoolReturn, SIGNAL(stateChanged(int)), gridView(), SIGNAL(gridRowSelectionChanged(int)));
-      OS_ASSERT(isConnected);
+      // isConnected = connect(checkBoxBoolReturn, SIGNAL(stateChanged(int)), gridView(), SIGNAL(gridRowSelectionChanged(int)));
+      // OS_ASSERT(isConnected);
 
       widget = checkBoxBoolReturn;
 
@@ -1073,6 +1081,12 @@ namespace openstudio {
       auto temp = getter();
       setter(temp);
     }
+    else if (QSharedPointer<CheckBoxConceptBoolReturn> concept = t_baseConcept.dynamicCast<CheckBoxConceptBoolReturn>()) {
+      auto setter = std::bind(&CheckBoxConceptBoolReturn::set, concept.data(), t_setterMO, std::placeholders::_1);
+      auto getter = std::bind(&CheckBoxConceptBoolReturn::get, concept.data(), t_getterMO);
+      auto temp = getter();
+      setter(temp);
+    }
     else if (QSharedPointer<ComboBoxConcept> concept = t_baseConcept.dynamicCast<ComboBoxConcept>()) {
       auto getterChoiceConcept = concept->choiceConcept(t_getterMO);
       auto setterChoiceConcept = concept->choiceConcept(t_setterMO);
@@ -1375,7 +1389,7 @@ namespace openstudio {
       // Is this widget's subrow a surface with a defaulted construction?
       if (t_obj) {
         if (auto planarSurface = t_obj->optionalCast<model::PlanarSurface>()) {
-          if (planarSurface && planarSurface->isConstructionDefaulted()) {
+          if ( planarSurface->isConstructionDefaulted()) {
             // Is this column a construction?
             if (column == m_constructionColumn) {
               if (OSDropZone2 * dropZone = qobject_cast<OSDropZone2 *>(t_widget)) {
@@ -1384,12 +1398,24 @@ namespace openstudio {
             }
           }
         }
+        // Is this the "Turn On Ideal Air Loads?"
+        // if( t_obj->iddObjectType() == openstudio::IddObjectType::OS_ThermalZone )
+        if (auto t_z = t_obj->optionalCast<model::ThermalZone>()) {
+          // Is this column a construction?
+          if (column == m_idealAirLoadsColumn) {
+            if (OSCheckBox3 * checkBox = qobject_cast<OSCheckBox3 *>(t_widget)) {
+              // Then we connect the inFocus
+              std::cout << "Connecting for " << t_obj->nameString() <<"\n";
+              connect(checkBox, &OSCheckBox3::inFocus, holder, &Holder::inFocus);
+            }
+          }
+        }
       }
 
       m_objectSelector->addWidget(t_obj, holder, row, column, hasSubRows ? numWidgets : boost::optional<int>(), t_selector);
 
       ++numWidgets;
-    };
+    }; // End of lambda
 
     if (m_hasHorizontalHeader && row == 0){
       if (column == 0){

--- a/openstudiocore/src/shared_gui_components/OSGridController.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.cpp
@@ -703,6 +703,10 @@ namespace openstudio {
         checkBoxBoolReturn->setToolTip(checkBoxConceptBoolReturn->tooltip().c_str());
       }
 
+      if (checkBoxConceptBoolReturn->hasClickFocus()) {
+        checkBoxBoolReturn->enableClickFocus();
+      }
+
       checkBoxBoolReturn->bind(t_mo,
         BoolGetter(std::bind(&CheckBoxConceptBoolReturn::get, checkBoxConceptBoolReturn.data(), t_mo)),
         boost::optional<BoolSetterBoolReturn>(std::bind(&CheckBoxConceptBoolReturn::set, checkBoxConceptBoolReturn.data(), t_mo, std::placeholders::_1)));

--- a/openstudiocore/src/shared_gui_components/OSGridController.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.cpp
@@ -1381,34 +1381,25 @@ namespace openstudio {
       }
       else if (OSDropZone2 * dropZone = qobject_cast<OSDropZone2 *>(t_widget)) {
         connect(dropZone, &OSDropZone2::inFocus, holder, &Holder::inFocus);
-      }
-      else if (HorizontalHeaderWidget * horizontalHeaderWidget = qobject_cast<HorizontalHeaderWidget *>(t_widget)) {
-        connect(horizontalHeaderWidget, &HorizontalHeaderWidget::inFocus, holder, &Holder::inFocus);
-      }
-
-      // Is this widget's subrow a surface with a defaulted construction?
-      if (t_obj) {
-        if (auto planarSurface = t_obj->optionalCast<model::PlanarSurface>()) {
-          if ( planarSurface->isConstructionDefaulted()) {
-            // Is this column a construction?
-            if (column == m_constructionColumn) {
-              if (OSDropZone2 * dropZone = qobject_cast<OSDropZone2 *>(t_widget)) {
+        // Is this widget's subrow a surface with a defaulted construction?
+        if (t_obj) {
+          if (auto planarSurface = t_obj->optionalCast<model::PlanarSurface>()) {
+            if ( planarSurface->isConstructionDefaulted()) {
+              // Is this column a construction?
+              if (column == m_constructionColumn) {
                 dropZone->setIsDefaulted(true);
               }
             }
           }
         }
-        // Is this the "Turn On Ideal Air Loads?"
-        // if( t_obj->iddObjectType() == openstudio::IddObjectType::OS_ThermalZone )
-        if (auto t_z = t_obj->optionalCast<model::ThermalZone>()) {
-          // Is this column a construction?
-          if (column == m_idealAirLoadsColumn) {
-            if (OSCheckBox3 * checkBox = qobject_cast<OSCheckBox3 *>(t_widget)) {
-              // Then we connect the inFocus
-              std::cout << "Connecting for " << t_obj->nameString() <<"\n";
-              connect(checkBox, &OSCheckBox3::inFocus, holder, &Holder::inFocus);
-            }
-          }
+      }
+      else if (HorizontalHeaderWidget * horizontalHeaderWidget = qobject_cast<HorizontalHeaderWidget *>(t_widget)) {
+        connect(horizontalHeaderWidget, &HorizontalHeaderWidget::inFocus, holder, &Holder::inFocus);
+      }
+      else if (OSCheckBox3 * checkBox = qobject_cast<OSCheckBox3 *>(t_widget)) {
+        // If it's not the "Select All" column, we connect the inFocus method
+        if( column > 1 ) {
+          connect(checkBox, &OSCheckBox3::inFocus, holder, &Holder::inFocus);
         }
       }
 

--- a/openstudiocore/src/shared_gui_components/OSGridController.hpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.hpp
@@ -304,16 +304,18 @@ public:
                          std::function<void (DataSourceType *, bool)> t_setter,
                          const boost::optional<DataSource> &t_source = boost::none)
   {
+    std::cout << "CheckBoxConcept\n";
     m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<CheckBoxConcept>(new CheckBoxConceptImpl<DataSourceType>(heading,tooltip,t_getter,t_setter)), t_source));
   }
 
   template<typename DataSourceType>
   void addCheckBoxColumn(const Heading &heading,
-    const std::string & tooltip,
-    std::function<bool(DataSourceType *)>  t_getter,
-    std::function<bool(DataSourceType *, bool)> t_setter,
-    const boost::optional<DataSource> &t_source = boost::none)
+                         const std::string & tooltip,
+                         std::function<bool(DataSourceType *)>  t_getter,
+                         std::function<bool(DataSourceType *, bool)> t_setter,
+                         const boost::optional<DataSource> &t_source = boost::none)
   {
+    std::cout << "CheckBoxConceptBoolReturn\n";
     m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<CheckBoxConceptBoolReturn>(new CheckBoxConceptBoolReturnImpl<DataSourceType>(heading, tooltip, t_getter, t_setter)), t_source));
   }
 
@@ -603,6 +605,9 @@ public:
   // (as determined by calling PlanarSurface::isConstructionDefaulted). An instantiated gridview
   // should set this value, if appropriate.
   int m_constructionColumn = -1;
+
+  // Selectively add an "Apply" button to the "Turn on Ideal Air Loads on thermal zone subtab
+  int m_idealAirLoadsColumn = -1;
 
 protected:
 

--- a/openstudiocore/src/shared_gui_components/OSGridController.hpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.hpp
@@ -304,7 +304,6 @@ public:
                          std::function<void (DataSourceType *, bool)> t_setter,
                          const boost::optional<DataSource> &t_source = boost::none)
   {
-    std::cout << "CheckBoxConcept\n";
     m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<CheckBoxConcept>(new CheckBoxConceptImpl<DataSourceType>(heading,tooltip,t_getter,t_setter)), t_source));
   }
 
@@ -315,7 +314,6 @@ public:
                          std::function<bool(DataSourceType *, bool)> t_setter,
                          const boost::optional<DataSource> &t_source = boost::none)
   {
-    std::cout << "CheckBoxConceptBoolReturn\n";
     m_baseConcepts.push_back(makeDataSourceAdapter(QSharedPointer<CheckBoxConceptBoolReturn>(new CheckBoxConceptBoolReturnImpl<DataSourceType>(heading, tooltip, t_getter, t_setter)), t_source));
   }
 

--- a/openstudiocore/src/shared_gui_components/OSGridController.hpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.hpp
@@ -606,9 +606,6 @@ public:
   // should set this value, if appropriate.
   int m_constructionColumn = -1;
 
-  // Selectively add an "Apply" button to the "Turn on Ideal Air Loads on thermal zone subtab
-  int m_idealAirLoadsColumn = -1;
-
 protected:
 
   // This function determines the category for


### PR DESCRIPTION
Fix #2712 which was specially about the "Turn on Ideal Air Loads", and do that for all checkboxes actually


For all checkboxes except the "All" column, the "Apply to Selected" button is enabled and functional (provided you do pass a Heading that has a `t_showColumnButton=true` which I did for all checkboxes now)

When you select such a checkbox, it becomes yellow to help you figure out one which you clicked.

here's a gif showing the UX:

![example](https://user-images.githubusercontent.com/5479063/45162624-b150de80-b1ee-11e8-9b02-387715efcb1e.gif)


Review assignee: @macumber 
