### PR TITLE
Fix #535 - update system combo box on loop name change

### DIFF
--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
@@ -171,19 +171,18 @@ HVACSystemsController::HVACSystemsController(bool isIP, const model::Model & mod
 
 
   // connect initial loops to trigger a refresh of the system combo box
-  // Populate system combo box
   auto airloops = m_model.getModelObjects<model::AirLoopHVAC>();
   std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
   for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
     // Trigger a full refresh if the airLoop name changes
-    std::cout << "Attaching name change for AirLoopHVAC " << it->nameString() << "\n";
+    // std::cout << "Attaching name change for AirLoopHVAC " << it->nameString() << "\n";
     it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 
   auto plantloops = m_model.getModelObjects<model::PlantLoop>();
   std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
   for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
-    std::cout << "Attaching name change for PlantLoop " << it->nameString() << "\n";
+    // std::cout << "Attaching name change for PlantLoop " << it->nameString() << "\n";
     it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 
@@ -228,7 +227,7 @@ model::Model HVACSystemsController::model() const
 
 void HVACSystemsController::repopulateSystemComboBox() {
 
-  std::cout << "repopulateSystemComboBox\n";
+  // std::cout << "repopulateSystemComboBox\n";
 
   QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
   bool signalsAlreadyBlocked = systemComboBox->signalsBlocked();
@@ -326,7 +325,7 @@ void HVACSystemsController::update()
 
     QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
 
-    std::cout << "update\n";
+    // std::cout << "update\n";
     systemComboBox->blockSignals(true);
 
     // Repopulate
@@ -516,7 +515,7 @@ void HVACSystemsController::onObjectAdded(const WorkspaceObject& workspaceObject
   // If it's a Loop, we trigger a repopulation of the System Combobox upon name change
   if( (newObjectIddType == model::PlantLoop::iddObjectType() )
       || (newObjectIddType == model::AirLoopHVAC::iddObjectType() ) ) {
-    std::cout << "Attaching name change for " << workspaceObject.briefDescription() << "\n";
+    // std::cout << "Attaching name change for " << workspaceObject.briefDescription() << "\n";
     workspaceObject.getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 }

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
@@ -132,6 +132,9 @@
 #include <QLayout>
 #include <QMutex>
 
+// Switch log Level in one go
+#define LOGLEVEL Trace
+
 namespace openstudio {
 
 const QString SHW = "SHW";
@@ -175,14 +178,14 @@ HVACSystemsController::HVACSystemsController(bool isIP, const model::Model & mod
   std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
   for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
     // Trigger a full refresh if the airLoop name changes
-    // std::cout << "Attaching name change for AirLoopHVAC " << it->nameString() << "\n";
+    LOG(LOGLEVEL, "HVACSystemsController Ctor: Attaching name change for AirLoopHVAC " << it->nameString());
     it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 
   auto plantloops = m_model.getModelObjects<model::PlantLoop>();
   std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
   for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
-    // std::cout << "Attaching name change for PlantLoop " << it->nameString() << "\n";
+    LOG(LOGLEVEL, "HVACSystemsController Ctor: Attaching name change for PlantLoop " << it->nameString());
     it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 
@@ -227,7 +230,7 @@ model::Model HVACSystemsController::model() const
 
 void HVACSystemsController::repopulateSystemComboBox() {
 
-  // std::cout << "repopulateSystemComboBox\n";
+  LOG(LOGLEVEL, "repopulateSystemComboBox() called");
 
   QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
   bool signalsAlreadyBlocked = systemComboBox->signalsBlocked();
@@ -325,7 +328,7 @@ void HVACSystemsController::update()
 
     QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
 
-    // std::cout << "update\n";
+    LOG(LOGLEVEL, "update() called");
     systemComboBox->blockSignals(true);
 
     // Repopulate
@@ -515,7 +518,7 @@ void HVACSystemsController::onObjectAdded(const WorkspaceObject& workspaceObject
   // If it's a Loop, we trigger a repopulation of the System Combobox upon name change
   if( (newObjectIddType == model::PlantLoop::iddObjectType() )
       || (newObjectIddType == model::AirLoopHVAC::iddObjectType() ) ) {
-    // std::cout << "Attaching name change for " << workspaceObject.briefDescription() << "\n";
+    LOG(LOGLEVEL, "onObjectAdded: Attaching name change for " << workspaceObject.briefDescription());
     workspaceObject.getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 }

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
@@ -169,6 +169,25 @@ HVACSystemsController::HVACSystemsController(bool isIP, const model::Model & mod
 
   connect(m_hvacSystemsView->hvacToolbarView->gridViewButton, &QPushButton::clicked, this, &HVACSystemsController::onShowGridClicked);
 
+
+  // connect initial loops to trigger a refresh of the system combo box
+  // Populate system combo box
+  auto airloops = m_model.getModelObjects<model::AirLoopHVAC>();
+  std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
+  for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
+    // Trigger a full refresh if the airLoop name changes
+    std::cout << "Attaching name change for AirLoopHVAC " << it->nameString() << "\n";
+    it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
+  }
+
+  auto plantloops = m_model.getModelObjects<model::PlantLoop>();
+  std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
+  for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
+    std::cout << "Attaching name change for PlantLoop " << it->nameString() << "\n";
+    it->getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
+  }
+
+
   m_updateMutex = new QMutex();
 
   updateLater();
@@ -206,6 +225,92 @@ model::Model HVACSystemsController::model() const
   return m_model;
 }
 
+
+void HVACSystemsController::repopulateSystemComboBox() {
+
+  std::cout << "repopulateSystemComboBox\n";
+
+  QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
+  bool signalsAlreadyBlocked = systemComboBox->signalsBlocked();
+
+  // If not already blocked, we do it
+  if( !signalsAlreadyBlocked ) {
+    // we want to avoid onSystemComboBoxIndexChanged that triggers setCurrentHandle With triggers update
+    // which will retrigger this very function...
+    systemComboBox->blockSignals(true);
+  }
+
+  // Repopulate
+  systemComboBox->clear();
+
+  // Populate system combo box
+  auto airloops = m_model.getModelObjects<model::AirLoopHVAC>();
+  std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
+  for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
+    systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
+  }
+
+  auto plantloops = m_model.getModelObjects<model::PlantLoop>();
+  std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
+  for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
+    systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
+  }
+
+  // TODO: When addressing issue #961 - HVAC Toolbar review, that's where you start
+  systemComboBox->addItem("Service Hot Water",SHW);
+  systemComboBox->addItem("Refrigeration",REFRIGERATION);
+  systemComboBox->addItem("VRF",VRF);
+
+  // Set system combo box current index
+  QString handle = currentHandle();
+  if( handle == SHW  ||
+      m_model.getModelObject<model::WaterUseConnections>(toUUID(handle))
+    )
+  {
+    int index = systemComboBox->findData(SHW);
+
+    OS_ASSERT(index >= 0);
+
+    systemComboBox->setCurrentIndex(index);
+  }
+  else if( handle == REFRIGERATION )
+  {
+    int index = systemComboBox->findData(REFRIGERATION);
+
+    OS_ASSERT(index >= 0);
+
+    systemComboBox->setCurrentIndex(index);
+  }
+  else if( handle == VRF )
+  {
+    int index = systemComboBox->findData(VRF);
+
+    OS_ASSERT(index >= 0);
+
+    systemComboBox->setCurrentIndex(index);
+  }
+  else
+  {
+    int index = systemComboBox->findData(handle);
+
+    if(index >= 0)
+    {
+      systemComboBox->setCurrentIndex(index);
+    }
+    else
+    {
+      systemComboBox->setCurrentIndex(systemComboBox->findData(SHW));
+    }
+  }
+
+
+  // Release if needed
+  if( !signalsAlreadyBlocked ) {
+    // Don't forget to renable both the combobox AND the HVACSystemsController!
+    systemComboBox->blockSignals(false);
+  }
+}
+
 void HVACSystemsController::update()
 {
   if( ! m_updateMutex->tryLock() ) {
@@ -221,70 +326,15 @@ void HVACSystemsController::update()
 
     QComboBox * systemComboBox = m_hvacSystemsView->hvacToolbarView->systemComboBox;
 
+    std::cout << "update\n";
     systemComboBox->blockSignals(true);
 
-    systemComboBox->clear();
-
-    // Populate system combo box
-    auto airloops = m_model.getModelObjects<model::AirLoopHVAC>();
-    std::sort(airloops.begin(),airloops.end(),WorkspaceObjectNameLess());
-    for( auto it = airloops.begin(); it != airloops.end(); ++it ) {
-      systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
-    }
-
-    auto plantloops = m_model.getModelObjects<model::PlantLoop>();
-    std::sort(plantloops.begin(),plantloops.end(),WorkspaceObjectNameLess());
-    for( auto it = plantloops.begin(); it != plantloops.end(); ++it ) {
-      systemComboBox->addItem(QString::fromStdString(it->name().get()), toQString(it->handle()));
-    }
-
-    systemComboBox->addItem("Service Hot Water",SHW);
-    systemComboBox->addItem("Refrigeration",REFRIGERATION);
-    systemComboBox->addItem("VRF",VRF);
-
-    // Set system combo box current index
-    QString handle = currentHandle();
-    if( handle == SHW  ||
-        m_model.getModelObject<model::WaterUseConnections>(toUUID(handle))
-      )
-    {
-      int index = systemComboBox->findData(SHW);
-
-      OS_ASSERT(index >= 0);
-
-      systemComboBox->setCurrentIndex(index);
-    }
-    else if( handle == REFRIGERATION )
-    {
-      int index = systemComboBox->findData(REFRIGERATION);
-
-      OS_ASSERT(index >= 0);
-
-      systemComboBox->setCurrentIndex(index);
-    }
-    else if( handle == VRF )
-    {
-      int index = systemComboBox->findData(VRF);
-
-      OS_ASSERT(index >= 0);
-
-      systemComboBox->setCurrentIndex(index);
-    }
-    else
-    {
-      int index = systemComboBox->findData(handle);
-
-      if(index >= 0)
-      {
-        systemComboBox->setCurrentIndex(index);
-      }
-      else
-      {
-        systemComboBox->setCurrentIndex(systemComboBox->findData(SHW));
-      }
-    }
+    // Repopulate
+    repopulateSystemComboBox();
 
     // Show layout
+    QString handle = currentHandle();
+
 
     m_hvacSystemsView->hvacToolbarView->zoomInButton->show();
     m_hvacSystemsView->hvacToolbarView->zoomOutButton->show();
@@ -457,9 +507,17 @@ void HVACSystemsController::onObjectAdded(const WorkspaceObject& workspaceObject
 {
   std::vector<IddObjectType> types = systemComboBoxTypes();
 
-  if(std::find(types.begin(),types.end(),workspaceObject.cast<model::ModelObject>().iddObjectType()) != types.end())
+  auto newObjectIddType = workspaceObject.cast<model::ModelObject>().iddObjectType();
+  if(std::find(types.begin(),types.end(),newObjectIddType) != types.end())
   {
     updateLater();
+  }
+
+  // If it's a Loop, we trigger a repopulation of the System Combobox upon name change
+  if( (newObjectIddType == model::PlantLoop::iddObjectType() )
+      || (newObjectIddType == model::AirLoopHVAC::iddObjectType() ) ) {
+    std::cout << "Attaching name change for " << workspaceObject.briefDescription() << "\n";
+    workspaceObject.getImpl<detail::IdfObject_Impl>().get()->detail::IdfObject_Impl::onNameChange.connect<HVACSystemsController, &HVACSystemsController::repopulateSystemComboBox>(this);
   }
 }
 

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.hpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.hpp
@@ -125,6 +125,10 @@ class HVACSystemsController : public QObject, public Nano::Observer
 
   void update();
 
+  // Trigger repopulation of the SystemComboBox only
+  // Will be connected to Plant/AirLoop name IdfObject name change and also called by (full) update
+  void repopulateSystemComboBox();
+
   void addToModel(AddToModelEnum addToModelEnum);
 
   void onAddSystemClicked();

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.hpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.hpp
@@ -155,6 +155,8 @@ class HVACSystemsController : public QObject, public Nano::Observer
 
   private:
 
+  REGISTER_LOGGER("openstudio.openstudio_lib.HVACSystemsController");
+
   std::vector<IddObjectType> systemComboBoxTypes() const;
 
   QPointer<HVACSystemsView> m_hvacSystemsView;


### PR DESCRIPTION
Fix #535 - update system combo box on loop name change

I used debug message to make sure that I don't end up triggering the same slots repeatedly (it proved useful: I actually was initially, forgot to add `!` to a bool check, but I fixed it!)

Demo:

![demo](https://user-images.githubusercontent.com/5479063/45205579-d98a1d00-b282-11e8-9a71-b25d3368bac0.gif)



Review Assignee: @macumber 