### PR TITLE
Fix #2718 #2625 fields that became autosizable

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -21763,11 +21763,13 @@ OS:Sizing:System,
        \units m3/s
        \minimum 0
        \default autosize
-  N2, \field Minimum System Air Flow Ratio
+  N2, \field Central Heating Maximum System Air Flow Ratio
        \type real
+       \autosizable
        \required-field
        \minimum 0
        \maximum 1
+       \default autosize
   N3, \field Preheat Design Temperature
        \type real
        \required-field

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -23683,10 +23683,24 @@ OS:ZoneHVAC:WaterToAirHeatPump,
         \note cycling fan operation (fan cycles with cooling or heating coil). Schedule values greater
         \note than 0 denote constant fan operation (fan runs continually regardless of coil operation).
         \note The fan operating mode defaults to cycling fan operation if this field is left blank.
-   A14; \field Availability Manager List Name
+   A14, \field Availability Manager List Name
         \note Enter the name of an AvailabilityManagerAssignmentList object.
         \type object-list
         \object-list SystemAvailabilityManagerLists
+   A15, \field Heat Pump Coil Water Flow Mode
+        \type choice
+        \key Constant
+        \key Cycling
+        \key ConstantOnDemand
+        \default Cycling
+        \note used only when the heat pump coils are of the type WaterToAirHeatPump:EquationFit
+        \note Constant results in 100% water flow regardless of compressor PLR
+        \note Cycling results in water flow that matches compressor PLR
+        \note ConstantOnDemand results in 100% water flow whenever the coil is on, but is 0% whenever the coil has no load
+   A26; \field Design Specification ZoneHVAC Sizing Object Name
+        \note Enter the name of a DesignSpecificationZoneHVACSizing object.
+        \type object-list
+        \object-list DesignSpecificationZoneHVACSizingName
 
 OS:ZoneHVAC:UnitHeater,
        \min-fields 10

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10906,7 +10906,8 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
        \note is optional; if a value is entered, then it is used for sizing normal-action reheat coils.
        \note If both this field and the following field are entered, the larger result is used.
        \type real
-       \default 0.3
+       \autosizable
+       \default autosize
   N3, \field Fixed Minimum Air Flow Rate
        \note This field is used if the field Zone Minimum Air Flow Input Method is FixedFlowRate.
        \note If the field Zone Minimum Air Flow Input Method is Scheduled, then this field
@@ -10914,7 +10915,8 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
        \note If both this field and the previous field are entered, the larger result is used.
        \type real
        \units m3/s
-       \default 0.0
+       \autosizable
+       \default autosize
   A7, \field Minimum Air Flow Fraction Schedule Name
        \note This field is used if the field Zone Minimum Air Flow Input Method is Scheduled
        \note Schedule values are fractions, 0.0 to 1.0.

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10844,7 +10844,8 @@ OS:AirTerminal:SingleDuct:VAV:NoReheat,
        \note is optional; if a value is entered, then it is used for sizing normal-action reheat coils.
        \note If both this field and the following field are entered, the larger result is used.
        \type real
-       \default 0.3
+       \autosizable
+       \default autosize
   N3 , \field Fixed Minimum Air Flow Rate
        \note This field is used if the field Zone Minimum Air Flow Input Method is FixedFlowRate.
        \note If the field Zone Minimum Air Flow Input Method is Scheduled, then this field
@@ -10852,7 +10853,8 @@ OS:AirTerminal:SingleDuct:VAV:NoReheat,
        \note If both this field and the previous field are entered, the larger result is used.
        \type real
        \units m3/s
-       \default 0.0
+       \autosizable
+       \default autosize
   A7 , \field Minimum Air Flow Fraction Schedule Name
        \note This field is used if the field Zone Minimum Air Flow Input Method is Scheduled
        \note Schedule values are fractions, 0.0 to 1.0.

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -21769,10 +21769,9 @@ OS:Sizing:System,
        \default autosize
   N2, \field Central Heating Maximum System Air Flow Ratio
        \type real
-       \autosizable
-       \required-field
        \minimum 0
        \maximum 1
+       \autosizable
        \default autosize
   N3, \field Preheat Design Temperature
        \type real

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVNoReheat.cpp
@@ -166,13 +166,19 @@ boost::optional<IdfObject> ForwardTranslator::translateAirTerminalSingleDuctVAVN
     idfObject.setString(AirTerminal_SingleDuct_VAV_NoReheatFields::ZoneMinimumAirFlowInputMethod,s.get());
   }
 
-  // ConstantMinimumAirFlowFraction
-  value = modelObject.constantMinimumAirFlowFraction();
-  idfObject.setDouble(AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction,value.get());
+  // ConstantMinimumAirFlowFraction: autosizable
+  if( modelObject.isConstantMinimumAirFlowFractionAutosized() ) {
+    idfObject.setString(AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, "Autosize");
+  } else if( (value = modelObject.constantMinimumAirFlowFraction()) ) {
+    idfObject.setDouble(AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, value.get());
+  }
 
-  // FixedMinimumAirFlowRate
-  value = modelObject.fixedMinimumAirFlowRate();
-  idfObject.setDouble(AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate,value.get());
+  // FixedMinimumAirFlowRate: autosizable
+  if( modelObject.isFixedMinimumAirFlowRateAutosized() ) {
+    idfObject.setString(AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, "Autosize");
+  } else if( (value = modelObject.fixedMinimumAirFlowRate()) ) {
+    idfObject.setDouble(AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, value.get());
+  }
 
   // MinimumAirFlowFractionScheduleName
   boost::optional<Schedule> minAirFlowFractionSchedule = modelObject.minimumAirFlowFractionSchedule();

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVReheat.cpp
@@ -168,13 +168,19 @@ boost::optional<IdfObject> ForwardTranslator::translateAirTerminalSingleDuctVAVR
     idfObject.setString(AirTerminal_SingleDuct_VAV_ReheatFields::ZoneMinimumAirFlowInputMethod,s.get());
   }
 
-  // ConstantMinimumAirFlowFraction
-  value = modelObject.constantMinimumAirFlowFraction();
-  idfObject.setDouble(AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction,value.get());
+  // ConstantMinimumAirFlowFraction: autosizable
+  if( modelObject.isConstantMinimumAirFlowFractionAutosized() ) {
+    idfObject.setString(AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction, "Autosize");
+  } else if( (value = modelObject.constantMinimumAirFlowFraction()) ) {
+    idfObject.setDouble(AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction, value.get());
+  }
 
-  // FixedMinimumAirFlowRate
-  value = modelObject.fixedMinimumAirFlowRate();
-  idfObject.setDouble(AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate,value.get());
+  // FixedMinimumAirFlowRate: autosizable
+  if( modelObject.isFixedMinimumAirFlowRateAutosized() ) {
+    idfObject.setString(AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate, "Autosize");
+  } else if( (value = modelObject.fixedMinimumAirFlowRate()) ) {
+    idfObject.setDouble(AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate, value.get());
+  }
 
   // MinimumAirFlowFractionScheduleName
   boost::optional<Schedule> minAirFlowFractionSchedule = modelObject.minimumAirFlowFractionSchedule();

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSizingSystem.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSizingSystem.cpp
@@ -82,12 +82,12 @@ boost::optional<IdfObject> ForwardTranslator::translateSizingSystem( SizingSyste
     idfObject.setDouble(Sizing_SystemFields::DesignOutdoorAirFlowRate,value.get());
   }
 
-  // MinimumSystemAirFlowRatio
+  // CentralHeatingMaximumSystemAirFlowRatio
+  if( modelObject.isCentralHeatingMaximumSystemAirFlowRatioAutosized() ) {
+    idfObject.setString(Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio, "Autosize");
+  } else if( (value = modelObject.centralHeatingMaximumSystemAirFlowRatio()) ) {
+    idfObject.setDouble(Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio, value.get());
 
-  value = modelObject.minimumSystemAirFlowRatio();
-  if( value )
-  {
-    idfObject.setDouble(Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio,value.get());
   }
 
   // PreheatDesignTemperature

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
@@ -435,6 +435,13 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACWaterToAirHeatPum
     }
   }
 
+  // TODO: field 'Availability Manager List Name' isn't implemented
+
+  // HeatPumpCoilWaterFlowMode
+  idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode,modelObject.heatPumpCoilWaterFlowMode());
+
+  // TODO: field 'Design Specification ZoneHVAC Sizing' isn't implemented since the object isn't wrapped in SDK
+
   return idfObject;
 }
 

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVNoReheat.cpp
@@ -113,6 +113,11 @@ OptionalModelObject ReverseTranslator::translateAirTerminalSingleDuctVAVNoReheat
     if( value )
     {
       airTerminal->setConstantMinimumAirFlowFraction(value.get());
+    } else {
+      s = workspaceObject.getString(AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction);
+      if( s && (istringEqual(s.get(),"Autosize") || istringEqual(s.get(),"Autocalculate") ) ) {
+        airTerminal->autosizeMaximumAirFlowRate();
+      }
     }
 
     // FixedMinimumAirFlowRate
@@ -120,6 +125,11 @@ OptionalModelObject ReverseTranslator::translateAirTerminalSingleDuctVAVNoReheat
     if( value )
     {
       airTerminal->setFixedMinimumAirFlowRate(value.get());
+    } else {
+      s = workspaceObject.getString(AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate);
+      if( s && (istringEqual(s.get(),"Autosize") || istringEqual(s.get(),"Autocalculate") ) ) {
+        airTerminal->autosizeFixedMinimumAirFlowRate();
+      }
     }
 
     boost::optional<WorkspaceObject> _schedule;

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVReheat.cpp
@@ -127,6 +127,11 @@ OptionalModelObject ReverseTranslator::translateAirTerminalSingleDuctVAVReheat( 
     if( value )
     {
       airTerminal->setConstantMinimumAirFlowFraction(value.get());
+    } else {
+      s = workspaceObject.getString(AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction);
+      if( s && (istringEqual(s.get(),"Autosize") || istringEqual(s.get(),"Autocalculate") ) ) {
+        airTerminal->autosizeMaximumAirFlowRate();
+      }
     }
 
     // FixedMinimumAirFlowRate
@@ -134,6 +139,11 @@ OptionalModelObject ReverseTranslator::translateAirTerminalSingleDuctVAVReheat( 
     if( value )
     {
       airTerminal->setFixedMinimumAirFlowRate(value.get());
+    } else {
+      s = workspaceObject.getString(AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate);
+      if( s && (istringEqual(s.get(),"Autosize") || istringEqual(s.get(),"Autocalculate") ) ) {
+        airTerminal->autosizeFixedMinimumAirFlowRate();
+      }
     }
 
     boost::optional<WorkspaceObject> _schedule;

--- a/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateSizingSystem.cpp
+++ b/openstudiocore/src/energyplus/ReverseTranslator/ReverseTranslateSizingSystem.cpp
@@ -91,12 +91,12 @@ OptionalModelObject ReverseTranslator::translateSizingSystem( const WorkspaceObj
     sizingSystem.autosizeDesignOutdoorAirFlowRate();
   }
 
-  // MinimumSystemAirFlowRatio
+  // CentralHeatingMaximumSystemAirFlowRatio
 
   value = workspaceObject.getDouble(Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio);
   if( value )
   {
-    sizingSystem.setMinimumSystemAirFlowRatio(value.get());
+    sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(value.get());
   }
 
   // PreheatDesignTemperature

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
@@ -108,7 +108,6 @@ namespace detail {
 
   std::vector<ScheduleTypeKey> AirTerminalSingleDuctVAVNoReheat_Impl::getScheduleTypeKeys(const Schedule& schedule) const
   {
-    // TODO: Check schedule display names.
     std::vector<ScheduleTypeKey> result;
     UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
     UnsignedVector::const_iterator b(fieldIndices.begin()), e(fieldIndices.end());
@@ -227,6 +226,11 @@ namespace detail {
     return result;
   }
 
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::isConstantMinimumAirFlowFractionDefaulted() const {
+    return isEmpty(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction);
+  }
+
+
   boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::fixedMinimumAirFlowRate() const {
     return getDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate,true);
   }
@@ -238,6 +242,10 @@ namespace detail {
       result = openstudio::istringEqual(value.get(), "Autosize");
     }
     return result;
+  }
+
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::isFixedMinimumAirFlowRateDefaulted() const {
+    return isEmpty(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate);
   }
 
   boost::optional<Schedule> AirTerminalSingleDuctVAVNoReheat_Impl::minimumAirFlowFractionSchedule() const {
@@ -254,6 +262,11 @@ namespace detail {
     OS_ASSERT(result);
   }
 
+  void AirTerminalSingleDuctVAVNoReheat_Impl::resetConstantMinimumAirFlowFraction() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, "");
+    OS_ASSERT(result);
+  }
+
   bool AirTerminalSingleDuctVAVNoReheat_Impl::setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate) {
     bool result = setDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, fixedMinimumAirFlowRate);
     return result;
@@ -261,6 +274,11 @@ namespace detail {
 
   void AirTerminalSingleDuctVAVNoReheat_Impl::autosizeFixedMinimumAirFlowRate() {
     bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, "Autosize");
+    OS_ASSERT(result);
+  }
+
+  void AirTerminalSingleDuctVAVNoReheat_Impl::resetFixedMinimumAirFlowRate() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, "");
     OS_ASSERT(result);
   }
 
@@ -457,6 +475,15 @@ bool AirTerminalSingleDuctVAVNoReheat_Impl::addToNode(Node & node)
     return getAutosizedValue("Design Size Maximum Air Flow Rate", "m3/s");
   }
 
+  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::autosizedConstantMinimumAirFlowFraction() const {
+    return getAutosizedValue("Design Size Constant Minimum Air Flow Fraction", "");
+  }
+
+  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::autosizedFixedMinimumAirFlowRate() const {
+    return getAutosizedValue("Design Size Minimum Air Flow Rate", "m3/s");
+  }
+
+
   void AirTerminalSingleDuctVAVNoReheat_Impl::autosize() {
     autosizeMaximumAirFlowRate();
   }
@@ -466,6 +493,16 @@ bool AirTerminalSingleDuctVAVNoReheat_Impl::addToNode(Node & node)
     val = autosizedMaximumAirFlowRate();
     if (val) {
       setMaximumAirFlowRate(val.get());
+    }
+
+    val = autosizedConstantMinimumAirFlowFraction();
+    if (val) {
+      setConstantMinimumAirFlowFraction(val.get());
+    }
+
+    val = autosizedFixedMinimumAirFlowRate();
+    if (val) {
+      setFixedMinimumAirFlowRate(val.get());
     }
 
   }
@@ -518,8 +555,13 @@ boost::optional<std::string> AirTerminalSingleDuctVAVNoReheat::zoneMinimumAirFlo
 boost::optional<double> AirTerminalSingleDuctVAVNoReheat::constantMinimumAirFlowFraction() const {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->constantMinimumAirFlowFraction();
 }
+
 bool AirTerminalSingleDuctVAVNoReheat::isConstantMinimumAirFlowFractionAutosized() const {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isConstantMinimumAirFlowFractionAutosized();
+}
+
+bool AirTerminalSingleDuctVAVNoReheat::isConstantMinimumAirFlowFractionDefaulted() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isConstantMinimumAirFlowFractionDefaulted();
 }
 
 boost::optional<double> AirTerminalSingleDuctVAVNoReheat::fixedMinimumAirFlowRate() const {
@@ -528,6 +570,10 @@ boost::optional<double> AirTerminalSingleDuctVAVNoReheat::fixedMinimumAirFlowRat
 
 bool AirTerminalSingleDuctVAVNoReheat::isFixedMinimumAirFlowRateAutosized() const {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isFixedMinimumAirFlowRateAutosized();
+}
+
+bool AirTerminalSingleDuctVAVNoReheat::isFixedMinimumAirFlowRateDefaulted() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isFixedMinimumAirFlowRateDefaulted();
 }
 
 boost::optional<Schedule> AirTerminalSingleDuctVAVNoReheat::minimumAirFlowFractionSchedule() const {
@@ -566,12 +612,20 @@ void AirTerminalSingleDuctVAVNoReheat::autosizeConstantMinimumAirFlowFraction() 
   getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizeConstantMinimumAirFlowFraction();
 }
 
+void AirTerminalSingleDuctVAVNoReheat::resetConstantMinimumAirFlowFraction() {
+  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->resetConstantMinimumAirFlowFraction();
+}
+
 bool AirTerminalSingleDuctVAVNoReheat::setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate) {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->setFixedMinimumAirFlowRate(fixedMinimumAirFlowRate);
 }
 
 void AirTerminalSingleDuctVAVNoReheat::autosizeFixedMinimumAirFlowRate() {
   getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizeFixedMinimumAirFlowRate();
+}
+
+void AirTerminalSingleDuctVAVNoReheat::resetFixedMinimumAirFlowRate() {
+  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->resetFixedMinimumAirFlowRate();
 }
 
 bool AirTerminalSingleDuctVAVNoReheat::setMinimumAirFlowFractionSchedule(Schedule& schedule) {
@@ -592,15 +646,23 @@ bool AirTerminalSingleDuctVAVNoReheat::setControlForOutdoorAir(bool controlForOu
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->setControlForOutdoorAir(controlForOutdoorAir);
 }
 
+boost::optional<double> AirTerminalSingleDuctVAVNoReheat::autosizedMaximumAirFlowRate() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizedMaximumAirFlowRate();
+}
+
+boost::optional<double> AirTerminalSingleDuctVAVNoReheat::autosizedConstantMinimumAirFlowFraction() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizedConstantMinimumAirFlowFraction();
+}
+
+boost::optional<double> AirTerminalSingleDuctVAVNoReheat::autosizedFixedMinimumAirFlowRate() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizedFixedMinimumAirFlowRate();
+}
+
 /// @cond
 AirTerminalSingleDuctVAVNoReheat::AirTerminalSingleDuctVAVNoReheat(std::shared_ptr<detail::AirTerminalSingleDuctVAVNoReheat_Impl> impl)
   : StraightComponent(std::move(impl))
 {}
 /// @endcond
-
-  boost::optional<double> AirTerminalSingleDuctVAVNoReheat::autosizedMaximumAirFlowRate() const {
-    return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizedMaximumAirFlowRate();
-  }
 
 } // model
 } // openstudio

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
@@ -486,6 +486,8 @@ bool AirTerminalSingleDuctVAVNoReheat_Impl::addToNode(Node & node)
 
   void AirTerminalSingleDuctVAVNoReheat_Impl::autosize() {
     autosizeMaximumAirFlowRate();
+    autosizeConstantMinimumAirFlowFraction();
+    autosizeFixedMinimumAirFlowRate();
   }
 
   void AirTerminalSingleDuctVAVNoReheat_Impl::applySizingValues() {

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.cpp
@@ -155,25 +155,6 @@ namespace detail {
     return getString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ZoneMinimumAirFlowInputMethod,true);
   }
 
-  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::constantMinimumAirFlowFraction() const {
-    return getDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction,true);
-  }
-
-  bool AirTerminalSingleDuctVAVNoReheat_Impl::isConstantMinimumAirFlowFractionDefaulted() const {
-    return isEmpty(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction);
-  }
-
-  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::fixedMinimumAirFlowRate() const {
-    return getDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate,true);
-  }
-
-  bool AirTerminalSingleDuctVAVNoReheat_Impl::isFixedMinimumAirFlowRateDefaulted() const {
-    return isEmpty(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate);
-  }
-
-  boost::optional<Schedule> AirTerminalSingleDuctVAVNoReheat_Impl::minimumAirFlowFractionSchedule() const {
-    return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::MinimumAirFlowFractionScheduleName);
-  }
 
   bool AirTerminalSingleDuctVAVNoReheat_Impl::setAvailabilitySchedule(Schedule& schedule) {
     bool result = setSchedule(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::AvailabilityScheduleName,
@@ -232,39 +213,54 @@ namespace detail {
     OS_ASSERT(result);
   }
 
-  bool AirTerminalSingleDuctVAVNoReheat_Impl::setConstantMinimumAirFlowFraction(boost::optional<double> constantMinimumAirFlowFraction) {
-    bool result(false);
-    if (constantMinimumAirFlowFraction) {
-      result = setDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, constantMinimumAirFlowFraction.get());
+
+  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::constantMinimumAirFlowFraction() const {
+    return getDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction,true);
+  }
+
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::isConstantMinimumAirFlowFractionAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
-    else {
-      resetConstantMinimumAirFlowFraction();
-      result = true;
-    }
-    OS_ASSERT(result);
     return result;
   }
 
-  void AirTerminalSingleDuctVAVNoReheat_Impl::resetConstantMinimumAirFlowFraction() {
-    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, "");
-    OS_ASSERT(result);
+  boost::optional<double> AirTerminalSingleDuctVAVNoReheat_Impl::fixedMinimumAirFlowRate() const {
+    return getDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate,true);
   }
 
-  bool AirTerminalSingleDuctVAVNoReheat_Impl::setFixedMinimumAirFlowRate(boost::optional<double> fixedMinimumAirFlowRate) {
-    bool result(false);
-    if (fixedMinimumAirFlowRate) {
-      result = setDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, fixedMinimumAirFlowRate.get());
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::isFixedMinimumAirFlowRateAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
-    else {
-      resetFixedMinimumAirFlowRate();
-      result = true;
-    }
-    OS_ASSERT(result);
     return result;
   }
 
-  void AirTerminalSingleDuctVAVNoReheat_Impl::resetFixedMinimumAirFlowRate() {
-    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, "");
+  boost::optional<Schedule> AirTerminalSingleDuctVAVNoReheat_Impl::minimumAirFlowFractionSchedule() const {
+    return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::MinimumAirFlowFractionScheduleName);
+  }
+
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::setConstantMinimumAirFlowFraction(double constantMinimumAirFlowFraction) {
+    bool result = setDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, constantMinimumAirFlowFraction);
+    return result;
+  }
+
+  void AirTerminalSingleDuctVAVNoReheat_Impl::autosizeConstantMinimumAirFlowFraction() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::ConstantMinimumAirFlowFraction, "Autosize");
+    OS_ASSERT(result);
+  }
+
+  bool AirTerminalSingleDuctVAVNoReheat_Impl::setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate) {
+    bool result = setDouble(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, fixedMinimumAirFlowRate);
+    return result;
+  }
+
+  void AirTerminalSingleDuctVAVNoReheat_Impl::autosizeFixedMinimumAirFlowRate() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_NoReheatFields::FixedMinimumAirFlowRate, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -522,16 +518,16 @@ boost::optional<std::string> AirTerminalSingleDuctVAVNoReheat::zoneMinimumAirFlo
 boost::optional<double> AirTerminalSingleDuctVAVNoReheat::constantMinimumAirFlowFraction() const {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->constantMinimumAirFlowFraction();
 }
-bool AirTerminalSingleDuctVAVNoReheat::isConstantMinimumAirFlowFractionDefaulted() const {
-  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isConstantMinimumAirFlowFractionDefaulted();
+bool AirTerminalSingleDuctVAVNoReheat::isConstantMinimumAirFlowFractionAutosized() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isConstantMinimumAirFlowFractionAutosized();
 }
 
 boost::optional<double> AirTerminalSingleDuctVAVNoReheat::fixedMinimumAirFlowRate() const {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->fixedMinimumAirFlowRate();
 }
 
-bool AirTerminalSingleDuctVAVNoReheat::isFixedMinimumAirFlowRateDefaulted() const {
-  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isFixedMinimumAirFlowRateDefaulted();
+bool AirTerminalSingleDuctVAVNoReheat::isFixedMinimumAirFlowRateAutosized() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->isFixedMinimumAirFlowRateAutosized();
 }
 
 boost::optional<Schedule> AirTerminalSingleDuctVAVNoReheat::minimumAirFlowFractionSchedule() const {
@@ -566,16 +562,16 @@ bool AirTerminalSingleDuctVAVNoReheat::setConstantMinimumAirFlowFraction(double 
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->setConstantMinimumAirFlowFraction(constantMinimumAirFlowFraction);
 }
 
-void AirTerminalSingleDuctVAVNoReheat::resetConstantMinimumAirFlowFraction() {
-  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->resetConstantMinimumAirFlowFraction();
+void AirTerminalSingleDuctVAVNoReheat::autosizeConstantMinimumAirFlowFraction() {
+  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizeConstantMinimumAirFlowFraction();
 }
 
 bool AirTerminalSingleDuctVAVNoReheat::setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate) {
   return getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->setFixedMinimumAirFlowRate(fixedMinimumAirFlowRate);
 }
 
-void AirTerminalSingleDuctVAVNoReheat::resetFixedMinimumAirFlowRate() {
-  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->resetFixedMinimumAirFlowRate();
+void AirTerminalSingleDuctVAVNoReheat::autosizeFixedMinimumAirFlowRate() {
+  getImpl<detail::AirTerminalSingleDuctVAVNoReheat_Impl>()->autosizeFixedMinimumAirFlowRate();
 }
 
 bool AirTerminalSingleDuctVAVNoReheat::setMinimumAirFlowFractionSchedule(Schedule& schedule) {

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
@@ -75,11 +75,11 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
 
   boost::optional<double> constantMinimumAirFlowFraction() const;
 
-  bool isConstantMinimumAirFlowFractionDefaulted() const;
+  bool isConstantMinimumAirFlowFractionAutosized() const;
 
   boost::optional<double> fixedMinimumAirFlowRate() const;
 
-  bool isFixedMinimumAirFlowRateDefaulted() const;
+  bool isFixedMinimumAirFlowRateAutosized() const;
 
   boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
@@ -101,11 +101,11 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
 
   bool setConstantMinimumAirFlowFraction(double constantMinimumAirFlowFraction);
 
-  void resetConstantMinimumAirFlowFraction();
+  void autosizeConstantMinimumAirFlowFraction();
 
   bool setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate);
 
-  void resetFixedMinimumAirFlowRate();
+  void autosizeFixedMinimumAirFlowRate();
 
   bool setMinimumAirFlowFractionSchedule(Schedule& schedule);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
@@ -32,6 +32,7 @@
 
 #include "ModelAPI.hpp"
 #include "StraightComponent.hpp"
+#include "../utilities/core/Deprecated.hpp"
 
 namespace openstudio {
 namespace model {
@@ -74,12 +75,12 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
   boost::optional<std::string> zoneMinimumAirFlowInputMethod() const;
 
   boost::optional<double> constantMinimumAirFlowFraction() const;
-
   bool isConstantMinimumAirFlowFractionAutosized() const;
+  bool isConstantMinimumAirFlowFractionDefaulted() const;
 
   boost::optional<double> fixedMinimumAirFlowRate() const;
-
   bool isFixedMinimumAirFlowRateAutosized() const;
+  bool isFixedMinimumAirFlowRateDefaulted() const;
 
   boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
@@ -105,12 +106,13 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
   void resetZoneMinimumAirFlowInputMethod();
 
   bool setConstantMinimumAirFlowFraction(double constantMinimumAirFlowFraction);
-
   void autosizeConstantMinimumAirFlowFraction();
+  void resetConstantMinimumAirFlowFraction();
 
   bool setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate);
-
   void autosizeFixedMinimumAirFlowRate();
+  void resetFixedMinimumAirFlowRate();
+
 
   bool setMinimumAirFlowFractionSchedule(Schedule& schedule);
 
@@ -122,9 +124,9 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
   /** @name Other */
   //@{
 
-  boost::optional<double> autosizedMaximumAirFlowRate() const ;
-
-
+  boost::optional<double> autosizedMaximumAirFlowRate() const;
+  boost::optional<double> autosizedConstantMinimumAirFlowFraction() const;
+  boost::optional<double> autosizedFixedMinimumAirFlowRate() const;
 
   //@}
  protected:

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat.hpp
@@ -83,6 +83,11 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
 
   boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
+  /** If true, OpenStudio will attach the DesignSpecificationOutdoorAir object associated
+    * with the terminal's zone on export to EnergyPlus idf format.
+    * This field replaces the functionality of the EnergyPlus field: Design Specification Outdoor Air Object Name.*/
+  bool controlForOutdoorAir() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -110,11 +115,6 @@ class MODEL_API AirTerminalSingleDuctVAVNoReheat : public StraightComponent {
   bool setMinimumAirFlowFractionSchedule(Schedule& schedule);
 
   void resetMinimumAirFlowFractionSchedule();
-
-  /** If true, OpenStudio will attach the DesignSpecificationOutdoorAir object associated
-    * with the terminal's zone on export to EnergyPlus idf format.
-    * This field replaces the functionality of the EnergyPlus field: Design Specification Outdoor Air Object Name.*/
-  bool controlForOutdoorAir() const;
 
   bool setControlForOutdoorAir(bool controlForOutdoorAir);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat_Impl.hpp
@@ -96,13 +96,17 @@ namespace detail {
 
     boost::optional<double> constantMinimumAirFlowFraction() const;
     bool isConstantMinimumAirFlowFractionAutosized() const;
+    bool isConstantMinimumAirFlowFractionDefaulted() const;
 
     boost::optional<double> fixedMinimumAirFlowRate() const;
     bool isFixedMinimumAirFlowRateAutosized() const;
+    bool isFixedMinimumAirFlowRateDefaulted() const;
 
     boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
-    boost::optional<double> autosizedMaximumAirFlowRate() const ;
+    boost::optional<double> autosizedMaximumAirFlowRate() const;
+    boost::optional<double> autosizedConstantMinimumAirFlowFraction() const;
+    boost::optional<double> autosizedFixedMinimumAirFlowRate() const;
 
     virtual void autosize() override;
 
@@ -126,9 +130,11 @@ namespace detail {
 
     bool setConstantMinimumAirFlowFraction(double constantMinimumAirFlowFraction);
     void autosizeConstantMinimumAirFlowFraction();
+    void resetConstantMinimumAirFlowFraction();
 
     bool setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate);
     void autosizeFixedMinimumAirFlowRate();
+    void resetFixedMinimumAirFlowRate();
 
     bool setMinimumAirFlowFractionSchedule(Schedule& schedule);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVNoReheat_Impl.hpp
@@ -43,19 +43,6 @@ namespace detail {
   /** AirTerminalSingleDuctVAVNoReheat_Impl is a StraightComponent_Impl that is the implementation class for AirTerminalSingleDuctVAVNoReheat.*/
   class MODEL_API AirTerminalSingleDuctVAVNoReheat_Impl : public StraightComponent_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -99,7 +86,6 @@ namespace detail {
     /** @name Getters */
     //@{
 
-    // TODO: Check return type. From object lists, some candidates are: Schedule.
     Schedule availabilitySchedule() const;
 
     boost::optional<double> maximumAirFlowRate() const;
@@ -109,27 +95,23 @@ namespace detail {
     boost::optional<std::string> zoneMinimumAirFlowInputMethod() const;
 
     boost::optional<double> constantMinimumAirFlowFraction() const;
-
-    bool isConstantMinimumAirFlowFractionDefaulted() const;
+    bool isConstantMinimumAirFlowFractionAutosized() const;
 
     boost::optional<double> fixedMinimumAirFlowRate() const;
+    bool isFixedMinimumAirFlowRateAutosized() const;
 
-    bool isFixedMinimumAirFlowRateDefaulted() const;
-
-    // TODO: Check return type. From object lists, some candidates are: Schedule.
     boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
-  boost::optional<double> autosizedMaximumAirFlowRate() const ;
+    boost::optional<double> autosizedMaximumAirFlowRate() const ;
 
-  virtual void autosize() override;
+    virtual void autosize() override;
 
-  virtual void applySizingValues() override;
+    virtual void applySizingValues() override;
 
     //@}
     /** @name Setters */
     //@{
 
-    // TODO: Check argument type. From object lists, some candidates are: Schedule.
     bool setAvailabilitySchedule(Schedule& schedule);
 
     bool setMaximumAirFlowRate(boost::optional<double> maximumAirFlowRate);
@@ -142,13 +124,11 @@ namespace detail {
 
     void resetZoneMinimumAirFlowInputMethod();
 
-    bool setConstantMinimumAirFlowFraction(boost::optional<double> constantMinimumAirFlowFraction);
+    bool setConstantMinimumAirFlowFraction(double constantMinimumAirFlowFraction);
+    void autosizeConstantMinimumAirFlowFraction();
 
-    void resetConstantMinimumAirFlowFraction();
-
-    bool setFixedMinimumAirFlowRate(boost::optional<double> fixedMinimumAirFlowRate);
-
-    void resetFixedMinimumAirFlowRate();
+    bool setFixedMinimumAirFlowRate(double fixedMinimumAirFlowRate);
+    void autosizeFixedMinimumAirFlowRate();
 
     bool setMinimumAirFlowFractionSchedule(Schedule& schedule);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -358,9 +358,18 @@ namespace detail{
     }
   }
 
-  double AirTerminalSingleDuctVAVReheat_Impl::constantMinimumAirFlowFraction()
+  boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::constantMinimumAirFlowFraction() const
   {
-    return this->getDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction).get();
+    return getDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction);
+  }
+
+  bool AirTerminalSingleDuctVAVReheat_Impl::isConstantMinimumAirFlowFractionAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
   }
 
   bool AirTerminalSingleDuctVAVReheat_Impl::setConstantMinimumAirFlowFraction( double value )
@@ -368,14 +377,33 @@ namespace detail{
     return this->setDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction,value);
   }
 
-  double AirTerminalSingleDuctVAVReheat_Impl::fixedMinimumAirFlowRate()
+  void AirTerminalSingleDuctVAVReheat_Impl::autosizeConstantMinimumAirFlowFraction() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ConstantMinimumAirFlowFraction, "Autosize");
+    OS_ASSERT(result);
+  }
+
+  boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::fixedMinimumAirFlowRate() const
   {
-    return this->getDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate).get();
+    return getDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate);
+  }
+
+  bool AirTerminalSingleDuctVAVReheat_Impl::isFixedMinimumAirFlowRateAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
   }
 
   bool AirTerminalSingleDuctVAVReheat_Impl::setFixedMinimumAirFlowRate( double value )
   {
     return this->setDouble(OS_AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate,value);
+  }
+
+  void AirTerminalSingleDuctVAVReheat_Impl::autosizeFixedMinimumAirFlowRate() {
+    bool result = setString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::FixedMinimumAirFlowRate, "Autosize");
+    OS_ASSERT(result);
   }
 
   boost::optional<Schedule> AirTerminalSingleDuctVAVReheat_Impl::minimumAirFlowFractionSchedule() const
@@ -821,9 +849,15 @@ bool AirTerminalSingleDuctVAVReheat::setZoneMinimumAirFlowMethod( std::string va
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setZoneMinimumAirFlowMethod(value);
 }
 
-double AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction()
+boost::optional<double> AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction() const
 {
+  // TODO: remove in 2 versions
+  LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->constantMinimumAirFlowFraction();
+}
+
+bool AirTerminalSingleDuctVAVReheat::isConstantMinimumAirFlowFractionAutosized() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->isConstantMinimumAirFlowFractionAutosized();
 }
 
 bool AirTerminalSingleDuctVAVReheat::setConstantMinimumAirFlowFraction( double value )
@@ -831,15 +865,30 @@ bool AirTerminalSingleDuctVAVReheat::setConstantMinimumAirFlowFraction( double v
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setConstantMinimumAirFlowFraction(value);
 }
 
-double AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate()
+void AirTerminalSingleDuctVAVReheat::autosizeConstantMinimumAirFlowFraction() {
+  getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizeConstantMinimumAirFlowFraction();
+}
+
+
+ boost::optional<double> AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate() const
 {
+  LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->fixedMinimumAirFlowRate();
+}
+
+bool AirTerminalSingleDuctVAVReheat::isFixedMinimumAirFlowRateAutosized() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->isFixedMinimumAirFlowRateAutosized();
 }
 
 bool AirTerminalSingleDuctVAVReheat::setFixedMinimumAirFlowRate( double value )
 {
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setFixedMinimumAirFlowRate(value);
 }
+
+void AirTerminalSingleDuctVAVReheat::autosizeFixedMinimumAirFlowRate() {
+  getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizeFixedMinimumAirFlowRate();
+}
+
 
 boost::optional<Schedule> AirTerminalSingleDuctVAVReheat::minimumAirFlowFractionSchedule() const
 {

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -739,6 +739,8 @@ namespace detail{
 
   void AirTerminalSingleDuctVAVReheat_Impl::autosize() {
     autosizeMaximumAirFlowRate();
+    autosizeConstantMinimumAirFlowFraction();
+    autosizeFixedMinimumAirFlowRate();
     autosizeMaximumHotWaterOrSteamFlowRate();
     autosizeMaximumFlowPerZoneFloorAreaDuringReheat();
     autosizeMaximumFlowFractionDuringReheat();

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -717,6 +717,14 @@ namespace detail{
     return getAutosizedValue("Design Size Maximum Air Flow Rate", "m3/s");
   }
 
+  boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::autosizedConstantMinimumAirFlowFraction() const {
+    return getAutosizedValue("Design Size Constant Minimum Air Flow Fraction", "");
+  }
+
+  boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::autosizedFixedMinimumAirFlowRate() const {
+    return getAutosizedValue("Design Size Minimum Air Flow Rate", "m3/s");
+  }
+
   boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::autosizedMaximumHotWaterOrSteamFlowRate() const {
     return getAutosizedValue("Design Size Maximum Reheat Water Flow Rate", "m3/s");
   }
@@ -743,6 +751,16 @@ namespace detail{
       setMaximumAirFlowRate(val.get());
     }
 
+    val = autosizedConstantMinimumAirFlowFraction();
+    if (val) {
+      setConstantMinimumAirFlowFraction(val.get());
+    }
+
+    val = autosizedFixedMinimumAirFlowRate();
+    if (val) {
+      setFixedMinimumAirFlowRate(val.get());
+    }
+
     val = autosizedMaximumHotWaterOrSteamFlowRate();
     if (val) {
       setMaximumHotWaterOrSteamFlowRate(val.get());
@@ -757,6 +775,8 @@ namespace detail{
     if (val) {
       setMaximumFlowFractionDuringReheat(val.get());
     }
+
+
 
   }
 
@@ -1063,6 +1083,14 @@ boost::optional<AirflowNetworkEquivalentDuct> AirTerminalSingleDuctVAVReheat::ai
 
 boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumAirFlowRate() const {
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumAirFlowRate();
+}
+
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedConstantMinimumAirFlowFraction() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedConstantMinimumAirFlowFraction();
+}
+
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedFixedMinimumAirFlowRate() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedFixedMinimumAirFlowRate();
 }
 
 boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumHotWaterOrSteamFlowRate() const {

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -53,6 +53,10 @@
 #include "../utilities/core/Compare.hpp"
 #include "../utilities/core/Assert.hpp"
 
+// TODO: only needed for API warning
+#include <OpenStudio.hxx>
+
+
 namespace openstudio {
 
 namespace model {
@@ -851,8 +855,14 @@ bool AirTerminalSingleDuctVAVReheat::setZoneMinimumAirFlowMethod( std::string va
 
 boost::optional<double> AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction() const
 {
-  // TODO: remove in 2 versions
-  LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
+  if( VersionString( openStudioVersion() ) < VersionString("2.8.0") ) {
+    // TODO: remove in 2 versions
+    LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
+  } else {
+    // TODO: remove in 2 versions. here's a message and a Debug crash to remind you
+    LOG(Debug, "Please go tell a developper to remove the warning in AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction");
+    OS_ASSERT(false);
+  }
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->constantMinimumAirFlowFraction();
 }
 
@@ -870,9 +880,16 @@ void AirTerminalSingleDuctVAVReheat::autosizeConstantMinimumAirFlowFraction() {
 }
 
 
- boost::optional<double> AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate() const
+boost::optional<double> AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate() const
 {
-  LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
+  if( VersionString( openStudioVersion() ) < VersionString("2.8.0") ) {
+    // TODO: remove in 2 versions
+    LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, it now returns an Optional double");
+  } else {
+    // TODO: remove in 2 versions. here's a message and a Debug crash to remind you
+    LOG(Debug, "Please go tell a developper to remove the warning AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate");
+    OS_ASSERT(false);
+  }
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->fixedMinimumAirFlowRate();
 }
 
@@ -1044,21 +1061,21 @@ boost::optional<AirflowNetworkEquivalentDuct> AirTerminalSingleDuctVAVReheat::ai
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->airflowNetworkEquivalentDuct();
 }
 
-  boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumAirFlowRate() const {
-    return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumAirFlowRate();
-  }
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumAirFlowRate() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumAirFlowRate();
+}
 
-  boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumHotWaterOrSteamFlowRate() const {
-    return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumHotWaterOrSteamFlowRate();
-  }
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumHotWaterOrSteamFlowRate() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumHotWaterOrSteamFlowRate();
+}
 
-  boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const {
-    return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumFlowPerZoneFloorAreaDuringReheat();
-  }
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumFlowPerZoneFloorAreaDuringReheat();
+}
 
-  boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumFlowFractionDuringReheat() const {
-    return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumFlowFractionDuringReheat();
-  }
+boost::optional<double> AirTerminalSingleDuctVAVReheat::autosizedMaximumFlowFractionDuringReheat() const {
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->autosizedMaximumFlowFractionDuringReheat();
+}
 
 } // model
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.hpp
@@ -199,13 +199,17 @@ class MODEL_API AirTerminalSingleDuctVAVReheat : public StraightComponent {
 
   bool setControlForOutdoorAir(bool controlForOutdoorAir);
 
-  boost::optional<double> autosizedMaximumAirFlowRate() const ;
+  boost::optional<double> autosizedMaximumAirFlowRate() const;
 
-  boost::optional<double> autosizedMaximumHotWaterOrSteamFlowRate() const ;
+  boost::optional<double> autosizedConstantMinimumAirFlowFraction() const;
 
-  boost::optional<double> autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const ;
+  boost::optional<double> autosizedFixedMinimumAirFlowRate() const;
 
-  boost::optional<double> autosizedMaximumFlowFractionDuringReheat() const ;
+  boost::optional<double> autosizedMaximumHotWaterOrSteamFlowRate() const;
+
+  boost::optional<double> autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const;
+
+  boost::optional<double> autosizedMaximumFlowFractionDuringReheat() const;
 
 
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat.hpp
@@ -92,16 +92,29 @@ class MODEL_API AirTerminalSingleDuctVAVReheat : public StraightComponent {
   bool setZoneMinimumAirFlowMethod( std::string value );
 
   /** Returns the value of the ConstantMinimumAirFlowFraction field. */
-  double constantMinimumAirFlowFraction();
+  boost::optional<double> constantMinimumAirFlowFraction() const;
 
   /** Sets the value of the ConstantMinimumAirFlowFraction field. */
   bool setConstantMinimumAirFlowFraction( double value );
 
+  /** Sets the value of the ConstantMinimumAirFlowFraction field to Autosize */
+  void autosizeConstantMinimumAirFlowFraction();
+
+  /** Returns true of the ConstantMinimumAirFlowFraction field is set to Autosize */
+  bool isConstantMinimumAirFlowFractionAutosized() const;
+
   /** Returns the value of the FixedMinimumAirFlowRate field. */
-  double fixedMinimumAirFlowRate();
+  boost::optional<double> fixedMinimumAirFlowRate() const;
 
   /** Sets the value of the FixedMinimumAirFlowRate field. */
   bool setFixedMinimumAirFlowRate( double value );
+
+  /** Sets the value of the FixedMinimumAirFlowRate field to Autosize */
+  void autosizeFixedMinimumAirFlowRate();
+
+  /** Returns true of the FixedMinimumAirFlowRate field is set to Autosize */
+  bool isFixedMinimumAirFlowRateAutosized() const;
+
 
   /** Returns the Schedule referred to by the MinimumAirFlowFractionScheduleName field. */
   boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
@@ -198,7 +211,7 @@ class MODEL_API AirTerminalSingleDuctVAVReheat : public StraightComponent {
 
   /** Creates a new equivalent duct object if an object is not already attached. */
   AirflowNetworkEquivalentDuct getAirflowNetworkEquivalentDuct(double length, double diameter);
-  
+
   /** Returns the attached equivalent duct object, if any. */
   boost::optional<AirflowNetworkEquivalentDuct> airflowNetworkEquivalentDuct() const;
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
@@ -165,17 +165,21 @@ namespace detail {
 
     bool setControlForOutdoorAir(bool controlForOutdoorAir);
 
-  boost::optional<double> autosizedMaximumAirFlowRate() const ;
+    boost::optional<double> autosizedMaximumAirFlowRate() const;
 
-  boost::optional<double> autosizedMaximumHotWaterOrSteamFlowRate() const ;
+    boost::optional<double> autosizedConstantMinimumAirFlowFraction() const;
 
-  boost::optional<double> autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const ;
+    boost::optional<double> autosizedFixedMinimumAirFlowRate() const;
 
-  boost::optional<double> autosizedMaximumFlowFractionDuringReheat() const ;
+    boost::optional<double> autosizedMaximumHotWaterOrSteamFlowRate() const;
 
-  virtual void autosize() override;
+    boost::optional<double> autosizedMaximumFlowPerZoneFloorAreaDuringReheat() const;
 
-  virtual void applySizingValues() override;
+    boost::optional<double> autosizedMaximumFlowFractionDuringReheat() const;
+
+    virtual void autosize() override;
+
+    virtual void applySizingValues() override;
 
     AirflowNetworkEquivalentDuct getAirflowNetworkEquivalentDuct(double length, double diameter);
 

--- a/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
+++ b/openstudiocore/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
@@ -101,13 +101,15 @@ namespace detail {
 
     bool setZoneMinimumAirFlowMethod( std::string value );
 
-    double constantMinimumAirFlowFraction();
-
+    boost::optional<double> constantMinimumAirFlowFraction() const;
+    bool isConstantMinimumAirFlowFractionAutosized() const;
     bool setConstantMinimumAirFlowFraction( double value );
+    void autosizeConstantMinimumAirFlowFraction();
 
-    double fixedMinimumAirFlowRate();
-
+    boost::optional<double> fixedMinimumAirFlowRate() const;
+    bool isFixedMinimumAirFlowRateAutosized() const;
     bool setFixedMinimumAirFlowRate( double value );
+    void autosizeFixedMinimumAirFlowRate();
 
     boost::optional<Schedule> minimumAirFlowFractionSchedule() const;
 
@@ -176,7 +178,7 @@ namespace detail {
   virtual void applySizingValues() override;
 
     AirflowNetworkEquivalentDuct getAirflowNetworkEquivalentDuct(double length, double diameter);
-    
+
     boost::optional<AirflowNetworkEquivalentDuct> airflowNetworkEquivalentDuct() const;
 
    private:

--- a/openstudiocore/src/model/AirflowNetworkEquivalentDuct_Impl.hpp
+++ b/openstudiocore/src/model/AirflowNetworkEquivalentDuct_Impl.hpp
@@ -64,9 +64,9 @@ namespace detail {
     /** @name Virtual Methods */
     //@{
 
-    virtual const std::vector<std::string>& outputVariableNames() const;
+    virtual const std::vector<std::string>& outputVariableNames() const override;
 
-    virtual IddObjectType iddObjectType() const;
+    virtual IddObjectType iddObjectType() const override;
 
     virtual boost::optional<ModelObject> componentModelObject() const override;
 

--- a/openstudiocore/src/model/HVACTemplates.cpp
+++ b/openstudiocore/src/model/HVACTemplates.cpp
@@ -342,7 +342,7 @@ Loop addSystemType3(Model & model)
   //set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn("Sensible");
   sizingSystem.autosizeDesignOutdoorAirFlowRate();
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0);
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0);
   sizingSystem.setPreheatDesignTemperature(7.0);
   sizingSystem.setPreheatDesignHumidityRatio(0.008);
   sizingSystem.setPrecoolDesignTemperature(12.8);
@@ -408,7 +408,7 @@ Loop addSystemType4(Model & model)
   //set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn("Sensible");
   sizingSystem.autosizeDesignOutdoorAirFlowRate();
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0);
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0);
   sizingSystem.setPreheatDesignTemperature(7.0);
   sizingSystem.setPreheatDesignHumidityRatio(0.008);
   sizingSystem.setPrecoolDesignTemperature(12.8);
@@ -916,7 +916,7 @@ Loop addSystemType9(Model & model)
   //set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn("Sensible");
   sizingSystem.autosizeDesignOutdoorAirFlowRate();
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0);
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0);
   sizingSystem.setPreheatDesignTemperature(7.0);
   sizingSystem.setPreheatDesignHumidityRatio(0.008);
   sizingSystem.setPrecoolDesignTemperature(12.8);
@@ -978,7 +978,7 @@ Loop addSystemType10(Model & model)
   //set the default parameters correctly for a constant volume system with no VAV terminals
   sizingSystem.setTypeofLoadtoSizeOn("Sensible");
   sizingSystem.autosizeDesignOutdoorAirFlowRate();
-  sizingSystem.setMinimumSystemAirFlowRatio(1.0);
+  sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(1.0);
   sizingSystem.setPreheatDesignTemperature(7.0);
   sizingSystem.setPreheatDesignHumidityRatio(0.008);
   sizingSystem.setPrecoolDesignTemperature(12.8);

--- a/openstudiocore/src/model/ModelObject.hpp
+++ b/openstudiocore/src/model/ModelObject.hpp
@@ -369,8 +369,8 @@ public:
 
 private:
 
-  std::string m_controlTypeName;
   std::string m_componentTypeName;
+  std::string m_controlTypeName;
 };
 
 /// optional ModelObject

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -917,6 +917,7 @@ bool SizingSystem_Impl::setAirLoopHVAC(const AirLoopHVAC & airLoopHVAC)
     autosizeDesignOutdoorAirFlowRate();
     autosizeCoolingDesignCapacity();
     autosizeHeatingDesignCapacity();
+    autosizeCentralHeatingMaximumSystemAirFlowRatio();
   }
 
   void SizingSystem_Impl::applySizingValues() {
@@ -936,6 +937,10 @@ bool SizingSystem_Impl::setAirLoopHVAC(const AirLoopHVAC & airLoopHVAC)
       setHeatingDesignCapacity(val.get());
     }
 
+    val = autosizedCentralHeatingMaximumSystemAirFlowRatio();
+    if (val) {
+      setCentralHeatingMaximumSystemAirFlowRatio(val.get());
+    }
   }
 
   std::vector<EMSActuatorNames> SizingSystem_Impl::emsActuatorNames() const {

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -902,7 +902,7 @@ bool SizingSystem_Impl::setAirLoopHVAC(const AirLoopHVAC & airLoopHVAC)
     valQuery << "WHERE CompType='AirLoopHVAC' ";
     valQuery << "AND Description='User Heating Air Flow Ratio' ";
     valQuery << "AND Units='' ";
-    valQuery << "AND CompName='" << parAirLoop.nameString() << "' ";
+    valQuery << "AND CompName='" << sqlName << "' ";
     boost::optional<double> val = model().sqlFile().get().execAndReturnFirstDouble(valQuery.str());
     // Check if the query succeeded
     if (val) {

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -1509,6 +1509,10 @@ SizingSystem::SizingSystem(std::shared_ptr<detail::SizingSystem_Impl> impl)
     getImpl<detail::SizingSystem_Impl>()->autosizeCentralHeatingMaximumSystemAirFlowRatio();
   }
 
+  boost::optional<double> SizingSystem::autosizedCentralHeatingMaximumSystemAirFlowRatio() const {
+    return getImpl<detail::SizingSystem_Impl>()->autosizedCentralHeatingMaximumSystemAirFlowRatio();
+  }
+
   // DEPRECATED: TODO REMOVED in 2.6.2, REMOVE FROM API In the FUTURE
   boost::optional<double> SizingSystem::minimumSystemAirFlowRatio() const {
     LOG(Warn, "SizingSystem::minimumSystemAirFlowRatio has been deprecated and will be removed in a future release, please use SizingSystem::centralHeatingMaximumSystemAirFlowRatio");

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -107,10 +107,29 @@ bool SizingSystem_Impl::isDesignOutdoorAirFlowRateAutosized() const {
   return result;
 }
 
-double SizingSystem_Impl::minimumSystemAirFlowRatio() const {
-  boost::optional<double> value = getDouble(OS_Sizing_SystemFields::MinimumSystemAirFlowRatio,true);
+boost::optional<double> SizingSystem_Impl::centralHeatingMaximumSystemAirFlowRatio() const {
+  boost::optional<double> value = getDouble(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio,true);
   OS_ASSERT(value);
   return value.get();
+}
+
+bool SizingSystem_Impl::setCentralHeatingMaximumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
+  bool result = setDouble(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio, centralHeatingMaximumSystemAirFlowRatio);
+  return result;
+}
+
+bool SizingSystem_Impl::isCentralHeatingMaximumSystemAirFlowRatioAutosized() const {
+  bool result = false;
+  boost::optional<std::string> value = getString(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio, true);
+  if (value) {
+    result = openstudio::istringEqual(value.get(), "Autosize");
+  }
+  return result;
+}
+
+void SizingSystem_Impl::autosizeCentralHeatingMaximumSystemAirFlowRatio() {
+  bool result = setString(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio, "Autosize");
+  OS_ASSERT(result);
 }
 
 double SizingSystem_Impl::preheatDesignTemperature() const {
@@ -393,11 +412,6 @@ void SizingSystem_Impl::resetDesignOutdoorAirFlowRate() {
 void SizingSystem_Impl::autosizeDesignOutdoorAirFlowRate() {
   bool result = setString(OS_Sizing_SystemFields::DesignOutdoorAirFlowRate, "Autosize");
   OS_ASSERT(result);
-}
-
-bool SizingSystem_Impl::setMinimumSystemAirFlowRatio(double minimumSystemAirFlowRatio) {
-  bool result = setDouble(OS_Sizing_SystemFields::MinimumSystemAirFlowRatio, minimumSystemAirFlowRatio);
-  return result;
 }
 
 bool SizingSystem_Impl::setPreheatDesignTemperature(double preheatDesignTemperature) {
@@ -930,7 +944,11 @@ SizingSystem::SizingSystem(const Model& model, const AirLoopHVAC & airLoopHVAC)
 
   setTypeofLoadtoSizeOn("Sensible");
   autosizeDesignOutdoorAirFlowRate();
-  setMinimumSystemAirFlowRatio(0.3);
+
+  setCentralHeatingMaximumSystemAirFlowRatio(0.3);
+  // TODO: should we autosize (E+ default) instead?
+  // autosizeCentralHeatingMaximumSystemAirFlowRatio();
+
   setPreheatDesignTemperature(7.0);
   setPreheatDesignHumidityRatio(0.008);
   setPrecoolDesignTemperature(12.8);
@@ -1014,10 +1032,6 @@ bool SizingSystem::isDesignOutdoorAirFlowRateDefaulted() const {
 
 bool SizingSystem::isDesignOutdoorAirFlowRateAutosized() const {
   return getImpl<detail::SizingSystem_Impl>()->isDesignOutdoorAirFlowRateAutosized();
-}
-
-double SizingSystem::minimumSystemAirFlowRatio() const {
-  return getImpl<detail::SizingSystem_Impl>()->minimumSystemAirFlowRatio();
 }
 
 double SizingSystem::preheatDesignTemperature() const {
@@ -1218,10 +1232,6 @@ void SizingSystem::resetDesignOutdoorAirFlowRate() {
 
 void SizingSystem::autosizeDesignOutdoorAirFlowRate() {
   getImpl<detail::SizingSystem_Impl>()->autosizeDesignOutdoorAirFlowRate();
-}
-
-bool SizingSystem::setMinimumSystemAirFlowRatio(double minimumSystemAirFlowRatio) {
-  return getImpl<detail::SizingSystem_Impl>()->setMinimumSystemAirFlowRatio(minimumSystemAirFlowRatio);
 }
 
 bool SizingSystem::setPreheatDesignTemperature(double preheatDesignTemperature) {
@@ -1439,6 +1449,35 @@ SizingSystem::SizingSystem(std::shared_ptr<detail::SizingSystem_Impl> impl)
   void SizingSystem::applySizingValues() {
     return getImpl<detail::SizingSystem_Impl>()->applySizingValues();
   }
+
+
+  boost::optional<double> SizingSystem::centralHeatingMaximumSystemAirFlowRatio() const {
+    return getImpl<detail::SizingSystem_Impl>()->centralHeatingMaximumSystemAirFlowRatio();
+  }
+
+  bool SizingSystem::setCentralHeatingMaximumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
+    return getImpl<detail::SizingSystem_Impl>()->setCentralHeatingMaximumSystemAirFlowRatio(centralHeatingMaximumSystemAirFlowRatio);  }
+
+  bool SizingSystem::isCentralHeatingMaximumSystemAirFlowRatioAutosized() const {
+    return getImpl<detail::SizingSystem_Impl>()->isCentralHeatingMaximumSystemAirFlowRatioAutosized();
+  }
+
+  void SizingSystem::autosizeCentralHeatingMaximumSystemAirFlowRatio() {
+    getImpl<detail::SizingSystem_Impl>()->autosizeCentralHeatingMaximumSystemAirFlowRatio();
+  }
+
+  // DEPRECATED
+  boost::optional<double> SizingSystem::minimumSystemAirFlowRatio() const {
+    return getImpl<detail::SizingSystem_Impl>()->centralHeatingMaximumSystemAirFlowRatio();
+  }
+
+  // DEPRECATED
+  bool SizingSystem::setMinimumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
+    return getImpl<detail::SizingSystem_Impl>()->setCentralHeatingMaximumSystemAirFlowRatio(centralHeatingMaximumSystemAirFlowRatio);
+  }
+
+
+
 
 } // model
 

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -108,9 +108,7 @@ bool SizingSystem_Impl::isDesignOutdoorAirFlowRateAutosized() const {
 }
 
 boost::optional<double> SizingSystem_Impl::centralHeatingMaximumSystemAirFlowRatio() const {
-  boost::optional<double> value = getDouble(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio,true);
-  OS_ASSERT(value);
-  return value.get();
+  return getDouble(OS_Sizing_SystemFields::CentralHeatingMaximumSystemAirFlowRatio,true);
 }
 
 bool SizingSystem_Impl::setCentralHeatingMaximumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
@@ -1468,6 +1466,7 @@ SizingSystem::SizingSystem(std::shared_ptr<detail::SizingSystem_Impl> impl)
 
   // DEPRECATED
   boost::optional<double> SizingSystem::minimumSystemAirFlowRatio() const {
+    LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, now it returns an Optional double");
     return getImpl<detail::SizingSystem_Impl>()->centralHeatingMaximumSystemAirFlowRatio();
   }
 
@@ -1475,9 +1474,6 @@ SizingSystem::SizingSystem(std::shared_ptr<detail::SizingSystem_Impl> impl)
   bool SizingSystem::setMinimumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
     return getImpl<detail::SizingSystem_Impl>()->setCentralHeatingMaximumSystemAirFlowRatio(centralHeatingMaximumSystemAirFlowRatio);
   }
-
-
-
 
 } // model
 

--- a/openstudiocore/src/model/SizingSystem.cpp
+++ b/openstudiocore/src/model/SizingSystem.cpp
@@ -44,6 +44,9 @@
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/sql/SqlFile.hpp"
 
+// TODO: only needed for API warning
+#include <OpenStudio.hxx>
+
 namespace openstudio {
 
 namespace model {
@@ -1464,14 +1467,27 @@ SizingSystem::SizingSystem(std::shared_ptr<detail::SizingSystem_Impl> impl)
     getImpl<detail::SizingSystem_Impl>()->autosizeCentralHeatingMaximumSystemAirFlowRatio();
   }
 
-  // DEPRECATED
+  // DEPRECATED: TODO REMOVED in 2.6.2, REMOVE FROM API In the FUTURE
   boost::optional<double> SizingSystem::minimumSystemAirFlowRatio() const {
+    LOG(Warn, "SizingSystem::minimumSystemAirFlowRatio has been deprecated and will be removed in a future release, please use SizingSystem::centralHeatingMaximumSystemAirFlowRatio");
     LOG(Warn, "Prior to OpenStudio 2.6.2, this field was returning a double, now it returns an Optional double");
+    if( VersionString( openStudioVersion() ) >= VersionString("2.8.0") ) {
+      // TODO: remove in 2 versions. here's a message and a Debug crash to remind you
+      LOG(Debug, "Please go tell a developper to remove SizingSystem::minimumSystemAirFlowRatio");
+      OS_ASSERT(false);
+    }
+
     return getImpl<detail::SizingSystem_Impl>()->centralHeatingMaximumSystemAirFlowRatio();
   }
 
-  // DEPRECATED
+  // DEPRECATED: TODO REMOVED in 2.6.2, REMOVE FROM API In the FUTURE
   bool SizingSystem::setMinimumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio) {
+    LOG(Warn, "SizingSystem::setMinimumSystemAirFlowRatio has been deprecated and will be removed in a future release, please use SizingSystem::setCentralHeatingMaximumSystemAirFlowRatio");
+    if( VersionString( openStudioVersion() ) >= VersionString("2.8.0") ) {
+      // TODO: remove in 2 versions. here's a message and a Debug crash to remind you
+      LOG(Debug, "Please go tell a developper to remove SizingSystem::minimumSystemAirFlowRatio");
+      OS_ASSERT(false);
+    }
     return getImpl<detail::SizingSystem_Impl>()->setCentralHeatingMaximumSystemAirFlowRatio(centralHeatingMaximumSystemAirFlowRatio);
   }
 

--- a/openstudiocore/src/model/SizingSystem.hpp
+++ b/openstudiocore/src/model/SizingSystem.hpp
@@ -290,9 +290,10 @@ class MODEL_API SizingSystem : public ModelObject
   OS_DEPRECATED bool setMinimumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio);
 
 
-  boost::optional<double> autosizedDesignOutdoorAirFlowRate() const ;
-  boost::optional<double> autosizedCoolingDesignCapacity() const ;
-  boost::optional<double> autosizedHeatingDesignCapacity() const ;
+  boost::optional<double> autosizedDesignOutdoorAirFlowRate() const;
+  boost::optional<double> autosizedCentralHeatingMaximumSystemAirFlowRatio() const;
+  boost::optional<double> autosizedCoolingDesignCapacity() const;
+  boost::optional<double> autosizedHeatingDesignCapacity() const;
 
   void autosize();
 

--- a/openstudiocore/src/model/SizingSystem.hpp
+++ b/openstudiocore/src/model/SizingSystem.hpp
@@ -32,6 +32,7 @@
 
 #include "ModelAPI.hpp"
 #include "ModelObject.hpp"
+#include "../utilities/core/Deprecated.hpp"
 
 namespace openstudio {
 
@@ -76,9 +77,6 @@ class MODEL_API SizingSystem : public ModelObject
   bool isDesignOutdoorAirFlowRateDefaulted() const;
 
   bool isDesignOutdoorAirFlowRateAutosized() const;
-
-  /** In EnergyPlus 8.3.0 and above this property maps to the EnergyPlus field "Central Heating Maximum System Air Flow Ratio" **/
-  double minimumSystemAirFlowRatio() const;
 
   double preheatDesignTemperature() const;
 
@@ -185,8 +183,6 @@ class MODEL_API SizingSystem : public ModelObject
 
   void autosizeDesignOutdoorAirFlowRate();
 
-  bool setMinimumSystemAirFlowRatio(double minimumSystemAirFlowRatio);
-
   bool setPreheatDesignTemperature(double preheatDesignTemperature);
 
   bool setPreheatDesignHumidityRatio(double preheatDesignHumidityRatio);
@@ -279,10 +275,23 @@ class MODEL_API SizingSystem : public ModelObject
 
   AirLoopHVAC airLoopHVAC() const;
 
+
+  boost::optional<double> centralHeatingMaximumSystemAirFlowRatio() const;
+  bool isCentralHeatingMaximumSystemAirFlowRatioAutosized() const;
+  bool setCentralHeatingMaximumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio);
+  void autosizeCentralHeatingMaximumSystemAirFlowRatio();
+
+
+  /** Deprecated, forwards to centralHeatingMaximumSystemAirFlowRatio
+   * In EnergyPlus 8.3.0 and above this property maps to the EnergyPlus field "Central Heating Maximum System Air Flow Ratio"
+   * Prior to 2.6.2, this was returning a double (no autosize possible) */
+  OS_DEPRECATED boost::optional<double> minimumSystemAirFlowRatio() const;
+  /* Deprecated, forwards to setCentralHeatingMaximumSystemAirFlowRatio */
+  OS_DEPRECATED bool setMinimumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio);
+
+
   boost::optional<double> autosizedDesignOutdoorAirFlowRate() const ;
-
   boost::optional<double> autosizedCoolingDesignCapacity() const ;
-
   boost::optional<double> autosizedHeatingDesignCapacity() const ;
 
   void autosize();

--- a/openstudiocore/src/model/SizingSystem_Impl.hpp
+++ b/openstudiocore/src/model/SizingSystem_Impl.hpp
@@ -275,6 +275,8 @@ class MODEL_API SizingSystem_Impl : public ModelObject_Impl
 
   boost::optional<double> autosizedDesignOutdoorAirFlowRate() const ;
 
+  boost::optional<double> autosizedCentralHeatingMaximumSystemAirFlowRatio() const;
+
   boost::optional<double> autosizedCoolingDesignCapacity() const ;
 
   boost::optional<double> autosizedHeatingDesignCapacity() const ;

--- a/openstudiocore/src/model/SizingSystem_Impl.hpp
+++ b/openstudiocore/src/model/SizingSystem_Impl.hpp
@@ -73,8 +73,6 @@ class MODEL_API SizingSystem_Impl : public ModelObject_Impl
 
   bool isDesignOutdoorAirFlowRateAutosized() const;
 
-  double minimumSystemAirFlowRatio() const;
-
   double preheatDesignTemperature() const;
 
   double preheatDesignHumidityRatio() const;
@@ -175,8 +173,6 @@ class MODEL_API SizingSystem_Impl : public ModelObject_Impl
 
   void autosizeDesignOutdoorAirFlowRate();
 
-  bool setMinimumSystemAirFlowRatio(double minimumSystemAirFlowRatio);
-
   bool setPreheatDesignTemperature(double preheatDesignTemperature);
 
   bool setPreheatDesignHumidityRatio(double preheatDesignHumidityRatio);
@@ -270,6 +266,12 @@ class MODEL_API SizingSystem_Impl : public ModelObject_Impl
   AirLoopHVAC airLoopHVAC() const;
 
   bool setAirLoopHVAC(const AirLoopHVAC & airLoopHVAC);
+
+
+  boost::optional<double> centralHeatingMaximumSystemAirFlowRatio() const;
+  bool isCentralHeatingMaximumSystemAirFlowRatioAutosized() const;
+  bool setCentralHeatingMaximumSystemAirFlowRatio(double centralHeatingMaximumSystemAirFlowRatio);
+  void autosizeCentralHeatingMaximumSystemAirFlowRatio();
 
   boost::optional<double> autosizedDesignOutdoorAirFlowRate() const ;
 

--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.cpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.cpp
@@ -429,6 +429,16 @@ namespace detail {
     return isEmpty(OS_ZoneHVAC_WaterToAirHeatPumpFields::FanPlacement);
   }
 
+  std::string ZoneHVACWaterToAirHeatPump_Impl::heatPumpCoilWaterFlowMode() const {
+    boost::optional<std::string> value = getString(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode, true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool ZoneHVACWaterToAirHeatPump_Impl::isHeatPumpCoilWaterFlowModeDefaulted() const {
+    return isEmpty(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode);
+  }
+
   boost::optional<Schedule> ZoneHVACWaterToAirHeatPump_Impl::supplyAirFanOperatingModeSchedule() const {
     return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanOperatingModeScheduleName);
   }
@@ -705,6 +715,16 @@ namespace detail {
     OS_ASSERT(result);
   }
 
+  bool ZoneHVACWaterToAirHeatPump_Impl::setHeatPumpCoilWaterFlowMode(std::string heatPumpCoilWaterFlowMode) {
+    bool result = setString(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode, heatPumpCoilWaterFlowMode);
+    return result;
+  }
+
+  void ZoneHVACWaterToAirHeatPump_Impl::resetHeatPumpCoilWaterFlowMode() {
+    bool result = setString(OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode, "");
+    OS_ASSERT(result);
+  }
+
   bool ZoneHVACWaterToAirHeatPump_Impl::setSupplyAirFanOperatingModeSchedule(Schedule& schedule) {
     bool result = setSchedule(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanOperatingModeScheduleName,
                               "ZoneHVACWaterToAirHeatPump",
@@ -742,9 +762,9 @@ namespace detail {
     return ZoneHVACWaterToAirHeatPump::fanPlacementValues();
   }
 
-  //std::vector<std::string> ZoneHVACWaterToAirHeatPump_Impl::fanPlacementValues() const {
-  //  return ZoneHVACWaterToAirHeatPump::fanPlacementValues();
-  //}
+  std::vector<std::string> ZoneHVACWaterToAirHeatPump_Impl::heatPumpCoilWaterFlowModeValues() const {
+    return ZoneHVACWaterToAirHeatPump::heatPumpCoilWaterFlowModeValues();
+  }
 
   boost::optional<ModelObject> ZoneHVACWaterToAirHeatPump_Impl::availabilityScheduleAsModelObject() const {
     OptionalModelObject result = availabilitySchedule();
@@ -970,6 +990,11 @@ std::vector<std::string> ZoneHVACWaterToAirHeatPump::fanPlacementValues() {
                         OS_ZoneHVAC_WaterToAirHeatPumpFields::FanPlacement);
 }
 
+std::vector<std::string> ZoneHVACWaterToAirHeatPump::heatPumpCoilWaterFlowModeValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode);
+}
+
 Schedule ZoneHVACWaterToAirHeatPump::availabilitySchedule() const {
   return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->availabilitySchedule();
 }
@@ -1092,6 +1117,14 @@ std::string ZoneHVACWaterToAirHeatPump::fanPlacement() const {
 
 bool ZoneHVACWaterToAirHeatPump::isFanPlacementDefaulted() const {
   return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->isFanPlacementDefaulted();
+}
+
+std::string ZoneHVACWaterToAirHeatPump::heatPumpCoilWaterFlowMode() const {;
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->heatPumpCoilWaterFlowMode();
+}
+
+bool ZoneHVACWaterToAirHeatPump::isHeatPumpCoilWaterFlowModeDefaulted() const {
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->isHeatPumpCoilWaterFlowModeDefaulted();
 }
 
 boost::optional<Schedule> ZoneHVACWaterToAirHeatPump::supplyAirFanOperatingModeSchedule() const {
@@ -1295,6 +1328,14 @@ bool ZoneHVACWaterToAirHeatPump::setFanPlacement(std::string fanPlacement) {
 
 void ZoneHVACWaterToAirHeatPump::resetFanPlacement() {
   getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->resetFanPlacement();
+}
+
+bool ZoneHVACWaterToAirHeatPump::setHeatPumpCoilWaterFlowMode(std::string heatPumpCoilWaterFlowMode) {
+  return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setHeatPumpCoilWaterFlowMode(heatPumpCoilWaterFlowMode);
+}
+
+void ZoneHVACWaterToAirHeatPump::resetHeatPumpCoilWaterFlowMode() {
+  getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->resetHeatPumpCoilWaterFlowMode();
 }
 
 bool ZoneHVACWaterToAirHeatPump::setSupplyAirFanOperatingModeSchedule(Schedule& schedule) {

--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.hpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump.hpp
@@ -50,6 +50,7 @@ namespace detail {
 
 /** ZoneHVACWaterToAirHeatPump is a ZoneHVACComponent that wraps the OpenStudio IDD object 'OS:ZoneHVAC:WaterToAirHeatPump'. */
 class MODEL_API ZoneHVACWaterToAirHeatPump : public ZoneHVACComponent {
+
  public:
   /** @name Constructors and Destructors */
   //@{
@@ -68,6 +69,9 @@ class MODEL_API ZoneHVACWaterToAirHeatPump : public ZoneHVACComponent {
   static IddObjectType iddObjectType();
 
   static std::vector<std::string> fanPlacementValues();
+
+  static std::vector<std::string> heatPumpCoilWaterFlowModeValues();
+
   /** @name Getters */
   //@{
 
@@ -138,8 +142,16 @@ class MODEL_API ZoneHVACWaterToAirHeatPump : public ZoneHVACComponent {
   std::string fanPlacement() const;
 
   bool isFanPlacementDefaulted() const;
+
+  std::string heatPumpCoilWaterFlowMode() const;
+
+  bool isHeatPumpCoilWaterFlowModeDefaulted() const;
+
   boost::optional<Schedule> supplyAirFanOperatingModeSchedule() const;
 
+  // TODO: field 'Availability Manager List Name' isn't implemented
+
+  // TODO: field 'Design Specification ZoneHVAC Sizing' isn't implemented since the object isn't wrapped in SDK
 
   //@}
   /** @name Setters */
@@ -247,6 +259,11 @@ class MODEL_API ZoneHVACWaterToAirHeatPump : public ZoneHVACComponent {
   bool setFanPlacement(std::string fanPlacement);
 
   void resetFanPlacement();
+
+  bool setHeatPumpCoilWaterFlowMode(std::string heatPumpCoilWaterFlowMode);
+
+  void resetHeatPumpCoilWaterFlowMode();
+
   bool setSupplyAirFanOperatingModeSchedule(Schedule& schedule);
 
   void resetSupplyAirFanOperatingModeSchedule();

--- a/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
+++ b/openstudiocore/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
@@ -151,25 +151,29 @@ namespace detail {
     std::string fanPlacement() const;
 
     bool isFanPlacementDefaulted() const;
+
+    std::string heatPumpCoilWaterFlowMode() const;
+    bool isHeatPumpCoilWaterFlowModeDefaulted() const;
+
     boost::optional<Schedule> supplyAirFanOperatingModeSchedule() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const ;
 
-  boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const ;
+    boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const ;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const ;
+    boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const ;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
+    boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
 
-  boost::optional<double> autosizedMaximumSupplyAirTemperaturefromSupplementalHeater() const ;
+    boost::optional<double> autosizedMaximumSupplyAirTemperaturefromSupplementalHeater() const ;
 
-  virtual void autosize() override;
+    virtual void autosize() override;
 
-  virtual void applySizingValues() override;
+    virtual void applySizingValues() override;
 
     //@}
     /** @name Setters */
@@ -278,6 +282,10 @@ namespace detail {
 
     void resetFanPlacement();
 
+    bool setHeatPumpCoilWaterFlowMode(std::string heatPumpCoilWaterFlowMode);
+
+    void resetHeatPumpCoilWaterFlowMode();
+
     bool setSupplyAirFanOperatingModeSchedule(Schedule& schedule);
 
     void resetSupplyAirFanOperatingModeSchedule();
@@ -301,6 +309,7 @@ namespace detail {
     boost::optional<HVACComponent> optionalSupplementalHeatingCoil() const;
 
     std::vector<std::string> fanPlacementValues() const;
+    std::vector<std::string> heatPumpCoilWaterFlowModeValues() const;
 
     boost::optional<ModelObject> availabilityScheduleAsModelObject() const;
     boost::optional<ModelObject> supplyAirFanAsModelObject() const;

--- a/openstudiocore/src/model/test/AirTerminalSingleDuctVAVNoReheat_GTest.cpp
+++ b/openstudiocore/src/model/test/AirTerminalSingleDuctVAVNoReheat_GTest.cpp
@@ -374,9 +374,9 @@ TEST_F(ModelFixture, AirTerminalSingleDuctVAVNoReheat_ConstantMinimumAirFlowFrac
 
   EXPECT_TRUE(testObject.setConstantMinimumAirFlowFraction(-1.0));
 
-  testObject.resetConstantMinimumAirFlowFraction();
-  EXPECT_TRUE(testObject.isConstantMinimumAirFlowFractionDefaulted());
-  EXPECT_DOUBLE_EQ(0.3, testObject.constantMinimumAirFlowFraction().get());
+  EXPECT_FALSE(testObject.isConstantMinimumAirFlowFractionAutosized());
+  testObject.autosizeConstantMinimumAirFlowFraction();
+  EXPECT_TRUE(testObject.isConstantMinimumAirFlowFractionAutosized());
 }
 
 TEST_F(ModelFixture, AirTerminalSingleDuctVAVNoReheat_FixedMinimumAirFlowRate)
@@ -386,7 +386,7 @@ TEST_F(ModelFixture, AirTerminalSingleDuctVAVNoReheat_FixedMinimumAirFlowRate)
 
   AirTerminalSingleDuctVAVNoReheat testObject = AirTerminalSingleDuctVAVNoReheat(m,s);
 
-  EXPECT_TRUE(testObject.isFixedMinimumAirFlowRateDefaulted());
+  EXPECT_TRUE(testObject.isFixedMinimumAirFlowRateAutosized());
 
   testObject.setFixedMinimumAirFlowRate(999.0);
   EXPECT_DOUBLE_EQ(999.0, testObject.fixedMinimumAirFlowRate().get());
@@ -396,9 +396,9 @@ TEST_F(ModelFixture, AirTerminalSingleDuctVAVNoReheat_FixedMinimumAirFlowRate)
 
   EXPECT_TRUE(testObject.setFixedMinimumAirFlowRate(-1.0));
 
-  testObject.resetFixedMinimumAirFlowRate();
-  EXPECT_TRUE(testObject.isFixedMinimumAirFlowRateDefaulted());
-  EXPECT_DOUBLE_EQ(0.0, testObject.fixedMinimumAirFlowRate().get());
+  EXPECT_FALSE(testObject.isFixedMinimumAirFlowRateAutosized());
+  testObject.autosizeFixedMinimumAirFlowRate();
+  EXPECT_TRUE(testObject.isFixedMinimumAirFlowRateAutosized());
 }
 
 TEST_F(ModelFixture, AirTerminalSingleDuctVAVNoReheat_MinimumAirFlowFractionSchedule)

--- a/openstudiocore/src/model/test/ZoneHVACWaterToAirHeatPump_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACWaterToAirHeatPump_GTest.cpp
@@ -310,4 +310,17 @@ TEST_F(ModelFixture, ZoneHVACWaterToAirHeatPump_SetGetFields) {
   EXPECT_TRUE(coolingCoil1.containingZoneHVACComponent());
   EXPECT_TRUE(heatingCoil1.containingZoneHVACComponent());
   EXPECT_TRUE(supplementalHC1.containingZoneHVACComponent());
+
+  //test fan placement
+  EXPECT_TRUE(testHP.setHeatPumpCoilWaterFlowMode("Constant"));
+  std::string str3 = testHP.heatPumpCoilWaterFlowMode();
+  EXPECT_EQ(str3, "Constant");
+  EXPECT_FALSE(testHP.isHeatPumpCoilWaterFlowModeDefaulted());
+
+  testHP.resetHeatPumpCoilWaterFlowMode();
+  EXPECT_TRUE(testHP.isHeatPumpCoilWaterFlowModeDefaulted());
+  str3 = testHP.heatPumpCoilWaterFlowMode();
+  EXPECT_EQ(str3,"Cycling");
+
+
 }

--- a/openstudiocore/src/sdd/MapHVAC.cpp
+++ b/openstudiocore/src/sdd/MapHVAC.cpp
@@ -1155,11 +1155,11 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateAirS
   value = dsgnAirFlowMinRatElement.text().toDouble(&ok);
   if( ok )
   {
-    sizingSystem.setMinimumSystemAirFlowRatio(value);
+    sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(value);
   }
   else
   {
-    sizingSystem.setMinimumSystemAirFlowRatio(0.3);
+    sizingSystem.setCentralHeatingMaximumSystemAirFlowRatio(0.3);
   }
 
   // DsgnPrehtTemp
@@ -7374,7 +7374,7 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateWtrH
       value = unitToUnit(value,"cfm","m^3/s").get();
       heatPump.setEvaporatorAirFlowRate(value);
     } else {
-			heatPump.autosizeEvaporatorAirFlowRate();	
+			heatPump.autosizeEvaporatorAirFlowRate();
 		}
 
     heatPump.setMinimumInletAirTemperatureforCompressorOperation(5.0);


### PR DESCRIPTION
**Warning:** this PR breaks backward compatibility in the API, because fields that weren't autosizable used to have a getter that returned a double, and now it must return boost::optional<double>.

----

## Changelog:

* Fix #2718 : `Sizing:System` "Minimum System Air Flow Ratio" is renamed to "Central Heating Maximum System Air Flow Ratio" to match E+, and becomes autosizable. 
* Fix #2625:  `AirTerminalSingleDuctVAVReheat` and `AirTerminalSingleDuctVAVNoReheat` have two fields - Constant Minimum Air Flow Fraction and Fixed Minimum Air Flow Rate that become autosizable
* All new autosizable fields go their related SQL querying methods (tested with the OpenStudio-resources autosizing_rb test) and added to the `autosize()` and `applySizingValues()`

## API Breaking changes:

* `SizingSystem::minimumSystemAirFlowRatio()` is now deprecated - please use `centralHeatingMaximumSystemAirFlowRatio()` instead -, and it used to return a `double` but now returns a `boost::optional<double>`.
* `AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction()` and `AirTerminalSingleDuctVAVReheat::fixedMinimumAirFlowRate()` used to return a `double` but now returns a `boost::optional<double>`.


Note: For `AirTerminalSingleDuctVAVReheat` and `AirTerminalSingleDuctVAVNoReheat`, I would have removed `isConstantMinimumAirFlowFractionDefaulted()` and `resetConstantMinimumAirFlowFraction()`, but in order to preserve the API, I kept them. Same for `fixedMinimumAirFlowRate`

----

## Other IDD change:

Fix #2458 - Implement the 'Heat Pump Coil Water Flow Mode' field for `ZoneHVAC:WaterToAirHeatPump`

I added 'Design Specification ZoneHVAC Sizing Object Name' to the IDD too, but since that class isn't wrapped in OS SDK I did do anything but add a "TODO" for a reminder.  Similarly 'Availability Manager List Name' was in the IDD but isn't in the SDK (though here the 'AvailabiltiyManagerList' class was added when I worked on #2844)




Review assignee: @kbenne 