### PR TITLE
Fix #2776 - Spaces tab Filters

### DIFF
--- a/openstudiocore/src/openstudio_lib/SpacesSpacesGridView.hpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSpacesGridView.hpp
@@ -83,6 +83,9 @@ namespace openstudio{
 
     REGISTER_LOGGER("openstudio.SpacesSpacesGridView");
 
+    // Overrides SpacesSubtabGrid view to trigger appropriate filtering
+    virtual bool hasSubRows() override { return false; };
+
   protected slots:
 
    virtual void onSelectItem() override;

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
@@ -891,11 +891,6 @@ namespace openstudio {
       }
     }
 
-    bool isRowLevel=true;
-    this->m_gridController->getObjectSelector()->m_filteredObjects = spaceFilteredObjects;
-    this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
-
-
     /***********************************************************************************
      * Filters that should apply at the SUBROW level because they are DataObject-related
      ***********************************************************************************/
@@ -937,10 +932,22 @@ namespace openstudio {
       }
     }
 
-    isRowLevel=false;
-    // allFilteredObjects.insert(spaceFilteredObjects.begin(), spaceFilteredObjects.end());
-    this->m_gridController->getObjectSelector()->m_filteredObjects = allFilteredObjects;
-    this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
+    if( this->hasSubRows() ) {
+      // We do it in two steps, the row level stuff (=space related)
+      bool isRowLevel=true;
+      this->m_gridController->getObjectSelector()->m_filteredObjects = spaceFilteredObjects;
+      this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
+      // The subrow level stuff, that could link to Space and/or Space Type
+      isRowLevel=false;
+      this->m_gridController->getObjectSelector()->m_filteredObjects = allFilteredObjects;
+      this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
+    } else {
+      // One step
+      bool isRowLevel=false;
+      allFilteredObjects.insert(spaceFilteredObjects.begin(), spaceFilteredObjects.end());
+      this->m_gridController->getObjectSelector()->m_filteredObjects = allFilteredObjects;
+      this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
+    }
   }
 
   void SpacesSubtabGridView::addObject(const IddObjectType& iddObjectType)

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
@@ -864,27 +864,44 @@ namespace openstudio {
 
   void SpacesSubtabGridView::filterChanged()
   {
-    std::set<openstudio::model::ModelObject> allFilteredObjects = m_objectsFilteredByStory;
+    // Note: JM 2018-08-21
+    // The distinction between these two is especially needed for the "Loads" Subtab
+    // because it can't match SpaceLoadInstances to a Space if the load is inherited from a SpaceType rather than the space
+
+    /****************************************************************************
+     * Filters that should apply at the ROW level because they are Space-related
+     ***************************************************************************/
+    std::set<openstudio::model::ModelObject> spaceFilteredObjects = m_objectsFilteredByStory;
 
     for (auto obj : m_objectsFilteredByThermalZone) {
-      if (allFilteredObjects.count(obj) == 0) {
-        allFilteredObjects.insert(obj);
+      if (spaceFilteredObjects.count(obj) == 0) {
+        spaceFilteredObjects.insert(obj);
       }
     }
 
     for (auto obj : m_objectsFilterdBySpaceType) {
-      if (allFilteredObjects.count(obj) == 0) {
-        allFilteredObjects.insert(obj);
-      }
-    }
-
-    for (auto obj : m_objectsFilterdBySubSurfaceType) {
-      if (allFilteredObjects.count(obj) == 0) {
-        allFilteredObjects.insert(obj);
+      if (spaceFilteredObjects.count(obj) == 0) {
+        spaceFilteredObjects.insert(obj);
       }
     }
 
     for (auto obj : m_objectsFilteredBySpaceName) {
+      if (spaceFilteredObjects.count(obj) == 0) {
+        spaceFilteredObjects.insert(obj);
+      }
+    }
+
+    bool isRowLevel=true;
+    this->m_gridController->getObjectSelector()->m_filteredObjects = spaceFilteredObjects;
+    this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
+
+
+    /***********************************************************************************
+     * Filters that should apply at the SUBROW level because they are DataObject-related
+     ***********************************************************************************/
+    std::set<openstudio::model::ModelObject> allFilteredObjects;
+
+    for (auto obj : m_objectsFilterdBySubSurfaceType) {
       if (allFilteredObjects.count(obj) == 0) {
         allFilteredObjects.insert(obj);
       }
@@ -920,9 +937,10 @@ namespace openstudio {
       }
     }
 
+    isRowLevel=false;
+    // allFilteredObjects.insert(spaceFilteredObjects.begin(), spaceFilteredObjects.end());
     this->m_gridController->getObjectSelector()->m_filteredObjects = allFilteredObjects;
-
-    this->m_gridController->getObjectSelector()->updateWidgets();
+    this->m_gridController->getObjectSelector()->updateWidgets(isRowLevel);
   }
 
   void SpacesSubtabGridView::addObject(const IddObjectType& iddObjectType)

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.hpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.hpp
@@ -208,7 +208,13 @@ namespace openstudio{
 
     virtual void interiorPartitionGroupFilterChanged(const QString & text);
 
+  private:
+    // All of the subtabs except the main SpacesSpace subtab will return true
+    // We use this in filterChanged
+    virtual bool hasSubRows() { return true; };
   };
+
+
 
 } // openstudio
 

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.hpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.hpp
@@ -158,6 +158,8 @@ namespace openstudio{
 
     void filterChanged();
 
+    // All these sets will store the objects that DO NEED to be hidden
+    // So if the set is empty -> show all
     std::set<openstudio::model::ModelObject> m_objectsFilteredByStory;
 
     std::set<openstudio::model::ModelObject> m_objectsFilteredByThermalZone;

--- a/openstudiocore/src/shared_gui_components/OSGridController.cpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.cpp
@@ -428,11 +428,29 @@ namespace openstudio {
     }
   }
 
-  void ObjectSelector::updateWidgets()
+  void ObjectSelector::updateWidgets(bool isRowLevel)
   {
-    for (const auto &obj : m_selectorObjects)
-    {
-      updateWidgets(obj);
+    if( isRowLevel ) {
+      // We loop on all object in the leftmost colum (eg: 'Space' for all SpaceSubtabs)
+      for( int t_row=0; t_row < this->m_grid->rowCount(); ++t_row ) {
+        bool objectVisible = true;
+
+        // If that object is present in m_filteredObjects
+        boost::optional<const model::ModelObject &> _rowLevelObj = getObject(t_row, 0, boost::optional<int>());
+        if( _rowLevelObj && (m_filteredObjects.count(_rowLevelObj.get()) != 0 ) ) {
+          LOG(Debug, "Hidding t_row=" << t_row << " matched as rowLevelObj (=" << _rowLevelObj.get().briefDescription() << ")");
+          objectVisible = false;
+        }
+
+        // We'll hide the entire row
+        updateWidgets(t_row, boost::optional<int>(), false, objectVisible);
+      }
+    } else {
+      // This contains the (unique) individual DataObjects (eg: Loads subtab = SpaceLoadInstances (People, Lights, etc))
+      for (const auto &obj : m_selectorObjects)
+      {
+        updateWidgets(obj);
+      }
     }
   }
 

--- a/openstudiocore/src/shared_gui_components/OSGridController.hpp
+++ b/openstudiocore/src/shared_gui_components/OSGridController.hpp
@@ -221,7 +221,7 @@ class ObjectSelector : public QObject, public Nano::Observer
     bool containsObject(const openstudio::model::ModelObject &t_obj) const;
     void selectAll();
     void clearSelection();
-    void updateWidgets();
+    void updateWidgets(bool isRowLevel=false);
 
     std::set<model::ModelObject> m_selectedObjects;
     std::set<model::ModelObject> m_selectorObjects;
@@ -232,6 +232,9 @@ class ObjectSelector : public QObject, public Nano::Observer
 
   private slots:
     void widgetDestroyed(QObject *t_obj);
+
+  protected:
+    REGISTER_LOGGER("openstudio.ObjectSelector");
 
   private:
     void updateWidgets(const model::ModelObject &t_obj);


### PR DESCRIPTION
Fix #2776 - Spaces tab Filters

There are two types of filters:
* Row-level filters: these apply to the Space itself
* Subrow-level filters: these apply to whatever is displayed (eg: Loads, etc). The current approach was to check the parent of the subrow-level object, and if that doesn't match, the parent's parent.
    * If the subrow-level object is a subSurface, it looks for Surface, then the Surface's parent = Space: that's OK
    * If the subrow-level object is a load (eg: People), it looks for the parent. If the parent is a Space => works kinda ok. If it's the Space Type => Never matches.

![filters](https://user-images.githubusercontent.com/5479063/45423544-fc0da300-b693-11e8-91b4-ce7ffdec3ac1.png)

I had to implement a workaround that consist in distinguishing between the "Properties" subtab (`SpacesSpacesGridView`) which doesn't have subrow level objects, and the rest of the subtabs that do. It's perhaps not the most elegant way, but I couldn't figure out how to do it without.

Demonstration of UX:

![2776_ux](https://user-images.githubusercontent.com/5479063/45423900-1300c500-b695-11e8-96bb-512fa0e2716f.gif)


Review assignee: @macumber 
