### PR TITLE
Fix #2600: Apply Measure Now incorrectly reporting warning message count with data from info messages

### DIFF
--- a/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
@@ -715,7 +715,7 @@ void DataPointJobItemView::update(const BCLMeasure & bclMeasure, const boost::op
     }
 
     std::vector<std::string> infos = result->stepInfo();
-    m_dataPointJobHeaderView->setNumWarnings(infos.size());
+    // m_dataPointJobHeaderView->setNumInfos(infos.size());
     for (const std::string& info : infos){
       m_dataPointJobContentView->addInfoMessage(info);
     }


### PR DESCRIPTION
Fix #2600: was overriding setNumWarnings with infos.size()

Review assignee: @macumber (it's just one trivial line.)