### PR TITLE
Handle TableMultiVariableLookup::points

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
@@ -300,16 +300,14 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
   }
   else
   {
-    std::vector<std::pair<std::vector<double>,double> > points = modelObject.points();
+    std::vector<TableMultiVariableLookupPoint> points = modelObject.points();
 
     // Slice the first and second x values off the coordinates
     std::vector<std::vector<double> > slices;
-    for(std::vector<std::pair<std::vector<double>,double> >::const_iterator it = points.begin();
-        it != points.end();
-        ++it)
-    {
-      OS_ASSERT(it->first.size() == t_numberofIndependentVariables);
-      std::vector<double> slice(it->first.begin() + 2,it->first.begin() + t_numberofIndependentVariables);
+    for (const TableMultiVariableLookupPoint pt: points) {
+      std::vector<double> xValues = pt.x();
+      OS_ASSERT(xValues.size() == t_numberofIndependentVariables);
+      std::vector<double> slice(xValues.begin() + 2, xValues.begin() + t_numberofIndependentVariables);
       slices.push_back(slice);
     }
 

--- a/openstudiocore/src/model/ModelCore.i
+++ b/openstudiocore/src/model/ModelCore.i
@@ -124,6 +124,11 @@ class Node;
 %template(ScheduleTypeKey) std::pair<std::string,std::string>;
 %template(ScheduleTypeKeyVector) std::vector< std::pair<std::string,std::string> >;
 
+// std::vector<std::pair<std::vector<double>,double> > TableMultiVariableLookup::points
+// %template(DoubleVector) std::vector<double>; // already in utilities/core/CommonImport.i
+%template(TableMultiVariableLookupPoint) std::pair<std::vector<double>,double>;
+%template(TableMultiVariableLookupPointVector) std::vector<std::pair<std::vector<double>,double> >;
+
 // include initial objects
 %include <model/AccessPolicyStore.hpp>
 %include <model/ModelObject.hpp>

--- a/openstudiocore/src/model/ModelCore.i
+++ b/openstudiocore/src/model/ModelCore.i
@@ -109,7 +109,7 @@ class Node;
 }
 
 // DLM: forward declaring these classes and requesting the valuewrapper feature seems to be sufficient for the Ruby bindings
-// For C# we ignore any methods using these and then reimpliment using partial class later
+// For C# we ignore any methods using these and then reimplement using partial class later
 %feature("valuewrapper") SpaceType;
 %feature("valuewrapper") Node;
 

--- a/openstudiocore/src/model/ModelCore.i
+++ b/openstudiocore/src/model/ModelCore.i
@@ -124,11 +124,6 @@ class Node;
 %template(ScheduleTypeKey) std::pair<std::string,std::string>;
 %template(ScheduleTypeKeyVector) std::vector< std::pair<std::string,std::string> >;
 
-// std::vector<std::pair<std::vector<double>,double> > TableMultiVariableLookup::points
-// %template(DoubleVector) std::vector<double>; // already in utilities/core/CommonImport.i
-%template(TableMultiVariableLookupPoint) std::pair<std::vector<double>,double>;
-%template(TableMultiVariableLookupPointVector) std::vector<std::pair<std::vector<double>,double> >;
-
 // include initial objects
 %include <model/AccessPolicyStore.hpp>
 %include <model/ModelObject.hpp>

--- a/openstudiocore/src/model/ModelResources.i
+++ b/openstudiocore/src/model/ModelResources.i
@@ -11,7 +11,6 @@
 
 %{
   #include <model/ScheduleTypeRegistry.hpp>
-  #include <model/TableMultiVariableLookup.hpp>
   #include <QColor>
   #include <utilities/data/TimeSeries.hpp>
   #include <utilities/sql/SqlFile.hpp>
@@ -216,7 +215,6 @@ SWIG_MODELOBJECT(RenderingColor, 1);
 SWIG_MODELOBJECT(DesignSpecificationOutdoorAir, 1);
 
 %include <model/ScheduleTypeRegistry.hpp>
-#include <model/TableMultiVariableLookup.hpp>
 
 #endif
 

--- a/openstudiocore/src/model/ModelResources.i
+++ b/openstudiocore/src/model/ModelResources.i
@@ -49,6 +49,17 @@ class ShadingControl;
 }
 }
 
+// extend classes
+%extend openstudio::model::TableMultiVariableLookupPoint {
+  // Use the overloaded operator<< for string representation
+  // puts point will return something like "(x1, x2) = (10.5, 0.75)"
+  std::string __str__() {
+    std::ostringstream os;
+    os << *$self;
+    return os.str();
+  }
+};
+
 MODELOBJECT_TEMPLATES(ScheduleInterval);
 MODELOBJECT_TEMPLATES(ScheduleFixedInterval);
 MODELOBJECT_TEMPLATES(ExternalFile);

--- a/openstudiocore/src/model/ModelResources.i
+++ b/openstudiocore/src/model/ModelResources.i
@@ -113,6 +113,7 @@ MODELOBJECT_TEMPLATES(CurveRectangularHyperbola1);
 MODELOBJECT_TEMPLATES(CurveRectangularHyperbola2);
 MODELOBJECT_TEMPLATES(CurveSigmoid);
 MODELOBJECT_TEMPLATES(CurveTriquadratic);
+MODELOBJECT_TEMPLATES(TableMultiVariableLookupPoint);
 MODELOBJECT_TEMPLATES(TableMultiVariableLookup);
 MODELOBJECT_TEMPLATES(SpaceLoadDefinition);
 MODELOBJECT_TEMPLATES(PeopleDefinition);

--- a/openstudiocore/src/model/ModelResources.i
+++ b/openstudiocore/src/model/ModelResources.i
@@ -50,6 +50,13 @@ class ShadingControl;
 }
 }
 
+// templates
+// std::vector<std::pair<std::vector<double>,double> >
+%template(TableMultiVariableLookupPointCoordinates) std::vector<double>;
+%template(TableMultiVariableLookupPoint) std::pair<std::vector<double>,double>;
+%template(TableMultiVariableLookupPointVector) std::vector<std::pair<std::vector<double>,double> >;
+
+
 MODELOBJECT_TEMPLATES(ScheduleInterval);
 MODELOBJECT_TEMPLATES(ScheduleFixedInterval);
 MODELOBJECT_TEMPLATES(ExternalFile);

--- a/openstudiocore/src/model/ModelResources.i
+++ b/openstudiocore/src/model/ModelResources.i
@@ -11,7 +11,7 @@
 
 %{
   #include <model/ScheduleTypeRegistry.hpp>
-
+  #include <model/TableMultiVariableLookup.hpp>
   #include <QColor>
   #include <utilities/data/TimeSeries.hpp>
   #include <utilities/sql/SqlFile.hpp>
@@ -49,13 +49,6 @@ class ShadingControl;
 
 }
 }
-
-// templates
-// std::vector<std::pair<std::vector<double>,double> >
-%template(TableMultiVariableLookupPointCoordinates) std::vector<double>;
-%template(TableMultiVariableLookupPoint) std::pair<std::vector<double>,double>;
-%template(TableMultiVariableLookupPointVector) std::vector<std::pair<std::vector<double>,double> >;
-
 
 MODELOBJECT_TEMPLATES(ScheduleInterval);
 MODELOBJECT_TEMPLATES(ScheduleFixedInterval);
@@ -223,6 +216,7 @@ SWIG_MODELOBJECT(RenderingColor, 1);
 SWIG_MODELOBJECT(DesignSpecificationOutdoorAir, 1);
 
 %include <model/ScheduleTypeRegistry.hpp>
+#include <model/TableMultiVariableLookup.hpp>
 
 #endif
 

--- a/openstudiocore/src/model/ScheduleFile_Impl.hpp
+++ b/openstudiocore/src/model/ScheduleFile_Impl.hpp
@@ -71,12 +71,16 @@ namespace detail {
 
     virtual std::vector<ResourceObject> resources() const override;
 
+    // These are pure virtual methods that were defined in ScheduleBase_Impl
+
+    virtual boost::optional<ScheduleTypeLimits> scheduleTypeLimits() const override;
+    virtual bool setScheduleTypeLimits(const ScheduleTypeLimits& scheduleTypeLimits) override;
+    virtual bool resetScheduleTypeLimits() override;
+
+
     //@}
     /** @name Getters */
     //@{
-
-    // TODO: Check return type. From object lists, some candidates are: ScheduleTypeLimits.
-    boost::optional<ScheduleTypeLimits> scheduleTypeLimits() const;
 
     ExternalFile externalFile() const;
 
@@ -107,11 +111,6 @@ namespace detail {
     //@}
     /** @name Setters */
     //@{
-
-    // TODO: Check argument type. From object lists, some candidates are: ScheduleTypeLimits.
-    bool setScheduleTypeLimits(const ScheduleTypeLimits& scheduleTypeLimits);
-
-    bool resetScheduleTypeLimits();
 
     bool setColumnNumber(int columnNumber);
 

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -72,6 +72,26 @@ double TableMultiVariableLookupPoint::y() const {
   return m_y;
 }
 
+std::ostream& operator<< (std::ostream& out, const openstudio::model::TableMultiVariableLookupPoint& point) {
+  std::vector<double> xValues = point.x();
+  std::stringstream ss_left, ss_right;
+  int i = 1;
+  ss_left << "(";
+  ss_right << "(";
+
+  for (const double& x: xValues) {
+    ss_left << "x" << i << ", ";
+    ss_right << x << ", ";
+    ++i;
+  }
+
+  ss_left << "y)";
+  ss_right << point.y() << ")";
+
+  out << ss_left.str() << " = " << ss_right.str();
+  return out;
+}
+
 namespace detail {
 
   bool TableMultiVariableLookup_Impl::xValuesEqual(const std::vector<double> & a, const std::vector<double> & b)
@@ -703,7 +723,7 @@ namespace detail {
 
   bool TableMultiVariableLookup_Impl::addPoint(const std::vector<double> & t_xValues, double t_yValue)
   {
-    if( t_xValues.size() != numberofIndependentVariables() )
+    if( t_xValues.size() != (unsigned)numberofIndependentVariables() )
     {
       return false;
     }
@@ -803,7 +823,7 @@ namespace detail {
     // We first check that ALL points have the right number of independent variables, before we do anything destructive such as clearing the points
     int n_independent = numberofIndependentVariables();
     for (const TableMultiVariableLookupPoint& pt: points) {
-      if (pt.x().size() != n_independent) {
+      if (pt.x().size() != (unsigned)n_independent) {
         LOG(Warn, "Cannot set points because all points must have exactly " << n_independent << " independent variable(s), for " << briefDescription());
         return false;
       }

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -51,6 +51,19 @@ namespace model {
 TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(std::vector<double> x, double y)
   : m_x(x), m_y(y) { };
 
+TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(double x1, double yValue)
+  : m_x(std::vector<double> {x1}), m_y(yValue) { };
+
+TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(double x1, double x2, double yValue)
+  : m_x(std::vector<double> {x1, x2}), m_y(yValue) { };
+TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(double x1, double x2, double x3, double yValue)
+  : m_x(std::vector<double> {x1, x2, x3}), m_y(yValue) { };
+TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(double x1, double x2, double x3, double x4, double yValue)
+  : m_x(std::vector<double> {x1, x2, x3, x4}), m_y(yValue) { };
+TableMultiVariableLookupPoint::TableMultiVariableLookupPoint(double x1, double x2, double x3, double x4, double x5, double yValue)
+  : m_x(std::vector<double> {x1, x2, x3, x4, x5}), m_y(yValue) { };
+
+
 std::vector<double> TableMultiVariableLookupPoint::x() const {
   return m_x;
 }

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -793,14 +793,14 @@ namespace detail {
   }
 
   // Helper function for printTable
-  std::string centered(double val, int targetSize, int precision) {
+  std::string centered(double val, int targetSize, unsigned int precision) {
     std::stringstream ss;
     ss << std::fixed << std::setprecision(precision) << val;
     return centered(ss.str(), targetSize);
   }
 
   // Print a table (for console output in particular)
-  std::string TableMultiVariableLookup_Impl::printTable(int precision) const {
+  std::string TableMultiVariableLookup_Impl::printTable(unsigned int precision) const {
     std::vector<TableMultiVariableLookupPoint> points = this->points();
     std::stringstream ss;
     int size = points[0].x().size();
@@ -1388,7 +1388,7 @@ std::vector<TableMultiVariableLookupPoint> TableMultiVariableLookup::points() co
   return getImpl<detail::TableMultiVariableLookup_Impl>()->points();
 }
 
-std::string TableMultiVariableLookup::printTable(int precision) const {
+std::string TableMultiVariableLookup::printTable(unsigned int precision) const {
   return getImpl<detail::TableMultiVariableLookup_Impl>()->printTable(precision);
 }
 

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -707,7 +707,11 @@ namespace detail {
   }
 
   bool TableMultiVariableLookup_Impl::setNumberofIndependentVariables(int numberofIndependentVariables) {
+    // This object only accept between 1 and 5 independent variables
+    // This is enforced by the IDD \minimum and \maximum, so no need to explicitly check here:
+    // setInt will return false if outside that range
     bool result = setInt(OS_Table_MultiVariableLookupFields::NumberofIndependentVariables, numberofIndependentVariables);
+
     return result;
   }
 
@@ -949,14 +953,12 @@ TableMultiVariableLookup::TableMultiVariableLookup(const Model& model, const int
 {
   OS_ASSERT(getImpl<detail::TableMultiVariableLookup_Impl>());
 
-  getImpl<detail::TableMultiVariableLookup_Impl>()->setNumberofIndependentVariables(numberofIndependentVariables);
-
-  // TODO: Appropriately handle the following required object-list fields.
-  bool ok = true;
-  // ok = setHandle();
-  OS_ASSERT(ok);
-  // ok = setNumberofIndependentVariables();
-  OS_ASSERT(ok);
+  // Check if numberofIndependentVariables between 1 and 5 included, otherwise THROW
+  bool ok = getImpl<detail::TableMultiVariableLookup_Impl>()->setNumberofIndependentVariables(numberofIndependentVariables);
+  if (!ok) {
+    remove();
+    LOG_AND_THROW("TableMultiVariableLookup only accepts between 1 and 5 independent variables (included).");
+  }
 }
 
 IddObjectType TableMultiVariableLookup::iddObjectType() {

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -1294,7 +1294,7 @@ bool TableMultiVariableLookup::addPoint(double x1, double x2, double x3, double 
   return getImpl<detail::TableMultiVariableLookup_Impl>()->addPoint(x1,x2,x3,x4,x5,yValue);
 }
 
-bool TableMultiVariableLookup::setPoints(const std::vector<TableMultiVariableLookup>& points) {
+bool TableMultiVariableLookup::setPoints(const std::vector<TableMultiVariableLookupPoint>& points) {
   return getImpl<detail::TableMultiVariableLookup_Impl>()->setPoints(points);
 }
 

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -672,7 +672,8 @@ namespace detail {
 
   double TableMultiVariableLookup_Impl::evaluate(const std::vector<double>& x) const
   {
-    return 1.0;
+    LOG(Warn, "Curve evaluation isn't implemented for TableMultiVariableLookup");
+    return -999.0;
   }
 
   bool TableMultiVariableLookup_Impl::addPoint(const std::vector<double> & t_xValues, double t_yValue)
@@ -1278,4 +1279,4 @@ TableMultiVariableLookup::TableMultiVariableLookup(std::shared_ptr<detail::Table
 /// @endcond
 
 } // model
-} // openstudio
+} // openstudio

--- a/openstudiocore/src/model/TableMultiVariableLookup.cpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.cpp
@@ -43,6 +43,7 @@
 #include "../utilities/core/Assert.hpp"
 
 #include <algorithm>
+#include <iomanip>
 
 namespace openstudio {
 namespace model {
@@ -780,6 +781,57 @@ namespace detail {
     return result;
   }
 
+  // Helper function for printTable
+  std::string centered( std::string const& original, int targetSize ) {
+    // assert( targetSize >= 0 );
+    int padding = targetSize - (int)( original.size() );
+    return padding > 0
+        ? std::string( padding / 2, ' ' )
+            + original
+            + std::string( padding - (padding / 2), ' ' )
+        : original;
+  }
+
+  // Helper function for printTable
+  std::string centered(double val, int targetSize, int precision) {
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(precision) << val;
+    return centered(ss.str(), targetSize);
+  }
+
+  // Print a table (for console output in particular)
+  std::string TableMultiVariableLookup_Impl::printTable(int precision) const {
+    std::vector<TableMultiVariableLookupPoint> points = this->points();
+    std::stringstream ss;
+    int size = points[0].x().size();
+
+    ss << "|" << centered("n", 5) << "|";
+    for (int i=1; i <= size; ++i) {
+      std::stringstream tempss;
+      tempss << "x" << i;
+      ss << centered(tempss.str(), 15) << "|";
+    }
+    ss << centered("y", 15) << "|";
+    ss << "\n" << "|-----+";
+    for (int i=1; i <= size; ++i) {
+      ss << std::string(15, '-') << "+";
+    }
+    ss << std::string(15, '-') << "|\n";
+
+    int i = 1;
+    for (const TableMultiVariableLookupPoint& pt: points) {
+      ss << "|" << centered(std::to_string(i), 5);
+      for (const double& x: pt.x()) {
+        ss << "|" << centered(x, 15, precision);
+      }
+      ss << "|" << centered(pt.y(), 15, precision) << "|\n";
+      ++i;
+    }
+
+    return ss.str();
+
+  }
+
   std::vector<double> TableMultiVariableLookup_Impl::xValues(int xIndex) const
   {
     std::vector<double> result;
@@ -1334,6 +1386,10 @@ bool TableMultiVariableLookup::setPoints(const std::vector<TableMultiVariableLoo
 std::vector<TableMultiVariableLookupPoint> TableMultiVariableLookup::points() const
 {
   return getImpl<detail::TableMultiVariableLookup_Impl>()->points();
+}
+
+std::string TableMultiVariableLookup::printTable(int precision) const {
+  return getImpl<detail::TableMultiVariableLookup_Impl>()->printTable(precision);
 }
 
 boost::optional<double> TableMultiVariableLookup::yValue(const std::vector<double> & xValues) const

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -45,6 +45,18 @@ namespace detail {
 
 } // detail
 
+
+class TableMultiVariableLookupPoint {
+ public:
+  TableMultiVariableLookupPoint(std::vector<double> x, double y);
+  std::vector<double> x() const;
+  double y() const;
+ private:
+  std::vector<double> m_x;
+  double m_y;
+};
+
+
 /** TableMultiVariableLookup is a Curve that wraps the OpenStudio IDD object 'OS:Table:MultiVariableLookup'. */
 class MODEL_API TableMultiVariableLookup : public Curve {
  public:
@@ -257,6 +269,10 @@ class MODEL_API TableMultiVariableLookup : public Curve {
   /** @name Other */
   //@{
 
+
+  // Primary way to add a point
+  bool addPoint(const TableMultiVariableLookupPoint& point);
+
   /**
    * Add a y value corresponding to xValues. The size of the XValues vector must be
    * equal to the number of independent variables specified when the table was created.
@@ -264,19 +280,17 @@ class MODEL_API TableMultiVariableLookup : public Curve {
    * will be replaced.
    */
   bool addPoint(const std::vector<double> & xValues, double yValue);
-
   bool addPoint(double x1, double yValue);
-
   bool addPoint(double x1, double x2, double yValue);
-
   bool addPoint(double x1, double x2, double x3, double yValue);
-
   bool addPoint(double x1, double x2, double x3, double x4, double yValue);
-
   bool addPoint(double x1, double x2, double x3, double x4, double x5, double yValue);
 
-  // Return a vector of xValues and corresponding yValues, this is the entire set of data points
-  std::vector<std::pair<std::vector<double>,double> > points() const;
+  // Return a vector of points, this is the entire set of data points
+  std::vector<TableMultiVariableLookupPoint> points() const;
+
+  // Directly set the points from a vector, will delete any existing points
+  bool setPoints(const std::vector<TableMultiVariableLookupPoint>& points);;
 
   boost::optional<double> yValue(const std::vector<double> & xValues) const;
 

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -178,7 +178,7 @@ class MODEL_API TableMultiVariableLookup : public Curve {
   int numberofIndependentVariables() const;
 
   /** Print a fixed-width table of the points, precision is the number of decimals */
-  std::string printTable(int precision=3) const;
+  std::string printTable(unsigned int precision=3) const;
 
   //@}
   /** @name Setters */

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -46,6 +46,7 @@ namespace detail {
 } // detail
 
 
+/** This class implements a single point of a TableMultiVariableLookup */
 class TableMultiVariableLookupPoint {
  public:
   TableMultiVariableLookupPoint(std::vector<double> x, double y);
@@ -61,6 +62,9 @@ class TableMultiVariableLookupPoint {
   std::vector<double> m_x;
   double m_y;
 };
+
+// Overload operator<<
+std::ostream& operator<< (std::ostream& out, const openstudio::model::TableMultiVariableLookupPoint& point);
 
 
 /** TableMultiVariableLookup is a Curve that wraps the OpenStudio IDD object 'OS:Table:MultiVariableLookup'. */

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -177,7 +177,8 @@ class MODEL_API TableMultiVariableLookup : public Curve {
 
   int numberofIndependentVariables() const;
 
-  // TODO: Handle this object's extensible fields.
+  /** Print a fixed-width table of the points, precision is the number of decimals */
+  std::string printTable(int precision=3) const;
 
   //@}
   /** @name Setters */

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -339,6 +339,9 @@ typedef boost::optional<TableMultiVariableLookup> OptionalTableMultiVariableLook
 /** \relates TableMultiVariableLookup*/
 typedef std::vector<TableMultiVariableLookup> TableMultiVariableLookupVector;
 
+/** \relates TableMultiVariableLookupPoint*/
+typedef std::vector<TableMultiVariableLookupPoint> TableMultiVariableLookupPointVector;
+
 } // model
 } // openstudio
 

--- a/openstudiocore/src/model/TableMultiVariableLookup.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup.hpp
@@ -49,6 +49,12 @@ namespace detail {
 class TableMultiVariableLookupPoint {
  public:
   TableMultiVariableLookupPoint(std::vector<double> x, double y);
+  TableMultiVariableLookupPoint(double x1, double yValue);
+  TableMultiVariableLookupPoint(double x1, double x2, double yValue);
+  TableMultiVariableLookupPoint(double x1, double x2, double x3, double yValue);
+  TableMultiVariableLookupPoint(double x1, double x2, double x3, double x4, double yValue);
+  TableMultiVariableLookupPoint(double x1, double x2, double x3, double x4, double x5, double yValue);
+
   std::vector<double> x() const;
   double y() const;
  private:

--- a/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
@@ -151,7 +151,7 @@ namespace detail {
     int numberofIndependentVariables() const;
 
     /** Print a fixed-width table of the points, precision is the number of decimals */
-    std::string printTable(int precision) const;
+    std::string printTable(unsigned int precision) const;
 
     //@}
     /** @name Setters */

--- a/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
@@ -37,6 +37,9 @@
 namespace openstudio {
 namespace model {
 
+// Foward declaration
+class TableMultiVariableLookupPoint;
+
 namespace detail {
 
   /** TableMultiVariableLookup_Impl is a Curve_Impl that is the implementation class for TableMultiVariableLookup.*/
@@ -279,19 +282,21 @@ namespace detail {
 
     double evaluate(const std::vector<double>& x) const override;
 
+    // Primary way to add a point
+    bool addPoint(const TableMultiVariableLookupPoint& point);
+
+    // Convenience functions
     bool addPoint(const std::vector<double> & xValues, double yValue);
-
     bool addPoint(double x1, double yValue);
-
     bool addPoint(double x1, double x2, double yValue);
-
     bool addPoint(double x1, double x2, double x3, double yValue);
-
     bool addPoint(double x1, double x2, double x3, double x4, double yValue);
-
     bool addPoint(double x1, double x2, double x3, double x4, double x5, double yValue);
 
-    std::vector<std::pair<std::vector<double>,double> > points() const;
+    // Directly set the points from a vector, will delete any existing points
+    bool setPoints(const std::vector<TableMultiVariableLookupPoint>& points);
+
+    std::vector<TableMultiVariableLookupPoint> points() const;
 
     static bool xValuesEqual(const std::vector<double> & a, const std::vector<double> & b);
 
@@ -306,4 +311,4 @@ namespace detail {
 } // model
 } // openstudio
 
-#endif // MODEL_TABLEMULTIVARIABLELOOKUP_IMPL_HPP
+#endif // MODEL_TABLEMULTIVARIABLELOOKUP_IMPL_HPP

--- a/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
+++ b/openstudiocore/src/model/TableMultiVariableLookup_Impl.hpp
@@ -150,7 +150,8 @@ namespace detail {
 
     int numberofIndependentVariables() const;
 
-    // TODO: Handle this object's extensible fields.
+    /** Print a fixed-width table of the points, precision is the number of decimals */
+    std::string printTable(int precision) const;
 
     //@}
     /** @name Setters */

--- a/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
+++ b/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
@@ -120,6 +120,16 @@ TEST_F(ModelFixture,TableMultiVariableLookup)
   }
 }
 
+TEST_F(ModelFixture, TableMultiVariableLookup_BadNumberOfVariables)
+{
+  Model model;
+
+  // Only between 1 and 5 (included) independent variables are allowed
+  EXPECT_THROW(TableMultiVariableLookup(model, 0), openstudio::Exception);
+  EXPECT_THROW(TableMultiVariableLookup(model, 6), openstudio::Exception);
+  EXPECT_NO_THROW(TableMultiVariableLookup(model, 5));
+}
+
 TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
 
   Model m;

--- a/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
+++ b/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
@@ -133,6 +133,7 @@ TEST_F(ModelFixture, TableMultiVariableLookup_BadNumberOfVariables)
 TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
 
   Model m;
+  // Table with 2 independent variables
   TableMultiVariableLookup table(m,2);
 
   EXPECT_TRUE(table.addPoint(70,32,0.1));
@@ -160,7 +161,7 @@ TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
 
   TableMultiVariableLookupPoint bad_point(70, 0.7);
   points.push_back(bad_point);
-  // It should catch that at least one point doesn't have the appropriate number of independent variables
+  // It should catch that our bad_point doesn't have the appropriate number of independent variables
   // and as a result both return false and don't affect the points
   EXPECT_FALSE(table.setPoints(points));
   EXPECT_EQ(3, table.points().size());

--- a/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
+++ b/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
@@ -120,3 +120,27 @@ TEST_F(ModelFixture,TableMultiVariableLookup)
   }
 }
 
+TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
+
+  Model m;
+  TableMultiVariableLookup table(m,2);
+
+  EXPECT_TRUE(table.addPoint(70,32,0.1));
+
+  TableMultiVariableLookupPoint pt1(std::vector<double> {71,32}, 0.15);
+  TableMultiVariableLookupPoint pt2(72, 32, 0.3);
+  TableMultiVariableLookupPoint pt3(std::vector<double> {74,32}, 0.5);
+
+  std::vector<TableMultiVariableLookupPoint> points;
+  points.push_back(pt1);
+  points.push_back(pt2);
+  points.push_back(pt3);
+
+  EXPECT_TRUE(table.setPoints(points));
+
+  TableMultiVariableLookupPoint bad_point(70, 0.7);
+  points.push_back(bad_point);
+  EXPECT_FALSE(table.setPoints(points));
+
+}
+

--- a/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
+++ b/openstudiocore/src/model/test/TableMultiVariableLookup_GTest.cpp
@@ -128,6 +128,7 @@ TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
   EXPECT_TRUE(table.addPoint(70,32,0.1));
 
   TableMultiVariableLookupPoint pt1(std::vector<double> {71,32}, 0.15);
+  // Add with the overloaded Ctor that takes (x0, x1, y)
   TableMultiVariableLookupPoint pt2(72, 32, 0.3);
   TableMultiVariableLookupPoint pt3(std::vector<double> {74,32}, 0.5);
 
@@ -136,11 +137,30 @@ TEST_F(ModelFixture,TableMultiVariableLookupPoint) {
   points.push_back(pt2);
   points.push_back(pt3);
 
+  // setPoints just replaces points
   EXPECT_TRUE(table.setPoints(points));
+  EXPECT_EQ(3, table.points().size());
+  {
+    TableMultiVariableLookupPoint pt = table.points()[0];
+    EXPECT_EQ(2, pt.x().size());
+    EXPECT_DOUBLE_EQ(71, pt.x()[0]);
+    EXPECT_DOUBLE_EQ(32, pt.x()[1]);
+    EXPECT_DOUBLE_EQ(0.15, pt.y());
+  }
 
   TableMultiVariableLookupPoint bad_point(70, 0.7);
   points.push_back(bad_point);
+  // It should catch that at least one point doesn't have the appropriate number of independent variables
+  // and as a result both return false and don't affect the points
   EXPECT_FALSE(table.setPoints(points));
+  EXPECT_EQ(3, table.points().size());
+  {
+    TableMultiVariableLookupPoint pt = table.points()[0];
+    EXPECT_EQ(2, pt.x().size());
+    EXPECT_DOUBLE_EQ(71, pt.x()[0]);
+    EXPECT_DOUBLE_EQ(32, pt.x()[1]);
+    EXPECT_DOUBLE_EQ(0.15, pt.y());
+  }
 
 }
 


### PR DESCRIPTION
Related to discussion with @macumber  in #3223 

```ruby
m = OpenStudio::Model::Model.new
capModFuncOfWaterFlow = OpenStudio::Model::TableMultiVariableLookup.new(m, 1)
capModFuncOfWaterFlow.setName("CapModFuncOfWaterFlow")
capModFuncOfWaterFlow.setCurveType("Quadratic")
capModFuncOfWaterFlow.setInterpolationMethod("EvaluateCurveToLimits")
capModFuncOfWaterFlow.setMinimumValueofX1(0)
capModFuncOfWaterFlow.setMaximumValueofX1(1.33)
capModFuncOfWaterFlow.setMinimumTableOutput(0.0)
capModFuncOfWaterFlow.setMaximumTableOutput(1.04)
capModFuncOfWaterFlow.setInputUnitTypeforX1("Dimensionless")
capModFuncOfWaterFlow.setOutputUnitType("Dimensionless")

capModFuncOfWaterFlow.addPoint(0.0, 0.0)
capModFuncOfWaterFlow.addPoint(0.05, 0.001)
capModFuncOfWaterFlow.addPoint(0.33333, 0.71)
capModFuncOfWaterFlow.addPoint(0.5, 0.85)
capModFuncOfWaterFlow.addPoint(0.666667, 0.92)
capModFuncOfWaterFlow.addPoint(0.833333, 0.97)
capModFuncOfWaterFlow.addPoint(1.0, 1.0)
capModFuncOfWaterFlow.addPoint(1.333333, 1.04)

points = capModFuncOfWaterFlow.points
```

**Original behavior**:

```ruby
points
=> #<SWIG::TYPE_p_std__vectorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_std__allocatorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_t_t:0x007f9688250ac8
 @__swigtype__=
  "_p_std__vectorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_std__allocatorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_t_t">

points[0]
NoMethodError: undefined method `[]' for #<SWIG::TYPE_p_std__vectorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_std__allocatorT_std__pairT_std__vectorT_double_std__allocatorT_double_t_t_double_t_t_t:0x007f9688250ac8>
from (pry):41:in `__pry__'
```

**With the changes**

```ruby
[23] OS-build(main)> points
=> [[[0.0], 0.0],
 [[0.05], 0.001],
 [[0.33333], 0.71],
 [[0.5], 0.85],
 [[0.666667], 0.92],
 [[0.833333], 0.97],
 [[1.0], 1.0],
 [[1.333333], 1.04]]
[24] OS-build(main)> points[0]
=> [[0.0], 0.0]
```