### PR TITLE
GeneratorFuelSupply: Change Ctor defaults to avoid E+ error with LiquidGeneric

### DIFF
--- a/openstudiocore/src/model/GeneratorFuelSupply.cpp
+++ b/openstudiocore/src/model/GeneratorFuelSupply.cpp
@@ -424,12 +424,19 @@ GeneratorFuelSupply::GeneratorFuelSupply(const Model& model, Schedule& tempSched
       << powerCurve.briefDescription() << ".");
   }
   setCompressorHeatLossFactor(1);
-  setFuelType("LiquidGeneric");
-  setLiquidGenericFuelLowerHeatingValue(43100);
-  setLiquidGenericFuelHigherHeatingValue(46200);
-  setLiquidGenericFuelMolecularWeight(1);
-  setLiquidGenericFuelCO2EmissionFactor(0);
-  setNumberofConstituentsinGaseousConstituentFuelSupply(0);
+
+  // From E+ 9.0.0, Microcogeneration.idf
+  // LiquidGeneric is broken, see https://github.com/NREL/EnergyPlus/issues/6998
+  setName("NATURALGAS");
+  setFuelType("GaseousConstituents");
+  addConstituent("METHANE", 0.9490);
+  addConstituent("CarbonDioxide", 0.0070);
+  addConstituent("NITROGEN", 0.0160);
+  addConstituent("ETHANE", 0.0250);
+  addConstituent("PROPANE", 0.0020);
+  addConstituent("BUTANE", 0.0006);
+  addConstituent("PENTANE", 0.0002);
+  addConstituent("OXYGEN", 0.0002);
 }
 
 GeneratorFuelSupply::GeneratorFuelSupply(const Model& model)
@@ -455,11 +462,19 @@ GeneratorFuelSupply::GeneratorFuelSupply(const Model& model)
   curveCubic.setName("Compressor Power Multiplier Function of FuelRate Curve");
   setCompressorPowerMultiplierFunctionofFuelRateCurve(curveCubic);
   setCompressorHeatLossFactor(1);
-  setFuelType("LiquidGeneric");
-  setLiquidGenericFuelLowerHeatingValue(43100);
-  setLiquidGenericFuelHigherHeatingValue(46200);
-  setLiquidGenericFuelMolecularWeight(1);
-  setNumberofConstituentsinGaseousConstituentFuelSupply(0);
+
+  // From E+ 9.0.0, Microcogeneration.idf
+  // LiquidGeneric is broken, see https://github.com/NREL/EnergyPlus/issues/6998
+  setName("NATURALGAS");
+  setFuelType("GaseousConstituents");
+  addConstituent("METHANE", 0.9490);
+  addConstituent("CarbonDioxide", 0.0070);
+  addConstituent("NITROGEN", 0.0160);
+  addConstituent("ETHANE", 0.0250);
+  addConstituent("PROPANE", 0.0020);
+  addConstituent("BUTANE", 0.0006);
+  addConstituent("PENTANE", 0.0002);
+  addConstituent("OXYGEN", 0.0002);
 }
 
 IddObjectType GeneratorFuelSupply::iddObjectType() {

--- a/openstudiocore/src/model/GeneratorFuelSupply.cpp
+++ b/openstudiocore/src/model/GeneratorFuelSupply.cpp
@@ -445,8 +445,6 @@ GeneratorFuelSupply::GeneratorFuelSupply(const Model& model)
 {
   OS_ASSERT(getImpl<detail::GeneratorFuelSupply_Impl>());
 
-  setLiquidGenericFuelCO2EmissionFactor(0);
-
   setFuelTemperatureModelingMode("Scheduled");
   ScheduleConstant schedule(model);
   schedule.setValue(20);

--- a/openstudiocore/src/model/GeneratorFuelSupply.cpp
+++ b/openstudiocore/src/model/GeneratorFuelSupply.cpp
@@ -284,7 +284,8 @@ namespace detail {
   }
 
   void GeneratorFuelSupply_Impl::resetFuelType() {
-    bool result = setString(OS_Generator_FuelSupplyFields::FuelType, "LiquidGeneric");
+    // TODO A bit unusual to set a default that doesn't exist in IDD
+    bool result = setString(OS_Generator_FuelSupplyFields::FuelType, "GaseousConstituents");
     OS_ASSERT(result);
   }
 

--- a/openstudiocore/src/model/test/GeneratorFuelSupply_GTest.cpp
+++ b/openstudiocore/src/model/test/GeneratorFuelSupply_GTest.cpp
@@ -70,16 +70,52 @@ TEST_F(ModelFixture, FuelCellFuelSupply) {
   EXPECT_EQ(1.0e10, curveCubic.maximumValueofx());
 
   EXPECT_EQ(1, fuelsupply.compressorHeatLossFactor());
+
+  EXPECT_EQ("GaseousConstituents", fuelsupply.fuelType());
+  EXPECT_TRUE(fuelsupply.setFuelType("LiquidGeneric"));
   EXPECT_EQ("LiquidGeneric", fuelsupply.fuelType());
   fuelsupply.resetFuelType();
-  EXPECT_EQ("LiquidGeneric", fuelsupply.fuelType());
-  EXPECT_EQ(43100, fuelsupply.liquidGenericFuelLowerHeatingValue().get());
+  EXPECT_EQ("GaseousConstituents", fuelsupply.fuelType());
+
+  // LHV
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelLowerHeatingValue());
+  EXPECT_TRUE(fuelsupply.setLiquidGenericFuelLowerHeatingValue(43100.0));
+  ASSERT_TRUE(fuelsupply.liquidGenericFuelLowerHeatingValue());
+  EXPECT_DOUBLE_EQ(43100.0, fuelsupply.liquidGenericFuelLowerHeatingValue().get());
   fuelsupply.resetLiquidGenericFuelLowerHeatingValue();
   EXPECT_FALSE(fuelsupply.liquidGenericFuelLowerHeatingValue());
-  EXPECT_EQ(46200, fuelsupply.liquidGenericFuelHigherHeatingValue().get());
+
+  // HHV
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelHigherHeatingValue());
+  EXPECT_TRUE(fuelsupply.setLiquidGenericFuelHigherHeatingValue(46200.0));
+  ASSERT_TRUE(fuelsupply.liquidGenericFuelHigherHeatingValue());
+  EXPECT_DOUBLE_EQ(46200.0, fuelsupply.liquidGenericFuelHigherHeatingValue().get());
   fuelsupply.resetLiquidGenericFuelHigherHeatingValue();
   EXPECT_FALSE(fuelsupply.liquidGenericFuelHigherHeatingValue());
-  EXPECT_EQ(1, fuelsupply.liquidGenericFuelMolecularWeight().get());
+
+  // Molecular weight
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelMolecularWeight());
+  EXPECT_TRUE(fuelsupply.setLiquidGenericFuelMolecularWeight(1.0));
+  ASSERT_TRUE(fuelsupply.liquidGenericFuelMolecularWeight());
+  EXPECT_DOUBLE_EQ(1.0, fuelsupply.liquidGenericFuelMolecularWeight().get());
+  fuelsupply.resetLiquidGenericFuelMolecularWeight();
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelMolecularWeight());
+
+  // CO2 Emission Factor
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelCO2EmissionFactor());
+  EXPECT_TRUE(fuelsupply.setLiquidGenericFuelCO2EmissionFactor(0.0));
+  ASSERT_TRUE(fuelsupply.liquidGenericFuelCO2EmissionFactor());
+  EXPECT_DOUBLE_EQ(0.0, fuelsupply.liquidGenericFuelCO2EmissionFactor().get());
+  fuelsupply.resetLiquidGenericFuelCO2EmissionFactor();
+  EXPECT_FALSE(fuelsupply.liquidGenericFuelCO2EmissionFactor());
+  fuelsupply.resetLiquidGenericFuelCO2EmissionFactor();
+
+
+  // CTOR creates 8 to match natural gas
+  EXPECT_EQ(8, fuelsupply.numberofConstituentsinGaseousConstituentFuelSupply().get());
+
+  fuelsupply.removeAllConstituents();
+
   EXPECT_EQ(0, fuelsupply.numberofConstituentsinGaseousConstituentFuelSupply().get());
   //should fail since name is wrong
   ASSERT_FALSE(fuelsupply.addConstituent("MadeUp", 0.0092));


### PR DESCRIPTION
GeneratorFuelSupply: Change Ctor defaults to avoid E+ error with LiquidGeneric

Cf: https://github.com/NREL/EnergyPlus/issues/6998

