### PR TITLE
Updates openstudio-standards to 0.2.6

### DIFF
--- a/dependencies/ruby/Gemfile
+++ b/dependencies/ruby/Gemfile
@@ -7,7 +7,7 @@ source 'http://rubygems.org'
 gem 'openstudio-workflow', '= 1.3.3'
 #gem 'openstudio-workflow', :github => 'NREL/OpenStudio-workflow-gem', :ref => '3e62211b29e28d341c4a84794f35a772c91a2145'
 
-gem 'openstudio-standards', '= 0.2.5'
+gem 'openstudio-standards', '= 0.2.6'
 #gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :ref => '1a6a81d242f1783ace78c737059d2ef6121e5675'
 
 gem 'simplecov', :github => 'NREL/simplecov', :ref => '98c33ffcb40fe867857a44b4d1a308f015b32e27'

--- a/dependencies/ruby/Gemfile.lock
+++ b/dependencies/ruby/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    openstudio-standards (0.2.5)
+    openstudio-standards (0.2.6)
     openstudio-workflow (1.3.3)
     openstudio_measure_tester (0.1.5)
       git (= 1.3.0)
@@ -55,7 +55,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (= 1.14.4)
-  openstudio-standards (= 0.2.5)
+  openstudio-standards (= 0.2.6)
   openstudio-workflow (= 1.3.3)
   openstudio_measure_tester (= 0.1.5)
   parallel (= 1.12.1)

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -588,8 +588,8 @@ endif()
 # to update the openstudio gems, you must first update the gems specified in the \dependencies\ruby\Gemfile file
 # next, build the openstudio-gems target of the OpenStudio super-build project (CMakeLists.txt one directory above this)
 # upload the openstudio-gems-DATE.tar.gz to the dependencies location on s3, then update the MD5sum and url below
-set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20181004.tar.gz")
-set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "4e9295cc8bc18971e83a32b57f303182")
+set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20181010.tar.gz")
+set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "e07e5bd74ab643f7ed9f0e013db8c2d0")
 
 set(OPENSTUDIO_GEMS_ZIP_LOCAL_PATH "${CMAKE_BINARY_DIR}/${OPENSTUDIO_GEMS_ZIP_FILENAME}")
 if(EXISTS "${OPENSTUDIO_GEMS_ZIP_LOCAL_PATH}")


### PR DESCRIPTION
Updates openstudio-standards gem to 0.2.6 to make the gems compatible with OpenStudio 2.7.0 API changes.