### PR TITLE
Encoding tests

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -716,7 +716,7 @@ if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
     URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.12.tar.gz
-    URL_MD5 41609f61cbfa23d482fa31e4cbe6d939
+    URL_MD5 3197d5a4a0245e12b19fa7898da2fda8
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
     BUILD_COMMAND ${MAKE}

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -711,11 +711,12 @@ else()
 endif()
 
 
+# using forked version of SWIG at https://github.com/macumber/swig
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
-    URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.7.tar.gz
-    URL_MD5 7fff46c84b8c630ede5b0f0827e3d90a
+    URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.12.tar.gz
+    URL_MD5 c804efcd8e5085f69f417ba8a9c220f7
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
     BUILD_COMMAND ${MAKE}
@@ -725,9 +726,9 @@ if(UNIX)
   set(SWIG_EXECUTABLE ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)
 else()
   # SWIG requires MinGW to compile on windows, so we just copy in the prebuilt binary
-  set(SWIG_ZIP "swigwin-3.0.7.zip")
-  set(SWIG_DIR "swigwin-3.0.7")
-  set(SWIG_EXPECTED_HASH "d8b5a9ce49c819cc1bfc1e797b85ba7a")
+  set(SWIG_ZIP "swigwin-3.0.12.zip")
+  set(SWIG_DIR "swigwin-3.0.12")
+  set(SWIG_EXPECTED_HASH "19a24f42564efae4ef4e249bafc1c944")
   if(EXISTS "${CMAKE_BINARY_DIR}/${SWIG_ZIP}")
     file(MD5 "${CMAKE_BINARY_DIR}/${SWIG_ZIP}" SWIG_HASH)
   endif()

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -711,12 +711,12 @@ else()
 endif()
 
 
-# using forked version of SWIG at https://github.com/macumber/swig
+# using forked version of SWIG at https://github.com/macumber/swig/tree/openstudio_swig_3_0_12
 if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
     URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.12.tar.gz
-    URL_MD5 3197d5a4a0245e12b19fa7898da2fda8
+    URL_MD5 a7d384966974ed79455a455b517ad83d
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
     BUILD_COMMAND ${MAKE}
@@ -728,7 +728,7 @@ else()
   # SWIG requires MinGW to compile on windows, so we just copy in the prebuilt binary
   set(SWIG_ZIP "swigwin-3.0.12.zip")
   set(SWIG_DIR "swigwin-3.0.12")
-  set(SWIG_EXPECTED_HASH "19a24f42564efae4ef4e249bafc1c944")
+  set(SWIG_EXPECTED_HASH "8ee412d1278ba3cac22e58f26a842918")
   if(EXISTS "${CMAKE_BINARY_DIR}/${SWIG_ZIP}")
     file(MD5 "${CMAKE_BINARY_DIR}/${SWIG_ZIP}" SWIG_HASH)
   endif()

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -716,7 +716,7 @@ if(UNIX)
   # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
   ExternalProject_Add(SWIG
     URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.12.tar.gz
-    URL_MD5 c804efcd8e5085f69f417ba8a9c220f7
+    URL_MD5 41609f61cbfa23d482fa31e4cbe6d939
     PATCH_COMMAND cp ${CMAKE_SOURCE_DIR}/../dependencies/pcre-8.31.tar.bz2 ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
     CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${CMAKE_BINARY_DIR}/SWIG-prefix/src/SWIG-install
     BUILD_COMMAND ${MAKE}

--- a/openstudiocore/src/cli/RubyInterpreter.hpp
+++ b/openstudiocore/src/cli/RubyInterpreter.hpp
@@ -39,6 +39,7 @@
 #include <sstream>
 
 #include <ruby.h>
+#include <ruby/encoding.h>
 // SWIGRubyRuntime.hxx includes ruby.h which includes ruby/win32.h, which has some brain damaged notions of
 // what standard errno values should be.
 

--- a/openstudiocore/src/cli/main.cpp
+++ b/openstudiocore/src/cli/main.cpp
@@ -495,6 +495,11 @@ int main(int argc, char *argv[])
    init_openstudio_internal();
   }
 
+  // DLM: this will interpret any strings passed on the command line as UTF-8
+  // can we be smarter and detect the correct encoding?
+  // might want to follow ruby and allow '--external-encoding=UTF-8' as an input argument?
+  rb_enc_set_default_external(rb_enc_from_encoding(rb_utf8_encoding()));
+
   // chop off the first argument which is the exe path/name
   ruby_set_argv(argc - 1,argv + 1);
 

--- a/openstudiocore/src/cli/test/test_encodings.rb
+++ b/openstudiocore/src/cli/test/test_encodings.rb
@@ -27,4 +27,27 @@ class Encoding_Test < Minitest::Test
     assert_equal("UTF-8", path.to_s.encoding.to_s)
   end   
   
+  def test_encoding2
+    test_string = "模型"
+    assert_equal("UTF-8", test_string.encoding.to_s)
+    
+    model = OpenStudio::Model::Model.new
+    space = OpenStudio::Model::Space.new(model)
+    
+    space.setName(test_string)
+    
+    name_string = space.nameString
+    assert_equal(test_string, name_string)
+    assert_equal("UTF-8", name_string.encoding.to_s)
+    
+    optional_string = space.name
+    assert(optional_string.is_initialized)
+    assert_equal(test_string, optional_string.get)
+    assert_equal("UTF-8", optional_string.get.encoding.to_s)
+    
+    path = OpenStudio::toPath(test_string)
+    assert_equal(test_string, path.to_s)
+    assert_equal("UTF-8", path.to_s.encoding.to_s)
+  end   
+  
 end

--- a/openstudiocore/src/cli/test/test_encodings.rb
+++ b/openstudiocore/src/cli/test/test_encodings.rb
@@ -1,0 +1,30 @@
+require 'minitest/autorun'
+require 'openstudio'
+
+# test encoding of strings returned from OpenStudio Ruby bindings
+class Encoding_Test < Minitest::Test
+
+  def test_encoding
+    test_string = "Hello"
+    assert_equal("UTF-8", test_string.encoding.to_s)
+    
+    model = OpenStudio::Model::Model.new
+    space = OpenStudio::Model::Space.new(model)
+    
+    space.setName(test_string)
+    
+    name_string = space.nameString
+    assert_equal(test_string, name_string)
+    assert_equal("UTF-8", name_string.encoding.to_s)
+    
+    optional_string = space.name
+    assert(optional_string.is_initialized)
+    assert_equal(test_string, optional_string.get)
+    assert_equal("UTF-8", optional_string.get.encoding.to_s)
+    
+    path = OpenStudio::toPath(test_string)
+    assert_equal(test_string, path.to_s)
+    assert_equal("UTF-8", path.to_s.encoding.to_s)
+  end   
+  
+end

--- a/openstudiocore/src/isomodel/EpwData.cpp
+++ b/openstudiocore/src/isomodel/EpwData.cpp
@@ -193,7 +193,7 @@ std::string EpwData::toISOData() const {
 void EpwData::loadData(const openstudio::path &fn)
 {
   // Array was fully initialized in constructor
-  std::ifstream myfile(openstudio::toString(fn).c_str());
+  std::ifstream myfile(openstudio::toSystemFilename(fn));
   if (myfile.is_open())
   {
     size_t i = 0;

--- a/openstudiocore/src/isomodel/UserModel.cpp
+++ b/openstudiocore/src/isomodel/UserModel.cpp
@@ -575,7 +575,7 @@ namespace isomodel {
   }
   void UserModel::loadBuilding(const openstudio::path &buildingFile){
     string line;
-    ifstream inputFile(openstudio::toString(buildingFile).c_str());
+    ifstream inputFile(openstudio::toSystemFilename(buildingFile));
     if (inputFile.is_open()) {
       while (inputFile.good()) {
         getline (inputFile,line);
@@ -663,7 +663,7 @@ namespace isomodel {
   void UserModel::save(const openstudio::path &t_buildingFile) const
   {
 
-    std::ofstream ofile(openstudio::toString(t_buildingFile).c_str());
+    std::ofstream ofile(openstudio::toSystemFilename(t_buildingFile));
 
     ofile << "terrainClass = " << _terrainClass << std::endl;
     ofile << "floorArea = " << _floorArea << std::endl;

--- a/openstudiocore/src/openstudio_lib/ScriptFolderListView.cpp
+++ b/openstudiocore/src/openstudio_lib/ScriptFolderListView.cpp
@@ -122,7 +122,7 @@ void ScriptFolderListView::createEmptyScript(const openstudio::path &t_folder_na
   // Scope for creating and closing file.
   {
     openstudio::filesystem::create_directories(m_rootPath / t_folder_name);
-    std::ofstream ofs(openstudio::toString(filename).c_str());
+    std::ofstream ofs(openstudio::toSystemFilename(filename));
     ofs << "# Empty Script" << std::endl;
   }
 

--- a/openstudiocore/src/radiance/ForwardTranslator.cpp
+++ b/openstudiocore/src/radiance/ForwardTranslator.cpp
@@ -327,7 +327,7 @@ namespace radiance {
 
       // write options files
       std::string dcmatsStringin;
-      std::ifstream dcmatfilein(openstudio::toString(radDir / openstudio::toPath("materials/materials_dc.rad")).c_str());
+      std::ifstream dcmatfilein(openstudio::toSystemFilename(radDir / openstudio::toPath("materials/materials_dc.rad")));
 
       while (dcmatfilein.good())
       {

--- a/openstudiocore/src/utilities/bcl/BCL.cpp
+++ b/openstudiocore/src/utilities/bcl/BCL.cpp
@@ -31,15 +31,10 @@
 
 #include "LocalBCL.hpp"
 #include "RemoteBCL.hpp"
-#include "BCLComponent.hpp"
-#include "BCLMeasure.hpp"
 
 #include "../core/Assert.hpp"
-#include "../data/Attribute.hpp"
 
-#include <QDomElement>
 
-#include <boost/lexical_cast.hpp>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/bcl/BCLComponent.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLComponent.cpp
@@ -29,7 +29,6 @@
 
 #include "BCLComponent.hpp"
 #include "../core/System.hpp"
-#include "../data/Attribute.hpp"
 #include "../core/FilesystemHelpers.hpp"
 
 #include <QDomDocument>

--- a/openstudiocore/src/utilities/bcl/BCLFileReference.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLFileReference.cpp
@@ -29,11 +29,8 @@
 
 #include "BCLFileReference.hpp"
 #include "../core/Checksum.hpp"
-#include "../core/String.hpp"
-#include "../core/System.hpp"
 
 #include <QDomDocument>
-#include <QDomElement>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
@@ -30,24 +30,18 @@
 #include "BCLMeasure.hpp"
 #include "LocalBCL.hpp"
 
-#include "../core/System.hpp"
-#include "../core/Path.hpp"
 #include "../core/PathHelpers.hpp"
 #include "../core/FilesystemHelpers.hpp"
 #include "../core/StringHelpers.hpp"
 #include "../core/FileReference.hpp"
-#include "../data/Attribute.hpp"
 #include "../core/Assert.hpp"
-#include "../core/Checksum.hpp"
 
 #include <OpenStudio.hxx>
 
 #include <QDir>
-#include <QDomDocument>
 #include <QSettings>
 #include <QRegularExpression>
 
-#include <boost/algorithm/string/predicate.hpp>
 
 #include <src/utilities/embedded_files.hxx>
 

--- a/openstudiocore/src/utilities/bcl/BCLMeasureArgument.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasureArgument.cpp
@@ -32,7 +32,6 @@
 #include "../core/Assert.hpp"
 
 #include <QDomDocument>
-#include <QDomElement>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/bcl/BCLMeasureOutput.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasureOutput.cpp
@@ -32,7 +32,6 @@
 #include "../core/Assert.hpp"
 
 #include <QDomDocument>
-#include <QDomElement>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/bcl/BCLXML.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLXML.cpp
@@ -29,15 +29,9 @@
 
 #include "BCLXML.hpp"
 
-#include "../data/Attribute.hpp"
 
-#include "../units/Unit.hpp"
 #include "../units/Quantity.hpp"
-#include "../core/Compare.hpp"
-#include "../core/String.hpp"
-#include "../core/System.hpp"
 #include "../core/Checksum.hpp"
-#include "../core/Assert.hpp"
 #include "../core/FilesystemHelpers.hpp"
 #include "../time/DateTime.hpp"
 

--- a/openstudiocore/src/utilities/bcl/LocalBCL.cpp
+++ b/openstudiocore/src/utilities/bcl/LocalBCL.cpp
@@ -27,33 +27,20 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#include "BCLComponent.hpp"
-#include "BCLMeasure.hpp"
 #include "LocalBCL.hpp"
 #include "RemoteBCL.hpp"
 #include "../core/Application.hpp"
 #include "../core/Assert.hpp"
-#include "../data/Attribute.hpp"
 #include "../time/DateTime.hpp"
-#include "../core/Path.hpp"
 #include "../core/PathHelpers.hpp"
-#include "../core/System.hpp"
 
 #include <QDir>
 #include <QIcon>
 #include <QInputDialog>
 #include <QSettings>
-#include <QSqlDatabase>
-#include <QSqlDriver>
-#include <QSqlError>
 #include <QSqlQuery>
-#include <QSqlResult>
 
-#include <boost/lexical_cast.hpp>
 
-#include <algorithm>
-#include <set>
-#include <vector>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
+++ b/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
@@ -31,25 +31,13 @@
 #include "RemoteBCL.hpp"
 #include "../core/Application.hpp"
 #include "../core/Assert.hpp"
-#include "../core/Path.hpp"
 #include "../core/PathHelpers.hpp"
 #include "../core/System.hpp"
 #include "../core/UnzipFile.hpp"
-#include "../core/ZipFile.hpp"
 
 #include <QDir>
-#include <QDomDocument>
-#include <QDomElement>
-#include <QFile>
-#include <QMessageBox>
 #include <QMutex>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
-#include <QNetworkRequest>
-#include <QSslError>
-#include <QTextStream>
-#include <QSslSocket>
-#include <QUrlQuery>
 
 #define REMOTE_PRODUCTION_SERVER "https://bcl.nrel.gov"
 #define REMOTE_DEVELOPMENT_SERVER "http://bcl7.development.nrel.gov"

--- a/openstudiocore/src/utilities/bcl/test/BCLComponent_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCLComponent_GTest.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include "BCLFixture.hpp"
-#include <resources.hxx>
 
 #include "../BCLComponent.hpp"
 

--- a/openstudiocore/src/utilities/bcl/test/BCLFileReference_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCLFileReference_GTest.cpp
@@ -29,11 +29,9 @@
 
 #include <gtest/gtest.h>
 #include "BCLFixture.hpp"
-#include <resources.hxx>
 
 #include "../BCLFileReference.hpp"
 
-#include <QTextStream>
 
 using namespace openstudio;
 

--- a/openstudiocore/src/utilities/bcl/test/BCLMeasure_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCLMeasure_GTest.cpp
@@ -30,9 +30,7 @@
 #include <gtest/gtest.h>
 #include "BCLFixture.hpp"
 #include "../../core/PathHelpers.hpp"
-#include <resources.hxx>
 
-#include "../BCLFileReference.hpp"
 #include "../BCLMeasure.hpp"
 
 

--- a/openstudiocore/src/utilities/bcl/test/BCLXML_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCLXML_GTest.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include "BCLFixture.hpp"
-#include <resources.hxx>
 
 #include "../BCLXML.hpp"
 

--- a/openstudiocore/src/utilities/bcl/test/BCL_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCL_GTest.cpp
@@ -30,20 +30,14 @@
 #include <gtest/gtest.h>
 #include "BCLFixture.hpp"
 
-#include "../BCLComponent.hpp"
-#include "../BCLMeasure.hpp"
 #include "../LocalBCL.hpp"
 #include "../RemoteBCL.hpp"
-#include "../../data/Attribute.hpp"
 #include "../../idd/IddFile.hpp"
 #include "../../idf/Workspace.hpp"
-#include "../../time/DateTime.hpp"
 #include "../../core/FilesystemHelpers.hpp"
 
-#include <QDateTime>
 #include <QDir>
 
-#include <time.h>
 
 using namespace openstudio;
 

--- a/openstudiocore/src/utilities/core/Application.cpp
+++ b/openstudiocore/src/utilities/core/Application.cpp
@@ -29,11 +29,8 @@
 
 #include "Application.hpp"
 #include "ApplicationPathHelpers.hpp"
-#include "PathHelpers.hpp"
 #include "String.hpp"
-#include <OpenStudio.hxx>
 
-#include <QWidget>
 #include <QSettings>
 
 #if _WIN32 || _MSC_VER
@@ -44,7 +41,6 @@
   #include <dlfcn.h>
 #endif
 
-#include <iostream>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/core/Checksum.cpp
+++ b/openstudiocore/src/utilities/core/Checksum.cpp
@@ -29,7 +29,6 @@
 
 #include "Checksum.hpp"
 
-#include <ios>
 #include <sstream>
 
 #include <boost/crc.hpp>

--- a/openstudiocore/src/utilities/core/Compare.cpp
+++ b/openstudiocore/src/utilities/core/Compare.cpp
@@ -28,12 +28,10 @@
 ***********************************************************************************************************************/
 
 #include "Compare.hpp"
-#include "Logger.hpp"
 #include "../idf/WorkspaceObject.hpp"
 #include "../bcl/BCLComponent.hpp"
 #include "Assert.hpp"
 
-#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 
 namespace openstudio {

--- a/openstudiocore/src/utilities/core/FileLogSink.cpp
+++ b/openstudiocore/src/utilities/core/FileLogSink.cpp
@@ -33,7 +33,6 @@
 #include "Assert.hpp"
 
 #include <QReadWriteLock>
-#include <QWriteLocker>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/core/FileReference.cpp
+++ b/openstudiocore/src/utilities/core/FileReference.cpp
@@ -32,10 +32,8 @@
 #include "Assert.hpp"
 #include "Checksum.hpp"
 #include "PathHelpers.hpp"
-#include "../time/DateTime.hpp"
 #include "../core/FilesystemHelpers.hpp"
 
-#include <QDateTime>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
@@ -29,7 +29,6 @@
 
 #include "FilesystemHelpers.hpp"
 #include "Path.hpp"
-#include "String.hpp"
 #include "Assert.hpp"
 
 namespace openstudio {

--- a/openstudiocore/src/utilities/core/Json.cpp
+++ b/openstudiocore/src/utilities/core/Json.cpp
@@ -30,13 +30,9 @@
 #include "Json.hpp"
 
 #include "Assert.hpp"
-#include "Compare.hpp"
-#include "Logger.hpp"
 #include "PathHelpers.hpp"
 #include "FilesystemHelpers.hpp"
-#include "String.hpp"
 
-#include <jsoncpp/json.h>
 
 #include <OpenStudio.hxx>
 

--- a/openstudiocore/src/utilities/core/LogSink.cpp
+++ b/openstudiocore/src/utilities/core/LogSink.cpp
@@ -32,17 +32,10 @@
 
 #include "Logger.hpp"
 
-#include <boost/log/common.hpp>
 #include <boost/log/support/regex.hpp>
 #include <boost/log/expressions.hpp>
-#include <boost/log/expressions/keyword.hpp>
-#include <boost/log/expressions/attr_fwd.hpp>
-#include <boost/log/expressions/attr.hpp>
-#include <boost/log/attributes/value_extraction.hpp>
 
 #include <QReadWriteLock>
-#include <QWriteLocker>
-#include <QThread>
 
 namespace sinks = boost::log::sinks;
 namespace keywords = boost::log::keywords;

--- a/openstudiocore/src/utilities/core/Logger.cpp
+++ b/openstudiocore/src/utilities/core/Logger.cpp
@@ -30,28 +30,12 @@
 #include "Logger.hpp"
 
 #include <boost/log/common.hpp>
-#include <boost/log/core/record.hpp>
-#include <boost/log/core/core.hpp>
-#include <boost/log/attributes/attribute.hpp>
-#include <boost/log/attributes/current_thread_id.hpp>
-#include <boost/log/attributes/attribute_value.hpp>
-#include <boost/log/sources/channel_feature.hpp>
-#include <boost/log/sources/severity_feature.hpp>
-#include <boost/log/sources/severity_channel_logger.hpp>
-#include <boost/log/sources/global_logger_storage.hpp>
-#include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/attributes/function.hpp>
-#include <boost/log/support/regex.hpp>
 
 #include <boost/utility/empty_deleter.hpp>
 
-#include <sstream>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include <QReadWriteLock>
-#include <QWriteLocker>
-#include <QApplication>
 #include <QThread>
 
 namespace sinks = boost::log::sinks;

--- a/openstudiocore/src/utilities/core/Path.cpp
+++ b/openstudiocore/src/utilities/core/Path.cpp
@@ -32,8 +32,6 @@
 
 #include <QDir>
 
-#include <iostream>
-#include <string>
 
 #ifdef Q_OS_WIN
 #include <locale>

--- a/openstudiocore/src/utilities/core/Path.cpp
+++ b/openstudiocore/src/utilities/core/Path.cpp
@@ -138,6 +138,20 @@ path toPath(const std::string& s)
   return path(s);
 }
 
+#ifdef WIN32
+/** UTF-16 encoded std::wstring for opening fstreams*/
+std::wstring toSystemFilename(const path& p)
+{
+  return p.wstring();
+}
+#else
+/** UTF-8 encoded std::string for opening fstreams*/
+std::string toSystemFilename(const path& p) 
+{
+  return p.string();
+}
+#endif
+
 } // openstudio
 
 // allow path to be written to QTextStream

--- a/openstudiocore/src/utilities/core/Path.hpp
+++ b/openstudiocore/src/utilities/core/Path.hpp
@@ -64,6 +64,14 @@ UTILITIES_API path toPath(const std::string& s);
 /** QString to path*/
 UTILITIES_API path toPath(const QString& q);
 
+#ifdef WIN32
+/** UTF-16 encoded std::wstring for opening fstreams*/
+UTILITIES_API std::wstring toSystemFilename(const path& p);
+#else
+/** UTF-8 encoded std::string for opening fstreams*/
+UTILITIES_API std::string toSystemFilename(const path& p);
+#endif
+
 /** Optional path*/
 typedef boost::optional<path> OptionalPath;
 

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -28,11 +28,9 @@
 ***********************************************************************************************************************/
 
 #include "PathHelpers.hpp"
-#include "Logger.hpp"
 #include "Assert.hpp"
 #include "FilesystemHelpers.hpp"
 
-#include <QDir>
 #include <QRegularExpression>
 
 #ifdef Q_OS_WIN

--- a/openstudiocore/src/utilities/core/PathWatcher.cpp
+++ b/openstudiocore/src/utilities/core/PathWatcher.cpp
@@ -31,7 +31,6 @@
 #include "Application.hpp"
 #include "Checksum.hpp"
 #include "Assert.hpp"
-#include "Logger.hpp"
 
 #include <QFileSystemWatcher>
 #include <QTimer>

--- a/openstudiocore/src/utilities/core/String.cpp
+++ b/openstudiocore/src/utilities/core/String.cpp
@@ -31,14 +31,8 @@
 
 #include "Logger.hpp"
 
-#include <boost/lexical_cast.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
-#include <sstream>
 #include <iomanip>
-#include <limits>
-#include <cmath>
-#include <cfloat>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/core/StringHelpers.cpp
+++ b/openstudiocore/src/utilities/core/StringHelpers.cpp
@@ -28,16 +28,11 @@
 ***********************************************************************************************************************/
 
 #include "Assert.hpp"
-#include "Optional.hpp"
 #include "StringHelpers.hpp"
 #include "../math/FloatCompare.hpp"
 
-#include <boost/regex.hpp>
-#include <boost/algorithm/string.hpp>
 
-#include <cmath>
 #include <iomanip>
-#include <sstream>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/core/StringStreamLogSink.cpp
+++ b/openstudiocore/src/utilities/core/StringStreamLogSink.cpp
@@ -32,12 +32,9 @@
 
 #include "Assert.hpp"
 
-#include <boost/lexical_cast.hpp>
 
-#include <sstream>
 
 #include <QReadWriteLock>
-#include <QWriteLocker>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/core/System.cpp
+++ b/openstudiocore/src/utilities/core/System.cpp
@@ -30,17 +30,10 @@
 #include "System.hpp"
 #include "Application.hpp"
 
-#include <boost/lexical_cast.hpp>
 #include <boost/thread.hpp>
 
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/matrix_sparse.hpp>
-#include <boost/numeric/ublas/io.hpp>
-#include <boost/numeric/ublas/matrix_proxy.hpp>
-#include <boost/numeric/ublas/triangular.hpp>
 #include <boost/numeric/ublas/lu.hpp>
 
-#include <cassert>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/core/URLHelpers.cpp
+++ b/openstudiocore/src/utilities/core/URLHelpers.cpp
@@ -28,8 +28,6 @@
 ***********************************************************************************************************************/
 
 #include "URLHelpers.hpp"
-#include "Path.hpp"
-#include "String.hpp"
 
 #include <QRegularExpression>
 

--- a/openstudiocore/src/utilities/core/UUID.cpp
+++ b/openstudiocore/src/utilities/core/UUID.cpp
@@ -29,7 +29,6 @@
 
 #include "UUID.hpp"
 #include "String.hpp"
-#include "Checksum.hpp"
 #include "StaticInitializer.hpp"
 
 #include <sstream>

--- a/openstudiocore/src/utilities/core/UnzipFile.cpp
+++ b/openstudiocore/src/utilities/core/UnzipFile.cpp
@@ -28,11 +28,7 @@
 ***********************************************************************************************************************/
 
 #include "UnzipFile.hpp"
-#include "FilesystemHelpers.hpp"
-#include <zlib/zconf.h>
-#include <zlib/zlib.h>
 #include <zlib/contrib/minizip/unzip.h>
-#include <fstream>
 
 
 #include <QDir>

--- a/openstudiocore/src/utilities/core/UpdateManager.cpp
+++ b/openstudiocore/src/utilities/core/UpdateManager.cpp
@@ -32,18 +32,11 @@
 #include "Application.hpp"
 #include <OpenStudio.hxx>
 
-#include <QNetworkAccessManager>
-#include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QDomDocument>
-#include <QThread>
-#include <QAbstractEventDispatcher>
 
-#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 
-#include <iostream>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/core/ZipFile.cpp
+++ b/openstudiocore/src/utilities/core/ZipFile.cpp
@@ -63,7 +63,7 @@ namespace openstudio {
     }
 
     try {
-      std::ifstream ifs(openstudio::toString(localPath).c_str(), std::ios_base::in | std::ios_base::binary);
+      std::ifstream ifs(openstudio::toSystemFilename(localPath), std::ios_base::in | std::ios_base::binary);
 
       if (!ifs.is_open() || ifs.fail())
       {

--- a/openstudiocore/src/utilities/core/ZipFile.cpp
+++ b/openstudiocore/src/utilities/core/ZipFile.cpp
@@ -30,13 +30,9 @@
 #include "ZipFile.hpp"
 #include "FilesystemHelpers.hpp"
 
-#include <zlib/zconf.h>
-#include <zlib/zlib.h>
 #include <zlib/contrib/minizip/zip.h>
 
-#include <QDir>
 
-#include <fstream>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/core/test/Zip_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/Zip_GTest.cpp
@@ -84,7 +84,7 @@ TEST_F(CoreFixture, Unzip_ExtractFileTest)
   ASSERT_TRUE(openstudio::filesystem::exists(outfile1));
 
 
-  std::ifstream ifs(openstudio::toString(outfile1).c_str());
+  std::ifstream ifs(openstudio::toSystemFilename(outfile1));
 
   std::string line;
   std::getline(ifs, line);

--- a/openstudiocore/src/utilities/data/Attribute.cpp
+++ b/openstudiocore/src/utilities/data/Attribute.cpp
@@ -35,19 +35,13 @@
 #include "../core/Json.hpp"
 #include "../core/FilesystemHelpers.hpp"
 
-#include "../units/UnitFactory.hpp"
-#include "../units/Quantity.hpp"
 #include "../units/QuantityFactory.hpp"
 #include "../units/OSOptionalQuantity.hpp"
 
-#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <sstream>
-#include <limits>
 
 #include <QDomElement>
-#include <QDomDocument>
 
 namespace openstudio {
 namespace detail{

--- a/openstudiocore/src/utilities/data/CalibrationResult.cpp
+++ b/openstudiocore/src/utilities/data/CalibrationResult.cpp
@@ -30,7 +30,6 @@
 #include "CalibrationResult.hpp"
 #include "../core/Assert.hpp"
 #include "../time/Date.hpp"
-#include "DataEnums.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/data/Matrix.cpp
+++ b/openstudiocore/src/utilities/data/Matrix.cpp
@@ -32,12 +32,10 @@
 #include "../math/FloatCompare.hpp"
 
 #include <random>
-#include <set>
 
 // this should all be moved to a utilities/core/Random.h
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/optional.hpp>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/data/Tag.cpp
+++ b/openstudiocore/src/utilities/data/Tag.cpp
@@ -30,7 +30,6 @@
 #include "Tag.hpp"
 
 #include "../core/String.hpp"
-#include "../core/Compare.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/data/TimeSeries.cpp
+++ b/openstudiocore/src/utilities/data/TimeSeries.cpp
@@ -30,8 +30,6 @@
 #include "TimeSeries.hpp"
 #include "../core/Assert.hpp"
 
-#include <exception>
-#include <set>
 
 using namespace std;
 using namespace boost;

--- a/openstudiocore/src/utilities/data/Variant.cpp
+++ b/openstudiocore/src/utilities/data/Variant.cpp
@@ -29,7 +29,6 @@
 
 #include "Variant.hpp"
 
-#include "../core/Assert.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/data/Vector.cpp
+++ b/openstudiocore/src/utilities/data/Vector.cpp
@@ -29,7 +29,6 @@
 
 #include "Vector.hpp"
 
-#include <algorithm>
 #include <random>
 
 // this should all be moved to a utilities/core/Random.h

--- a/openstudiocore/src/utilities/filetypes/EpwFile.cpp
+++ b/openstudiocore/src/utilities/filetypes/EpwFile.cpp
@@ -2719,7 +2719,7 @@ namespace openstudio{
     m_checksum = openstudio::checksum(m_path);
 
     // open file
-    std::ifstream ifs(openstudio::toString(m_path));
+    std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
     if (!parse(ifs, storeData)){
       ifs.close();
@@ -2858,7 +2858,7 @@ namespace openstudio{
       m_checksum = openstudio::checksum(m_path);
 
       // open file
-      std::ifstream ifs(openstudio::toString(m_path));
+      std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
       if (!parse(ifs, true)){
         ifs.close();
@@ -4024,7 +4024,7 @@ namespace openstudio{
       m_checksum = openstudio::checksum(m_path);
 
       // open file
-      std::ifstream ifs(openstudio::toString(m_path));
+      std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
       if (!parse(ifs)){
         ifs.close();
@@ -4048,7 +4048,7 @@ namespace openstudio{
       m_checksum = openstudio::checksum(m_path);
 
       // open file
-      std::ifstream ifs(openstudio::toString(m_path));
+      std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
       if (!parse(ifs, true)) {
         ifs.close();
@@ -4098,7 +4098,7 @@ namespace openstudio{
       m_checksum = openstudio::checksum(m_path);
 
       // open file
-      std::ifstream ifs(openstudio::toString(m_path));
+      std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
       if (!parse(ifs, true)) {
         ifs.close();
@@ -4171,7 +4171,7 @@ namespace openstudio{
       m_checksum = openstudio::checksum(m_path);
 
       // open file
-      std::ifstream ifs(openstudio::toString(m_path));
+      std::ifstream ifs(openstudio::toSystemFilename(m_path));
 
       if (!parse(ifs, true)) {
         ifs.close();

--- a/openstudiocore/src/utilities/filetypes/EpwFile.cpp
+++ b/openstudiocore/src/utilities/filetypes/EpwFile.cpp
@@ -33,16 +33,9 @@
 #include <utilities/idd/IddEnums.hxx>
 #include "../core/Checksum.hpp"
 #include "../core/StringHelpers.hpp"
-#include "../core/FilesystemHelpers.hpp"
 #include "../core/Assert.hpp"
-#include "../units/QuantityConverter.hpp"
 
-#include <QStringList>
-#include <QTextStream>
 
-#include <cmath>
-#include <string>
-#include <fstream>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/filetypes/RunOptions.cpp
+++ b/openstudiocore/src/utilities/filetypes/RunOptions.cpp
@@ -32,7 +32,6 @@
 
 #include "../core/Assert.hpp"
 
-#include <jsoncpp/json.h>
 
 namespace openstudio{
 namespace detail{

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -79,7 +79,8 @@ namespace detail{
       openstudio::path p = toPath(s);
       if (boost::filesystem::exists(p) && boost::filesystem::is_regular_file(p)){
         // open file
-        std::ifstream ifs(openstudio::toString(p));
+        std::ifstream ifs(openstudio::toSystemFilename(p));
+
         m_value.clear();
         parsingSuccessful = reader.parse(ifs, m_value);
       }
@@ -100,7 +101,7 @@ namespace detail{
     }
 
     // open file
-    std::ifstream ifs(openstudio::toString(p));
+    std::ifstream ifs(openstudio::toSystemFilename(p));
 
     Json::Reader reader;
     bool parsingSuccessful = reader.parse(ifs, m_value);
@@ -197,7 +198,8 @@ namespace detail{
     }
 
     if (makeParentFolder(*p)) {
-      std::ofstream outFile(openstudio::toString(*p));
+      std::ofstream outFile(openstudio::toSystemFilename(*p));
+
       if (outFile) {
         try {
           outFile << string();

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -30,10 +30,7 @@
 #include "WorkflowJSON.hpp"
 #include "WorkflowJSON_Impl.hpp"
 
-#include "WorkflowStep.hpp"
 #include "WorkflowStep_Impl.hpp"
-#include "WorkflowStepResult.hpp"
-#include "RunOptions.hpp"
 #include "RunOptions_Impl.hpp"
 
 #include "../core/Assert.hpp"
@@ -41,10 +38,7 @@
 #include "../core/Checksum.hpp"
 #include "../time/DateTime.hpp"
 
-#include <boost/optional.hpp>
 
-#include <string>
-#include <fstream>
 
 namespace openstudio{
 namespace detail{

--- a/openstudiocore/src/utilities/filetypes/WorkflowStep.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowStep.cpp
@@ -32,7 +32,6 @@
 
 #include "../core/Assert.hpp"
 
-#include <jsoncpp/json.h>
 
 namespace openstudio{
 namespace detail{

--- a/openstudiocore/src/utilities/filetypes/WorkflowStepResult.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowStepResult.cpp
@@ -32,7 +32,6 @@
 
 #include "../utilities/core/Assert.hpp"
 
-#include "../utilities/data/Attribute.hpp"
 
 #include <jsoncpp/json.h>
 

--- a/openstudiocore/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
+++ b/openstudiocore/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
@@ -532,7 +532,7 @@ TEST(Filetypes, WorkflowJSON_Full)
     openstudio::path expectedSeedPath = resourcesPath() / toPath("osversion/1_9_0/example.osm");
     if (!boost::filesystem::exists(expectedSeedPath)){
       boost::filesystem::create_directories(expectedSeedPath.parent_path());
-      std::ofstream outFile(openstudio::toString(expectedSeedPath));
+      std::ofstream outFile(openstudio::toSystemFilename(expectedSeedPath));
       if (outFile) {
         outFile << "OS:Version,\n\
                     {8b3ac8ca-71e7-486e-ac28-74f6e601c3f2}, !- Handle\n\

--- a/openstudiocore/src/utilities/geometry/FloorplanJS.cpp
+++ b/openstudiocore/src/utilities/geometry/FloorplanJS.cpp
@@ -234,7 +234,7 @@ namespace openstudio{
       openstudio::path p = toPath(s);
       if (boost::filesystem::exists(p) && boost::filesystem::is_regular_file(p)){
         // open file
-        std::ifstream ifs(openstudio::toString(p));
+        std::ifstream ifs(openstudio::toSystemFilename(p));
         m_value.clear();
         parsingSuccessful = reader.parse(ifs, m_value);
       }

--- a/openstudiocore/src/utilities/geometry/FloorplanJS.cpp
+++ b/openstudiocore/src/utilities/geometry/FloorplanJS.cpp
@@ -31,18 +31,13 @@
 #include "ThreeJS.hpp"
 #include "Vector3d.hpp"
 #include "Geometry.hpp"
-#include "Plane.hpp"
 #include "Intersection.hpp"
 
 #include "../core/Assert.hpp"
-#include "../core/Compare.hpp"
 //#include "../core/Path.hpp"
 #include "../core/Json.hpp"
 
-#include <jsoncpp/json.h>
 
-#include <iostream>
-#include <string>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/geometry/Geometry.cpp
+++ b/openstudiocore/src/utilities/geometry/Geometry.cpp
@@ -30,7 +30,6 @@
 #include "Geometry.hpp"
 #include "Intersection.hpp"
 #include "Transformation.hpp"
-#include "Point3d.hpp"
 #include "Vector3d.hpp"
 
 #include "../core/Assert.hpp"
@@ -39,7 +38,6 @@
 
 #include <polypartition/polypartition.h>
 
-#include <list>
 
 namespace openstudio{
   /// convert degrees to radians

--- a/openstudiocore/src/utilities/geometry/Intersection.cpp
+++ b/openstudiocore/src/utilities/geometry/Intersection.cpp
@@ -53,7 +53,6 @@ typedef boost::geometry::model::multi_polygon<BoostPolygon> BoostMultiPolygon;
 
 #include <polypartition/polypartition.h>
 
-#include <list>
 
 // remove_spikes
 // adapted from https://github.com/boostorg/geometry/commits/develop/include/boost/geometry/algorithms/remove_spikes.hpp eb3260708eb241d8da337f4be73b41d69d33cd09

--- a/openstudiocore/src/utilities/geometry/Test/FloorplanJS_GTest.cpp
+++ b/openstudiocore/src/utilities/geometry/Test/FloorplanJS_GTest.cpp
@@ -42,7 +42,7 @@ TEST_F(GeometryFixture, FloorplanJS)
   openstudio::path p = resourcesPath() / toPath("utilities/Geometry/floorplan.json");
   ASSERT_TRUE(exists(p));
 
-  std::ifstream ifs(toString(p));
+  std::ifstream ifs(toSystemFilename(p));
   EXPECT_TRUE(ifs.is_open());
 
   std::istreambuf_iterator<char> eos;

--- a/openstudiocore/src/utilities/geometry/Test/ThreeJS_GTest.cpp
+++ b/openstudiocore/src/utilities/geometry/Test/ThreeJS_GTest.cpp
@@ -41,7 +41,7 @@ TEST_F(GeometryFixture, ThreeJS)
   openstudio::path p = resourcesPath() / toPath("utilities/Geometry/threejs.json");
   ASSERT_TRUE(exists(p));
 
-  std::ifstream ifs(toString(p));
+  std::ifstream ifs(toSystemFilename(p));
   EXPECT_TRUE(ifs.is_open());
 
   std::istreambuf_iterator<char> eos;

--- a/openstudiocore/src/utilities/geometry/ThreeJS.cpp
+++ b/openstudiocore/src/utilities/geometry/ThreeJS.cpp
@@ -300,7 +300,7 @@ namespace openstudio{
       openstudio::path p = toPath(s);
       if (boost::filesystem::exists(p) && boost::filesystem::is_regular_file(p)){
         // open file
-        std::ifstream ifs(openstudio::toString(p));
+        std::ifstream ifs(openstudio::toSystemFilename(p));
         root.clear();
         parsingSuccessful = reader.parse(ifs, root);
       }

--- a/openstudiocore/src/utilities/idd/IddField.cpp
+++ b/openstudiocore/src/utilities/idd/IddField.cpp
@@ -34,7 +34,6 @@
 #include "CommentRegex.hpp"
 #include <utilities/idd/IddFactory.hxx>
 
-#include "../units/Unit.hpp"
 #include "../units/UnitFactory.hpp"
 #include "../units/IddUnitString.hpp"
 #include "../units/QuantityConverter.hpp"
@@ -42,15 +41,12 @@
 #include "../units/IPUnit.hpp"
 #include "../units/Quantity.hpp"
 
-#include "../core/Finder.hpp"
 #include "../core/Assert.hpp"
 #include "../core/Containers.hpp"
 
 
-#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <algorithm>
 
 using boost::algorithm::trim;
 

--- a/openstudiocore/src/utilities/idd/IddFieldProperties.cpp
+++ b/openstudiocore/src/utilities/idd/IddFieldProperties.cpp
@@ -29,7 +29,6 @@
 
 #include "IddFieldProperties.hpp"
 
-#include "../core/Optional.hpp"
 #include "../core/Containers.hpp"
 
 #include <sstream>

--- a/openstudiocore/src/utilities/idd/IddFile.cpp
+++ b/openstudiocore/src/utilities/idd/IddFile.cpp
@@ -478,7 +478,7 @@ std::ostream& IddFile::print(std::ostream& os) const
 
 std::pair<VersionString, std::string> IddFile::parseVersionBuild(const openstudio::path &p)
 {
-  std::ifstream ifs(openstudio::toString(p));
+  std::ifstream ifs(openstudio::toSystemFilename(p));
 
   if (!ifs.good()) {
     throw std::runtime_error("Unable to open file for reading: " + openstudio::toString(p));

--- a/openstudiocore/src/utilities/idd/IddFile.cpp
+++ b/openstudiocore/src/utilities/idd/IddFile.cpp
@@ -40,10 +40,7 @@
 #include "../core/Containers.hpp"
 
 
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 
-#include <sstream>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idd/IddKey.cpp
+++ b/openstudiocore/src/utilities/idd/IddKey.cpp
@@ -30,10 +30,8 @@
 #include "IddKey.hpp"
 #include "IddKey_Impl.hpp"
 
-#include "IddKeyProperties.hpp"
 #include "IddRegex.hpp"
 
-#include <boost/algorithm/string.hpp>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idd/IddObject.cpp
+++ b/openstudiocore/src/utilities/idd/IddObject.cpp
@@ -41,8 +41,6 @@
 
 
 #include <boost/lexical_cast.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string.hpp>
 
 using std::string;
 using std::vector;

--- a/openstudiocore/src/utilities/idf/DataError.cpp
+++ b/openstudiocore/src/utilities/idf/DataError.cpp
@@ -33,9 +33,7 @@
 
 #include "../idd/IddObject.hpp"
 
-#include "../core/Compare.hpp"
 #include "../core/Assert.hpp"
-#include "../core/Optional.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/Idf.i
+++ b/openstudiocore/src/utilities/idf/Idf.i
@@ -212,7 +212,7 @@
   }
 
   // for Marshal mixin
-  static openstudio::IdfObject _load(const std::string& text) const {
+  static openstudio::IdfObject _load(const std::string& text) {
     boost::optional<openstudio::IdfObject> result = openstudio::IdfObject::load(text);
     if (!result){
       throw openstudio::Exception("Cannot load IdfObject from string '" + text + "'");

--- a/openstudiocore/src/utilities/idf/IdfExtensibleGroup.cpp
+++ b/openstudiocore/src/utilities/idf/IdfExtensibleGroup.cpp
@@ -28,15 +28,11 @@
 ***********************************************************************************************************************/
 
 #include "IdfExtensibleGroup.hpp"
-#include "IdfObject.hpp"
 #include "IdfObject_Impl.hpp"
 
-#include "../idd/IddObjectProperties.hpp"
-#include "../idd/IddFieldProperties.hpp"
 
 #include "../core/Assert.hpp"
 
-#include <boost/lexical_cast.hpp>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/IdfFile.cpp
+++ b/openstudiocore/src/utilities/idf/IdfFile.cpp
@@ -32,9 +32,6 @@
 #include "IdfRegex.hpp"
 #include "ValidityReport.hpp"
 
-#include <utilities/idd/IddObject_Impl.hpp> // needed for serialization
-#include <utilities/idd/IddField_Impl.hpp> // needed for serialization
-#include <utilities/idd/IddFile_Impl.hpp> // needed for serialization
 #include "../idd/IddRegex.hpp"
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/idd/IddEnums.hxx>
@@ -43,19 +40,13 @@
 
 #include "../plot/ProgressBar.hpp"
 #include "../core/PathHelpers.hpp"
-#include "../core/String.hpp"
 #include "../core/Assert.hpp"
-#include "../core/Compare.hpp"
 
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/regex.hpp>
 
 
 #include <boost/iostreams/filter/newline.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
-#include <sstream>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/IdfObject.cpp
+++ b/openstudiocore/src/utilities/idf/IdfObject.cpp
@@ -34,14 +34,9 @@
 #include "IdfRegex.hpp"
 #include "ValidityReport.hpp"
 
-#include "../idd/IddObject.hpp"
-#include "../idd/IddObjectProperties.hpp"
-#include "../idd/IddFieldProperties.hpp"
 #include "../idd/IddKey.hpp"
-#include "../idd/ExtensibleIndex.hpp"
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/idd/IddEnums.hxx>
-#include "../idd/IddField.hpp"
 #include "../idd/IddRegex.hpp"
 #include "../idd/CommentRegex.hpp"
 #include "../idd/Comments.hpp"
@@ -50,20 +45,14 @@
 #include "../core/Finder.hpp"
 #include "../core/Assert.hpp"
 #include "../core/Url.hpp"
-#include "../core/UUID.hpp"
 
 #include "../units/Quantity.hpp"
 #include "../units/OSOptionalQuantity.hpp"
 #include "../units/QuantityConverter.hpp"
 
 #include <boost/lexical_cast.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
-#include <iostream>
-#include <sstream>
 #include <iomanip>
-#include <algorithm>
-#include <limits>
 
 using std::cout;
 using std::endl;

--- a/openstudiocore/src/utilities/idf/IdfObjectWatcher.cpp
+++ b/openstudiocore/src/utilities/idf/IdfObjectWatcher.cpp
@@ -29,7 +29,6 @@
 
 #include "IdfObjectWatcher.hpp"
 #include "IdfObject_Impl.hpp"
-#include "../core/Assert.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/ImfFile.cpp
+++ b/openstudiocore/src/utilities/idf/ImfFile.cpp
@@ -35,16 +35,13 @@
 
 #include "../core/Assert.hpp"
 #include "../core/PathHelpers.hpp"
-#include "../core/String.hpp"
 
-#include <boost/algorithm/string.hpp>
 #include <boost/iostreams/filter/newline.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
 
 
 
-#include <sstream>
 
 namespace openstudio{
 

--- a/openstudiocore/src/utilities/idf/ObjectOrderBase.cpp
+++ b/openstudiocore/src/utilities/idf/ObjectOrderBase.cpp
@@ -30,7 +30,6 @@
 #include "ObjectOrderBase.hpp"
 #include "../math/Permutation.hpp"
 
-#include "../core/Assert.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/ValidityReport.cpp
+++ b/openstudiocore/src/utilities/idf/ValidityReport.cpp
@@ -32,7 +32,6 @@
 
 #include "../idd/IddObject.hpp"
 
-#include "../core/Optional.hpp"
 #include "../core/Assert.hpp"
 
 namespace openstudio {

--- a/openstudiocore/src/utilities/idf/Workspace.cpp
+++ b/openstudiocore/src/utilities/idf/Workspace.cpp
@@ -30,7 +30,6 @@
 #include "Workspace.hpp"
 #include "Workspace_Impl.hpp"
 
-#include "WorkspaceObject_Impl.hpp"
 #include "IdfFile.hpp"
 #include "URLSearchPath.hpp"
 #include "ValidityReport.hpp"
@@ -41,20 +40,11 @@
 #include "../plot/ProgressBar.hpp"
 
 #include "../core/Assert.hpp"
-#include "../core/Containers.hpp"
 #include "../core/URLHelpers.hpp"
-#include "../core/Compare.hpp"
 #include "../core/StringHelpers.hpp"
 
-#include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <sstream>
-#include <iostream>
-#include <deque>
-#include <map>
-#include <list>
 
 using namespace std;
 using openstudio::istringEqual; // used for all name comparisons

--- a/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.cpp
@@ -31,10 +31,7 @@
 #include "WorkspaceObject.hpp"
 #include "WorkspaceObject_Impl.hpp"
 
-#include "../idd/IddObjectProperties.hpp"
-#include "../idd/IddFieldProperties.hpp"
 
-#include <boost/lexical_cast.hpp>
 
 using std::shared_ptr;
 using std::dynamic_pointer_cast;

--- a/openstudiocore/src/utilities/idf/WorkspaceObject.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceObject.cpp
@@ -28,30 +28,21 @@
 ***********************************************************************************************************************/
 
 #include "WorkspaceObject.hpp"
-#include "WorkspaceObject_Impl.hpp"
 
 #include "Workspace.hpp"
 #include "Workspace_Impl.hpp"
 #include "WorkspaceObjectDiff.hpp"
 #include "WorkspaceObjectDiff_Impl.hpp"
 #include "WorkspaceExtensibleGroup.hpp"
-#include "IdfExtensibleGroup.hpp"
 #include "ValidityReport.hpp"
 
 #include <utilities/idd/IddEnums.hxx>
 
-#include "../idd/IddObjectProperties.hpp"
-#include "../idd/IddFieldProperties.hpp"
 
-#include "../core/Compare.hpp"
 #include "../core/Assert.hpp"
-#include "../core/Containers.hpp"
 #include "../core/StringHelpers.hpp"
 
-#include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
 
-#include <iostream>
 using namespace std;
 
 using openstudio::detail::WorkspaceObject_Impl;

--- a/openstudiocore/src/utilities/idf/WorkspaceObjectOrder.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceObjectOrder.cpp
@@ -33,7 +33,6 @@
 
 #include "../math/Permutation.hpp"
 
-#include "../core/Assert.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/WorkspaceObjectWatcher.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceObjectWatcher.cpp
@@ -28,9 +28,7 @@
 ***********************************************************************************************************************/
 
 #include "WorkspaceObjectWatcher.hpp"
-#include "WorkspaceObject.hpp"
 #include "WorkspaceObject_Impl.hpp"
-#include "../core/Assert.hpp"
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/idf/WorkspaceWatcher.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceWatcher.cpp
@@ -31,7 +31,6 @@
 #include "Workspace_Impl.hpp"
 #include "../core/Assert.hpp"
 
-#include <QTimer>
 
 namespace openstudio {
 

--- a/openstudiocore/src/utilities/sql/SqlFile_Impl.cpp
+++ b/openstudiocore/src/utilities/sql/SqlFile_Impl.cpp
@@ -31,17 +31,12 @@
 #include "SqlFileTimeSeriesQuery.hpp"
 #include "OpenStudio.hxx"
 
-#include "../core/String.hpp"
 #include "../time/Calendar.hpp"
 #include "../filetypes/EpwFile.hpp"
 #include "../core/Containers.hpp"
-#include "../core/Optional.hpp"
-#include "../time/DateTime.hpp"
 #include "../core/Assert.hpp"
 
 
-#include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
 
 using boost::multi_index_container;
 using boost::multi_index::indexed_by;

--- a/openstudiocore/src/utilities/time/Date.cpp
+++ b/openstudiocore/src/utilities/time/Date.cpp
@@ -28,9 +28,7 @@
 ***********************************************************************************************************************/
 
 #include "Date.hpp"
-#include "../core/Exception.hpp"
 
-#include <sstream>
 
 using namespace std;
 using namespace boost;

--- a/openstudiocore/src/utilities/time/DateTime.cpp
+++ b/openstudiocore/src/utilities/time/DateTime.cpp
@@ -29,7 +29,6 @@
 
 #include "DateTime.hpp"
 #include <QDateTime>
-#include <cmath>
 
 using namespace std;
 using namespace boost;

--- a/openstudiocore/src/utilities/time/Time.cpp
+++ b/openstudiocore/src/utilities/time/Time.cpp
@@ -29,7 +29,6 @@
 
 #include "Time.hpp"
 
-#include <cmath>
 
 using namespace std;
 using namespace boost;


### PR DESCRIPTION
Updates SWIG to 3.0.12 and applies the following patch:

https://github.com/macumber/swig/commit/45ffaf776c06d7f3bb64ac75e6dab4a9f733b414

This assumes strings coming from C++ to SWIG are UTF-8 encoded
