### PR TITLE
Remove QRegExp and QRegularExpression

### DIFF
--- a/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
@@ -40,8 +40,8 @@
 
 #include <QDir>
 #include <QSettings>
-#include <QRegularExpression>
-
+#include <boost/regex.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #include <src/utilities/embedded_files.hxx>
 
@@ -911,35 +911,53 @@ namespace openstudio{
     boost::optional<openstudio::path> path = primaryRubyScriptPath();
     if (path && exists(*path)){
 
-      QString fileString;
+      std::string fileString;
       openstudio::filesystem::ifstream file(*path, std::ios_base::binary);
       if (file.is_open()){
 
-        QRegularExpression::PatternOptions opts = QRegularExpression::DotMatchesEverythingOption | QRegularExpression::MultilineOption;
-        QString nameFunction = "\\1def name\n\\1  return \"" + toQString(name) + "\"\n\\1end";
-        QString descriptionFunction = "\\1def description\n\\1  return \"" + toQString(description) + "\"\n\\1end";
-        QString modelerDescriptionFunction = "\\1def modeler_description\n\\1  return \"" + toQString(modelerDescription) + "\"\n\\1end";
+        // Replacement paterns
+        std::string nameFunction = "$1def name\n$1  return \"" + name + "\"\n$1end";
+        std::string descriptionFunction = "$1def description\n$1  return \"" + description + "\"\n$1end";
+        std::string modelerDescriptionFunction = "$1def modeler_description\n$1  return \"" + modelerDescription + "\"\n$1end";
 
-        fileString = openstudio::filesystem::read_as_QByteArray(file);
+        fileString = openstudio::filesystem::read_as_string(file);
+
+        boost::regex re;
 
         if (oldMeasureType != newMeasureType){
-          fileString.replace(toQString(oldMeasureType.valueName()), toQString(newMeasureType.valueName()));
+          // TODO: JM 2018-11-06 boost::replace_all should work but I'm using GCC-7 to build the pre update_depends branch
+          // so boost was compiled with an older GCC (there was ABI compatibility breakage in between)
+          // boost::replace_all(fileString, oldMeasureType.valueName(), newMeasureType.valueName());
+          re.set_expression(oldMeasureType.valueName());
+          fileString = boost::regex_replace(fileString, re, newMeasureType.valueName());
         }
 
         if (!oldClassName.empty() && !newClassName.empty() && oldClassName != newClassName){
           // DLM: might also want to check that oldClassName is greater than 3 characters long?
           // should we be doing a more selective replace (like require leading space and trailing space, ., or :)?
-          fileString.replace(toQString(oldClassName), toQString(newClassName));
+          // TODO: same as above
+          // boost::replace_all(fileString, oldClassName, newClassName);
+          re.set_expression(oldClassName);
+          fileString = boost::regex_replace(fileString, re, newClassName);
         }
 
-        fileString.replace(QRegularExpression("^(\\s+)def\\s+name(.*?)end[\\s#]?$", opts), nameFunction);
-        fileString.replace(QRegularExpression("^(\\s+)def\\s+description(.*?)end[\\s#]?$", opts), descriptionFunction);
-        fileString.replace(QRegularExpression("^(\\s+)def\\s+modeler_description(.*?)end[\\s#]?$", opts), modelerDescriptionFunction);
+        // Note JM 2018-11-06: Use the iterator overload of regex_replace for inplace replacement? Actually don't.
+        // There's undefined behavior when you end up replacing with something that doesn't have the same length
+        re.set_expression("^([\t ]*?)def\\s+name(.*?)end[\\s#]?$");
+        fileString = boost::regex_replace(fileString, re, nameFunction);
+
+        re.set_expression("^([\t ]*?)def\\s+description(.*?)end[\\s#]?$");
+        fileString = boost::regex_replace(fileString, re, descriptionFunction);
+
+        re.set_expression("^([\t ]*?)def\\s+modeler_description(.*?)end[\\s#]?$");
+        fileString = boost::regex_replace(fileString, re, modelerDescriptionFunction);
+
         file.close();
 
         openstudio::filesystem::ofstream ofile(*path, std::ios_base::binary);
         if (ofile.is_open()){
-          openstudio::filesystem::write(ofile, fileString);
+          ofile << fileString;
+          // openstudio::filesystem::write(ofile, fileString);
           ofile.close();
           return true;
         }

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -31,7 +31,7 @@
 #include "Assert.hpp"
 #include "FilesystemHelpers.hpp"
 
-#include <QRegularExpression>
+#include <boost/regex.hpp>
 
 #ifdef Q_OS_WIN
 #include <Windows.h>
@@ -340,12 +340,13 @@ bool isEmptyDirectory(const path& dirName)
 boost::optional<std::string> windowsDriveLetter(const path& p)
 {
   boost::optional<std::string> result;
-  QString q = toQString(p);
 
-  QRegularExpression regex("^([a-zA-Z]):");
-  QRegularExpressionMatch match = regex.match(q);
-  if (match.hasMatch()){
-    result = toString(match.captured(1));
+  std::string path_str = toString(p);
+
+  boost::regex regex("^([a-zA-Z]):");
+  boost::smatch m;
+  if (boost::regex_search(path_str, m, regex)) {
+    result = m[1];
   }
 
   return result;
@@ -369,10 +370,9 @@ bool isNetworkPath(const path& p)
   }
 
   // check if path begins with \\, e.g. \\server\file
-  QString q = toQString(p.string()); // toQString(p) converts backslashes to slashes
-  QRegularExpression regex("^\\\\\\\\");
-  QRegularExpressionMatch match = regex.match(q);
-  if (match.hasMatch()){
+  // Shouldn't convert backslashes to slashes
+  boost::regex regex("^\\\\\\\\");
+  if (boost::regex_search(p.string(), regex)) {
     return true;
   }
 

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -360,6 +360,8 @@ bool isNetworkPath(const path& p)
 
 #ifdef Q_OS_WIN
 
+  // TODO: JM 2018-11-06: couldn't this entire block be replaced by "PathIsNetworkPath"?
+
   // if this is a windows drive, check if this is mapped to a remote drive
   boost::optional<std::string> wdl = windowsDriveLetter(p);
   if (wdl){

--- a/openstudiocore/src/utilities/core/RubyException.hpp
+++ b/openstudiocore/src/utilities/core/RubyException.hpp
@@ -54,7 +54,8 @@ namespace openstudio
         std::string result;
 
         boost::regex regex("\\w*\\.rb:\\d*");
-        if (boost::regex_search(location, m, regex)) {
+        boost::smatch m;
+        if (boost::regex_search(m_location, m, regex)) {
           result = m[0];
         }
 

--- a/openstudiocore/src/utilities/core/RubyException.hpp
+++ b/openstudiocore/src/utilities/core/RubyException.hpp
@@ -32,8 +32,7 @@
 
 #include <stdexcept>
 
-#include <QRegExp>
-#include <QString>
+#include <boost/regex.hpp>
 
 namespace openstudio
 {
@@ -54,10 +53,9 @@ namespace openstudio
       {
         std::string result;
 
-        QRegExp regex("(\\w*\\.rb:\\d*)");
-        int pos = regex.indexIn(QString::fromStdString(m_location));
-        if (pos > -1) {
-          result = regex.cap(1).toStdString();
+        boost::regex regex("\\w*\\.rb:\\d*");
+        if (boost::regex_search(location, m, regex)) {
+          result = m[0];
         }
 
         return result;

--- a/openstudiocore/src/utilities/core/URLHelpers.cpp
+++ b/openstudiocore/src/utilities/core/URLHelpers.cpp
@@ -29,7 +29,7 @@
 
 #include "URLHelpers.hpp"
 
-#include <QRegularExpression>
+#include <boost/regex.hpp>
 
 namespace openstudio {
 
@@ -101,13 +101,14 @@ boost::optional<openstudio::path> getOptionalOriginalPath(const Url& url)
 {
   boost::optional<openstudio::path> result;
   if (url.scheme() == "file" || url.scheme().isEmpty()){
-    QString localFile = url.toLocalFile();
+    std::string localFile = toString(url.toLocalFile());
 
     // test for root slash added to windows paths, "/E:/test/CloudTest/scripts/StandardReports/measure.rb"
-    const QRegularExpression regexp("^\\/([a-zA-Z]:\\/.*)");
-    QRegularExpressionMatch match = regexp.match(localFile);
-    if (match.hasMatch()){
-      localFile = match.captured(1);
+    boost::regex re("^\\/([a-zA-Z]:\\/.*)");
+    boost::smatch m;
+
+    if (boost::regex_search(localFile, m, re)) {
+      localFile = m[1];
     }
 
     result = toPath(localFile);

--- a/openstudiocore/src/utilities/core/test/Path_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/Path_GTest.cpp
@@ -31,7 +31,6 @@
 
 #include <resources.hxx>
 
-
 #include "CoreFixture.hpp"
 #include "../Path.hpp"
 #include "../PathHelpers.hpp"
@@ -39,7 +38,6 @@
 #include "../Filesystem.hpp"
 #include "utilities/sql/SqlFileDataDictionary.hpp"
 
-#include <QTextCodec>
 #include <clocale>
 
 using openstudio::path;
@@ -481,3 +479,4 @@ TEST_F(CoreFixture, LastLevelDirectoryWithDot) {
   EXPECT_EQ("A measure with 90.1 dots", toString(lastLevelDir));
   EXPECT_EQ(measure_directory, measure_directory.parent_path() / lastLevelDir);
 }
+

--- a/openstudiocore/src/utilities/sql/Test/SqlFile_GTest.cpp
+++ b/openstudiocore/src/utilities/sql/Test/SqlFile_GTest.cpp
@@ -40,11 +40,9 @@
 #include "../../units/UnitFactory.hpp"
 #include "../../core/Application.hpp"
 
-#include <QRegularExpression>
-
-#include <resources.hxx>
-
 #include <iostream>
+#include <boost/regex.hpp>
+#include <resources.hxx>
 
 using namespace std;
 using namespace boost;
@@ -337,10 +335,11 @@ void regressionTestSqlFile(const std::string& name, double netSiteEnergy, double
   EXPECT_NO_THROW(sqlFile = SqlFile(path));
   ASSERT_TRUE(sqlFile);
 
-  QRegularExpression re("1ZoneEvapCooler-V(.*)\\.sql");
-  QRegularExpressionMatch match = re.match(toQString(name));
-  ASSERT_TRUE(match.hasMatch());
-  VersionString expected(toString(match.captured(1)));
+  // Capture the version (1st group)
+  boost::regex re("1ZoneEvapCooler-V(.*)\\.sql");
+  boost::smatch m;
+  ASSERT_TRUE(boost::regex_match(name, m, re));
+  VersionString expected(m[1]);
   VersionString actual(sqlFile->energyPlusVersion());
   EXPECT_EQ(expected.major(), actual.major());
   EXPECT_EQ(expected.minor(), actual.minor());


### PR DESCRIPTION
## Remove QRegularExpression and QRegExp dependencies

Replaced with `boost::regex`.

I think I caught every location that isn't OS App related
```bash
$ cd OpenStudio/openstudiocore
$ grep -Rl "QReg[uE]" 
model_editor/InspectorGadget.cpp
model_editor/IGLineEdit.cpp
model_editor/IGPrecisionDialog.cpp
openstudio_lib/FacilityShadingGridView.cpp
openstudio_lib/FacilityStoriesGridView.cpp
openstudio_lib/ResultsTabView.cpp
openstudio_lib/SpacesSubtabGridView.cpp
shared_gui_components/EditView.cpp
```

Note: I left two "TODO" inside BCLMeasure.cpp because boost::replace_all isn't working in my current setting (I use a much newer GCC than the one that compiled boost), but it should work fine after update_depends is merged in (on my system, I have a test project with boost 1.68 compiled with GCC-7 and this works)
