### PR TITLE
Remove QTemporaryFile and QDir

### DIFF
--- a/openstudiocore/src/cli/RubyInterpreter.hpp
+++ b/openstudiocore/src/cli/RubyInterpreter.hpp
@@ -777,9 +777,9 @@ class RubyInterpreter
       int error;
 
       // save and restore the current working directory in case the call to ruby upsets it
-//      QDir cwd = QDir::current();
+//      const auto cwd = openstudio::filesystem::current_dir();
       rb_protect(evaluateSimpleImpl,val,&error);
-//      QDir::setCurrent(cwd.dirName());
+//      openstudio::filesystem::current_dir(cwd);
 
 
       if (error != 0)

--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -79,14 +79,12 @@
 #include "../utilities/core/Logger.hpp"
 #include "../utilities/core/PathHelpers.hpp"
 #include "../utilities/core/Assert.hpp"
+#include "../utilities/core/FilesystemHelpers.hpp"
 
 #include <OpenStudio.hxx>
 
 #include <QDir>
 #include <QMessageBox>
-#include <QTemporaryFile>
-
-
 
 
 namespace openstudio {
@@ -290,31 +288,10 @@ QString longPathName(const QString& path)
 
   openstudio::path createModelTempDir()
   {
-    openstudio::path result;
-    auto tempFile = new QTemporaryFile();
-
-    if (tempFile->open())
-    {
-      QString path = longPathName(tempFile->fileName());
-
-      // must close tempFile so you can create directory with same name on Windows
-      delete tempFile;
-
-      QDir modelTempDir(path);
-      LOG_FREE(Info, "createModelTempDir", "Creating directory '" << toString(modelTempDir.path()) << "'");
-      bool test = modelTempDir.mkpath(modelTempDir.path());
-      OS_ASSERT(test);
-
-      result = toPath(path);
-
-      return result;
-    }
-
-    delete tempFile;
-
-    OS_ASSERT(false);
-
-    return openstudio::path();
+    const auto result = openstudio::filesystem::create_temporary_directory("osmodel");
+    LOG_FREE(Info, "createModelTempDir", "Created directory '" << toString(result) << "'");
+    OS_ASSERT(!result.empty());
+    return result;
   }
 
   bool initializeModelTempDir(const openstudio::path& osmPath, const openstudio::path& modelTempDir)

--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -92,48 +92,61 @@ namespace openstudio {
 namespace model {
   bool copyDir(const openstudio::path &sourceDir, const openstudio::path &destinationDir)
   {
-    if (!openstudio::filesystem::exists(sourceDir) || !openstudio::filesystem::is_directory(sourceDir))
-    {
-      throw std::runtime_error("Source directory " + sourceDir.string() + " does not exist or is not a directory");
-    }
+    const auto src = openstudio::filesystem::canonical(sourceDir);
+    const auto dest = openstudio::filesystem::canonical(destinationDir);
 
-    if (openstudio::filesystem::exists(destinationDir))
-    {
-      throw std::runtime_error("Destination directory " + destinationDir.string() + " already exists");
-    }
-
-    if (!openstudio::filesystem::create_directory(destinationDir))
-    {
-      throw std::runtime_error("Cannot create destination directory " + destinationDir.string());
+    if (src == dest) {
+      LOG_FREE(Warning, "Refusing to copy directory '" << toString(sourceDir) << "' only itself '" << toString(destinationDir) 
+          << "' canonical path: '" << toString(src) << "'");
+      return true; // there is no error, just nothing to do
     }
 
 
+    if (!openstudio::filesystem::exists(src) || !openstudio::filesystem::is_directory(src))
+    {
+      throw std::runtime_error("Source directory " + src.string() + " does not exist or is not a directory");
+    }
 
-    for (const auto& dirEnt : openstudio::filesystem::recursive_directory_iterator{sourceDir})
+    if (openstudio::filesystem::exists(dest))
+    {
+      throw std::runtime_error("Destination directory " + dest.string() + " already exists");
+    }
+
+    if (!openstudio::filesystem::create_directory(dest))
+    {
+      throw std::runtime_error("Cannot create destination directory " + dest.string());
+    }
+
+
+
+    for (const auto& dirEnt : openstudio::filesystem::recursive_directory_iterator{src})
     {
       const auto& path = dirEnt.path();
       auto relativePathStr = path.string();
-      boost::replace_first(relativePathStr, sourceDir.string(), "");
+      boost::replace_first(relativePathStr, src.string(), "");
 
       try {
-        openstudio::filesystem::copy(path, destinationDir / relativePathStr);
+        openstudio::filesystem::copy(path, dest / relativePathStr);
       } catch (const std::exception &e) {
-        LOG_FREE(Error, "copyDir", "Error copying from: " << toString(path) << " to: " << toString(destinationDir / relativePathStr) << " Description: " << e.what());
+        LOG_FREE(Error, "copyDir", "Error copying from: " << toString(path) << " to: " << toString(dest / relativePathStr) << " Description: " << e.what());
         return false;
       }
     }
 
+    return true;
   }
 
   bool removeDir(const openstudio::path &path)
   {
     try {
       const auto count = openstudio::filesystem::remove_all(path);
-      return true;
+      LOG_FREE(Debug, "removeDir", "Removed " << count << " files");
     } catch (const std::exception &e) {
       LOG_FREE(Error, "removeDir", "Error removing from: " << toString(path) << " Description: " << e.what());
       return false;
     }
+
+    return true;
   }
 
   openstudio::path createModelTempDir()

--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -90,13 +90,13 @@
 
 namespace openstudio {
 namespace model {
-  bool copyDir(const openstudio::path &sourceDir, const openstudio::path &destinationDir)
+  bool replaceDir(const openstudio::path &sourceDir, const openstudio::path &destinationDir)
   {
     const auto src = openstudio::filesystem::canonical(sourceDir);
     const auto dest = openstudio::filesystem::canonical(destinationDir);
 
     if (src == dest) {
-      LOG_FREE(Warn, "copyDir", "Refusing to copy directory '" << toString(sourceDir) << "' only itself '" << toString(destinationDir) 
+      LOG_FREE(Warn, "replaceDir", "Refusing to copy directory '" << toString(sourceDir) << "' only itself '" << toString(destinationDir) 
           << "' canonical path: '" << toString(src) << "'");
       return true; // there is no error, just nothing to do
     }
@@ -104,17 +104,29 @@ namespace model {
 
     if (!openstudio::filesystem::exists(src) || !openstudio::filesystem::is_directory(src))
     {
-      throw std::runtime_error("Source directory " + src.string() + " does not exist or is not a directory");
+      LOG_FREE(Error, "replaceDir", "Source directory does not exist: " << toString(src));
+      return false;
     }
 
     if (openstudio::filesystem::exists(dest))
     {
-      throw std::runtime_error("Destination directory " + dest.string() + " already exists");
+      if (openstudio::filesystem::is_directory(dest)) {
+        try {
+          openstudio::filesystem::remove_all(dest);
+        } catch (const std::exception &e) {
+          LOG_FREE(Error, "replaceDir", "Destination directory could not be removed: " << toString(dest));
+          return false;
+        }
+      } else {
+        LOG_FREE(Error, "replaceDir", "Destination exists and is not a directory, aborting: " << toString(dest));
+        return false;
+      }
     }
 
     if (!openstudio::filesystem::create_directory(dest))
     {
-      throw std::runtime_error("Cannot create destination directory " + dest.string());
+      LOG_FREE(Error, "replaceDir", "Could not create destination directory: " << toString(dest));
+      return false;
     }
 
 
@@ -128,7 +140,7 @@ namespace model {
       try {
         openstudio::filesystem::copy(path, dest / relativePathStr);
       } catch (const std::exception &e) {
-        LOG_FREE(Error, "copyDir", "Error copying from: " << toString(path) << " to: " << toString(dest / relativePathStr) << " Description: " << e.what());
+        LOG_FREE(Error, "replaceDir", "Error copying from: " << toString(path) << " to: " << toString(dest / relativePathStr) << " Description: " << e.what());
         return false;
       }
     }
@@ -183,7 +195,7 @@ namespace model {
       if (openstudio::filesystem::exists(sourceDir)){
         LOG_FREE(Debug, "initializeModelTempDir", "Copying '" << toString(sourceDir) << "' to '" << toString(destDir) << "'");
 
-        test = copyDir(sourceDir, destDir);
+        test = replaceDir(sourceDir, destDir);
         if (!test){
           LOG_FREE(Error, "initializeModelTempDir", "Could not copy '" << toString(sourceDir) << "' to '" << toString(destDir) << "'");
           result = false;
@@ -349,7 +361,7 @@ namespace model {
 
       LOG_FREE(Debug, "saveModelTempDir", "Copying " << toString(srcDir) << " to " << toString(dstDir));
 
-      test = copyDir(srcDir, dstDir);
+      test = replaceDir(srcDir, dstDir);
       if (!test){
         LOG_FREE(Error, "saveModelTempDir", "Could not copy '" << toString(srcDir) << "' to '" << toString(dstDir) << "'");
       }

--- a/openstudiocore/src/model/FileOperations.cpp
+++ b/openstudiocore/src/model/FileOperations.cpp
@@ -96,7 +96,7 @@ namespace model {
     const auto dest = openstudio::filesystem::canonical(destinationDir);
 
     if (src == dest) {
-      LOG_FREE(Warning, "Refusing to copy directory '" << toString(sourceDir) << "' only itself '" << toString(destinationDir) 
+      LOG_FREE(Warn, "copyDir", "Refusing to copy directory '" << toString(sourceDir) << "' only itself '" << toString(destinationDir) 
           << "' canonical path: '" << toString(src) << "'");
       return true; // there is no error, just nothing to do
     }

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -120,7 +120,6 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QString>
-#include <QTemporaryFile>
 #include <QTimer>
 #include <QWidget>
 

--- a/openstudiocore/src/radiance/ForwardTranslator.cpp
+++ b/openstudiocore/src/radiance/ForwardTranslator.cpp
@@ -86,9 +86,9 @@
 
 #include <QPolygonF>
 #include <QPointF>
-#include <QDir>
 #include <QDateTime>
 #include <QThread>
+#include <QFile>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/regex.hpp>

--- a/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLMeasure.cpp
@@ -38,10 +38,9 @@
 
 #include <OpenStudio.hxx>
 
-#include <QDir>
 #include <QSettings>
 #include <QRegularExpression>
-
+#include <QFile>
 
 #include <src/utilities/embedded_files.hxx>
 
@@ -53,7 +52,7 @@ namespace openstudio{
         LOG_AND_THROW("'" << toString(dir) << "' exists but is not an empty directory");
       }
     }else{
-      if (!QDir().mkpath(toQString(dir))){
+      if (!openstudio::filesystem::create_directories(dir)) {
         LOG_AND_THROW("'" << toString(dir) << "' cannot be created as an empty directory");
       }
     }
@@ -61,7 +60,7 @@ namespace openstudio{
 
   bool BCLMeasure::copyDirectory(const path& source, const path& destination) const {
 
-    if (!QDir().mkpath(toQString(destination)))
+    if (!openstudio::filesystem::create_directories(destination))
     {
       return false;
     }
@@ -501,7 +500,7 @@ namespace openstudio{
   openstudio::path BCLMeasure::userMeasuresDir()
   {
     QSettings settings("OpenStudio", "BCLMeasure");
-    QString value = settings.value("userMeasuresDir", QDir::homePath().append("/OpenStudio/Measures")).toString();
+    QString value = settings.value("userMeasuresDir", toQString(openstudio::filesystem::home_path() / toPath("OpenStudio/Measures"))).toString();
     openstudio::path result = toPath(value);
     return openstudio::filesystem::system_complete(result);
   }
@@ -512,7 +511,7 @@ namespace openstudio{
       return false;
     }
     if (!exists(userMeasuresDir)){
-      if (!QDir().mkpath(toQString(userMeasuresDir))){
+      if (!openstudio::filesystem::create_directories(userMeasuresDir)) {
         return false;
       }
     }
@@ -1251,7 +1250,7 @@ namespace openstudio{
         return boost::none;
       }
     }else{
-      if (!QDir().mkpath(toQString(newDir))){
+      if (!openstudio::filesystem::create_directories(newDir)) {
         return boost::none;
       }
     }

--- a/openstudiocore/src/utilities/bcl/LocalBCL.hpp
+++ b/openstudiocore/src/utilities/bcl/LocalBCL.hpp
@@ -150,10 +150,14 @@ namespace openstudio{
     bool setDevAuthKey(const std::string& devAuthKey);
 
     /// Returns the path to the local BCL library
-    QString libraryPath() const;
+    openstudio::path libraryPath() const;
 
     /// Relocates the local BCL library, stores the library path in user preferences
-    bool setLibraryPath(const std::string& libraryPath);
+    bool setLibraryPath(const openstudio::path& libraryPath);
+
+    /// returns the fully qualified path of the current database file
+    openstudio::filesystem::path dbPath() const;
+
 
     //@}
   private:
@@ -161,8 +165,8 @@ namespace openstudio{
     /// private constructor
     LocalBCL(const path& libraryPath);
 
-    // no body on purpose, do not want this generated
-    LocalBCL(const LocalBCL& other);
+    /// Explicitly not copyable
+    LocalBCL(const LocalBCL& other) = delete;
 
     bool initializeLocalDb();
 
@@ -179,10 +183,14 @@ namespace openstudio{
 
     std::string formatString(double d, uint prec = 15);
 
+    /// returns the current database referenced by the current file
+    QSqlDatabase getDatabase(const bool open = true) const;
+
+
     static std::shared_ptr<LocalBCL> &instanceInternal();
 
-    QString m_libraryPath;
-    const QString m_dbName;
+    openstudio::path m_libraryPath;
+    const openstudio::path m_dbName;
     QString dbVersion;
     std::string m_prodAuthKey;
     std::string m_devAuthKey;

--- a/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
+++ b/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
@@ -35,7 +35,7 @@
 #include "../core/System.hpp"
 #include "../core/UnzipFile.hpp"
 
-#include <QDir>
+#include <QFile>
 #include <QMutex>
 #include <QNetworkReply>
 
@@ -596,7 +596,7 @@ namespace openstudio{
       return false;
     }
 
-    m_downloadFile = std::shared_ptr<QFile>(new QFile(QDir::tempPath().append(toQString("/"+uid+".bcl"))));
+    m_downloadFile = std::make_shared<QFile>(toQString(openstudio::filesystem::temp_directory_path() / toPath(uid + ".bcl")));
     if (!m_downloadFile->open(QIODevice::WriteOnly | QIODevice::Truncate)){
       m_mutex->unlock();
       return false;
@@ -1009,12 +1009,12 @@ namespace openstudio{
 
           // Extract the files to a temp location
           openstudio::path src = toPath(fileName);
-          openstudio::path tempDest = toPath(QDir::tempPath().append(toQString("/" + m_downloadUid + "/")));
+          openstudio::path tempDest = openstudio::filesystem::temp_directory_path() / toPath(m_downloadUid  + '/');
 
-          if (QDir().exists(toQString(tempDest))) {
+          if (openstudio::filesystem::is_directory(tempDest)) {
             removeDirectory(tempDest);
           }
-          QDir().mkpath(toQString(tempDest));
+          openstudio::filesystem::create_directories(tempDest);
 
           std::vector<openstudio::path> createdFiles;
           try {
@@ -1062,7 +1062,7 @@ namespace openstudio{
               // check if component has proper uid and vid
               if (!uid.empty() && !versionId.empty()) {
 
-                dest = toPath(LocalBCL::instance().libraryPath().append(toQString("/" + uid + "/" + versionId)));
+                dest = LocalBCL::instance().libraryPath() / openstudio::toPath(uid) / openstudio::toPath(versionId);
 
                 removeDirectory(dest);
                 if (copyDirectory(componentXmlPath.parent_path(), dest))
@@ -1085,7 +1085,7 @@ namespace openstudio{
                 // check if component has proper uid and vid
                 if (!uid.empty() && !versionId.empty()) {
 
-                  dest = toPath(LocalBCL::instance().libraryPath().append(toQString("/" + uid + "/" + versionId)));
+                dest = LocalBCL::instance().libraryPath() / openstudio::toPath(uid) / openstudio::toPath(versionId);
 
                   removeDirectory(dest);
                   if (copyDirectory(measureXmlPath.parent_path(), dest))

--- a/openstudiocore/src/utilities/bcl/test/BCLMeasure_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCLMeasure_GTest.cpp
@@ -136,7 +136,8 @@ TEST_F(BCLFixture, BCLMeasure_CTor)
   try{
     BCLMeasure measure("Test Measure", className, dir, "Envelope.Fenestration",
                        MeasureType::ModelMeasure, "Description", "Modeler Description");
-  }catch(std::exception&){
+  }catch(const std::exception &e){
+    LOG_FREE(Error, "BCLFixture", "exception during measure creation: " << e.what());
     ASSERT_TRUE(false);
   }
   ASSERT_TRUE(exists(dir));

--- a/openstudiocore/src/utilities/bcl/test/BCL_GTest.cpp
+++ b/openstudiocore/src/utilities/bcl/test/BCL_GTest.cpp
@@ -36,8 +36,6 @@
 #include "../../idf/Workspace.hpp"
 #include "../../core/FilesystemHelpers.hpp"
 
-#include <QDir>
-
 
 using namespace openstudio;
 
@@ -242,7 +240,7 @@ TEST_F(BCLFixture, RemoteBCLTest2)
   EXPECT_FALSE(lastDownload->files().empty());
   for (const std::string& file : lastDownload->files()) {
     openstudio::path path = toPath(lastDownload->directory() + "/files/" + file);
-    EXPECT_TRUE(QDir().exists(toQString(path)));
+    EXPECT_TRUE(openstudio::filesystem::exists(path));
 
     const auto time = openstudio::filesystem::last_write_time_as_time_t(path);
     EXPECT_GT(time, startTime);
@@ -256,7 +254,7 @@ TEST_F(BCLFixture, RemoteBCLTest2)
   EXPECT_FALSE(component->files().empty());
   for (const std::string& file : component->files()) {
     openstudio::path path = toPath(component->directory() + "/files/" + file);
-    EXPECT_TRUE(QDir().exists(toQString(path)));
+    EXPECT_TRUE(openstudio::filesystem::exists(path));
 
     const auto time = openstudio::filesystem::last_write_time_as_time_t(path);
     EXPECT_GT(time, startTime);
@@ -277,7 +275,7 @@ TEST_F(BCLFixture, RemoteBCLTest2)
   ASSERT_FALSE(oscFiles.empty());
   EXPECT_EQ(1u, oscFiles.size());
   openstudio::path oscPath = toPath(oscFiles[0]);
-  EXPECT_TRUE(QDir().exists(toQString(oscPath)));
+  EXPECT_TRUE(openstudio::filesystem::exists(oscPath));
   // DLM: the real loading procedure would be to run this through the version translator first
   boost::optional<Workspace> workspace = Workspace::load(oscPath, IddFile::catchallIddFile());
   // This will fail on Windows if the path is greater than MAX_PATH

--- a/openstudiocore/src/utilities/core/Filesystem.hpp
+++ b/openstudiocore/src/utilities/core/Filesystem.hpp
@@ -55,6 +55,7 @@ namespace filesystem {
   using boost::filesystem::recursive_directory_iterator;
   using boost::filesystem::filesystem_error;
   using boost::filesystem::copy_option;
+  using copy_options = boost::filesystem::copy_option;
 
   // functions
   using boost::filesystem::basename;

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
@@ -59,6 +59,10 @@ namespace openstudio {
     /// Result values are relative to t_path
     UTILITIES_API std::vector<openstudio::path> directory_files(const openstudio::path &t_path);
 
+    /// Returns all dir paths (non recursively) in the directory t_path.
+    /// Result values are relative to t_path
+    UTILITIES_API std::vector<openstudio::path> directory_directories(const openstudio::path &t_path);
+
     /// Returns all file paths (recursively) in the directory t_path.
     /// Result values are relative to t_path
     UTILITIES_API std::vector<openstudio::path> recursive_directory_files(const openstudio::path &t_path);
@@ -76,6 +80,11 @@ namespace openstudio {
     /// where `id` is unique identifier determined by the runtime.
     /// \returns path created or empty path if creation failed
     UTILITIES_API openstudio::path create_temporary_directory(const openstudio::path &base_name);
+
+
+    /// Returns the current user's home path
+    UTILITIES_API openstudio::path home_path();
+
   }
 }
 

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
@@ -70,6 +70,12 @@ namespace openstudio {
     UTILITIES_API void write(openstudio::filesystem::ofstream &t_file, const QString &);
 
     UTILITIES_API time_t last_write_time_as_time_t(const openstudio::path &t_path);
+
+    /// Creates a new temporary directory in the form of
+    /// "/systemtemppath/{base_name}-id"
+    /// where `id` is unique identifier determined by the runtime.
+    /// \returns path created or empty path if creation failed
+    UTILITIES_API openstudio::path create_temporary_directory(const openstudio::path &base_name);
   }
 }
 

--- a/openstudiocore/src/utilities/core/Path.cpp
+++ b/openstudiocore/src/utilities/core/Path.cpp
@@ -30,8 +30,6 @@
 #include "Path.hpp"
 #include "String.hpp"
 
-#include <QDir>
-
 
 #ifdef Q_OS_WIN
 #include <locale>
@@ -40,30 +38,6 @@
 
 namespace openstudio {
 
-//#ifdef Q_OS_WIN
-//
-//#include <windows.h>
-//
-//QString longPathName(const QString& path)
-//{
-//  if (path.isEmpty())
-//    return QString();
-//  QString maybeShort = QDir::toNativeSeparators(path);
-//  QByteArray shortName = maybeShort.toLocal8Bit();
-//  char longPath[MAX_PATH];
-//  int err = GetLongPathName(shortName.constData(), longPath, MAX_PATH);
-//  (void)err;
-//  return QDir::fromNativeSeparators(QString::fromLocal8Bit(longPath));
-//}
-//
-//#else
-//
-//QString longPathName(const QString& path)
-//{
-//  return path;
-//}
-//
-//#endif
 
 /*
   | Class       | Internal      | Platform  |
@@ -95,7 +69,7 @@ path toPath(const QString& q)
 /** path to a temporary directory. */
 path tempDir()
 {
-  return toPath(QDir::tempPath());
+  return openstudio::filesystem::temp_directory_path();
 }
 
 /** path to UTF-8 encoding. */

--- a/openstudiocore/src/utilities/core/RubyInterpreter.hpp
+++ b/openstudiocore/src/utilities/core/RubyInterpreter.hpp
@@ -32,8 +32,6 @@
 
 #include "RubyException.hpp"
 
-#include <QDir>
-
 // SWIGRubyRuntime.hxx includes ruby.h which includes ruby/win32.h, which has some brain damaged notions of
 // what standard errno values should be. We solved this in systemoutliner with some creative
 // compilation firewalls and opaque types and such. We don't have quite as much flexibility here
@@ -904,9 +902,9 @@ end # module OpenStudio
           int error;
 
           // save and restore the current working directory in case the call to ruby upsets it
-          QDir cwd = QDir::current();
+          const auto cwd = openstudio::filesystem::current_path();
           rb_protect(evaluateSimpleImpl,val,&error);
-          QDir::setCurrent(cwd.dirName());
+          openstudio::filesystem::current_path(cwd);
 
 
           if (error != 0)

--- a/openstudiocore/src/utilities/core/UnzipFile.cpp
+++ b/openstudiocore/src/utilities/core/UnzipFile.cpp
@@ -31,8 +31,6 @@
 #include <zlib/contrib/minizip/unzip.h>
 
 
-#include <QDir>
-
 namespace openstudio {
 
   UnzipFile::UnzipFile(const openstudio::path &filename)
@@ -90,8 +88,7 @@ namespace openstudio {
       bool cont = true;
 
       openstudio::path createdFile = outputPath / filename;
-
-      QDir().mkpath(toQString(createdFile.parent_path()));
+      openstudio::filesystem::create_directories(createdFile.parent_path());
 
       openstudio::filesystem::ofstream file(createdFile, std::ios_base::trunc | std::ios_base::binary);
       while (cont)


### PR DESCRIPTION
## Remove QTemporaryFile and QDir

While removing these two dependencies I also removed dead code that relied on them (as opposed to spending the time updating code that isn't used) and cleaned up some redundant code.

 * `QTemporaryFile` is a clean extraction
 * `QDir` mostly effected BCL.
    * It's possible we'll get merge conflicts with code that is removing `QSql` because I took the opportunity to clean up some redundant code. If this happens I can hopefully sort out the merge conflicts easily.


