### PR TITLE
Change daylighting error to a warning

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -96,7 +96,7 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
     if (daylightingControl) {
       idfObject.setString(WindowShadingControlFields::DaylightingControlObjectName, daylightingControl->nameString());
     } else {
-      LOG(Error, "Cannot find DaylightingControl for " << modelObject.briefDescription());
+      LOG(Warn, "Cannot find DaylightingControl for " << modelObject.briefDescription());
     }
   } else {
     LOG(Error, "Cannot find ThermalZone for " << modelObject.briefDescription());


### PR DESCRIPTION
The Daylighting control object is not required for the WindowShadingControl object. See AirflowWindowsAndBetweenGlassBlinds.idf example file, for example. We get lots of errors because of this but simulations run fine.

cc @joseph-robertson 