### PR TITLE
Reduce shading control FT error to warn

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -80,7 +80,7 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
           zoneName = thermalZone->nameString();
           zone = thermalZone;
         } else if (zoneName != thermalZone->nameString()) {
-          LOG(Error, modelObject.briefDescription() << " controls SubSurfaces in multiple zones");
+          LOG(Warn, modelObject.briefDescription() << " controls SubSurfaces in multiple zones");
         }
       } else {
         LOG(Error, "Cannot find ThermalZone for " << subSurface.briefDescription() << " referencing " << modelObject.briefDescription());


### PR DESCRIPTION
Similar to [this shading control daylighting PR](https://github.com/NREL/OpenStudio/pull/3361), the shading control error about spanning multiple controls should be reduced to a warning. It's fine to have a shading control span multiple thermal zones depending on its controls. We are successfully using this configuration in E+ without issues.
