### PR TITLE
Remove more qstring

### DIFF
--- a/openstudiocore/src/bimserver/BIMserverConnection.cpp
+++ b/openstudiocore/src/bimserver/BIMserverConnection.cpp
@@ -49,6 +49,13 @@
 #include <iostream>
 #include <boost/none.hpp>
 
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+static auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 
 namespace openstudio {
 namespace bimserver {
@@ -572,7 +579,7 @@ namespace bimserver {
   }
 
   void BIMserverConnection::sendCheckInIFCRequest(QString IFCFilePath) {
-    const auto path = openstudio::toPath(IFCFilePath);
+    const auto path = openstudio::toPath(IFCFilePath.toStdString());
     openstudio::filesystem::ifstream file(path);
     if (!file.is_open()) {
       emit errorOccured(QString("Cannot open file, please verify and try again"));
@@ -584,7 +591,7 @@ namespace bimserver {
     parameters["comment"] = QJsonValue(QString(""));
     parameters["deserializerOid"] = QJsonValue(m_deserializerOid);
     parameters["fileSize"] = QJsonValue(toQString(openstudio::string_conversions::number(openstudio::filesystem::file_size(path))));
-    parameters["fileName"] = QJsonValue(openstudio::toQString(path.stem()));
+    parameters["fileName"] = QJsonValue(toQString(toString(path.stem())));
     //encode file into Base64
     std::vector<char> data = openstudio::filesystem::read(file);
     QByteArray fileArrayEncoded = QByteArray(data.data(), data.size()).toBase64();

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateOutputMeter.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateOutputMeter.cpp
@@ -37,6 +37,7 @@
 #include <utilities/idd/Output_Meter_Cumulative_FieldEnums.hxx>
 #include <utilities/idd/Output_Meter_MeterFileOnly_FieldEnums.hxx>
 #include <utilities/idd/Output_Meter_Cumulative_MeterFileOnly_FieldEnums.hxx>
+#include "../../utilities/core/StringHelpers.hpp"
 #include "../../utilities/idd/IddEnums.hpp"
 #include <utilities/idd/IddEnums.hxx>
 
@@ -52,13 +53,13 @@ boost::optional<IdfObject> ForwardTranslator::translateOutputMeter( OutputMeter 
 {
   boost::optional<IdfObject> idfObject;
 
-  QString name = toQString(modelObject.name()).replace(QString("FuelOil_"), QString("FuelOil#"));
+  const auto name = openstudio::replace(modelObject.name(), "FuelOil_", "FuelOil#");
 
   if (modelObject.meterFileOnly() && modelObject.cumulative()){
     idfObject = IdfObject (openstudio::IddObjectType::Output_Meter_Cumulative_MeterFileOnly);
     m_idfObjects.push_back(*idfObject);
 
-    idfObject->setString(Output_Meter_Cumulative_MeterFileOnlyFields::KeyName, toString(name));
+    idfObject->setString(Output_Meter_Cumulative_MeterFileOnlyFields::KeyName, name);
 
     if (!modelObject.isReportingFrequencyDefaulted()){
       idfObject->setString(Output_Meter_Cumulative_MeterFileOnlyFields::ReportingFrequency, modelObject.reportingFrequency());
@@ -68,7 +69,7 @@ boost::optional<IdfObject> ForwardTranslator::translateOutputMeter( OutputMeter 
     idfObject = IdfObject (openstudio::IddObjectType::Output_Meter_MeterFileOnly);
     m_idfObjects.push_back(*idfObject);
 
-    idfObject->setString(Output_Meter_MeterFileOnlyFields::KeyName, toString(name));
+    idfObject->setString(Output_Meter_MeterFileOnlyFields::KeyName, name);
 
     if (!modelObject.isReportingFrequencyDefaulted()){
       idfObject->setString(Output_Meter_MeterFileOnlyFields::ReportingFrequency, modelObject.reportingFrequency());
@@ -78,7 +79,7 @@ boost::optional<IdfObject> ForwardTranslator::translateOutputMeter( OutputMeter 
     idfObject = IdfObject (openstudio::IddObjectType::Output_Meter_Cumulative);
     m_idfObjects.push_back(*idfObject);
 
-    idfObject->setString(Output_Meter_CumulativeFields::KeyName, toString(name));
+    idfObject->setString(Output_Meter_CumulativeFields::KeyName, name);
 
     if (!modelObject.isReportingFrequencyDefaulted()){
       idfObject->setString(Output_Meter_CumulativeFields::ReportingFrequency, modelObject.reportingFrequency());
@@ -88,7 +89,7 @@ boost::optional<IdfObject> ForwardTranslator::translateOutputMeter( OutputMeter 
     idfObject = IdfObject (openstudio::IddObjectType::Output_Meter);
     m_idfObjects.push_back(*idfObject);
 
-    idfObject->setString(Output_MeterFields::KeyName, toString(name));
+    idfObject->setString(Output_MeterFields::KeyName, name);
 
     if (!modelObject.isReportingFrequencyDefaulted()){
       idfObject->setString(Output_MeterFields::ReportingFrequency, modelObject.reportingFrequency());

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateRunPeriodControlSpecialDays.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateRunPeriodControlSpecialDays.cpp
@@ -32,6 +32,7 @@
 #include <utilities/idd/RunPeriodControl_SpecialDays_FieldEnums.hxx>
 #include <utilities/idd/OS_RunPeriodControl_SpecialDays_FieldEnums.hxx>
 #include "../../utilities/idd/IddEnums.hpp"
+#include "../../utilities/core/StringHelpers.hpp"
 #include <utilities/idd/IddEnums.hxx>
 
 using namespace openstudio::model;
@@ -56,9 +57,8 @@ boost::optional<IdfObject> ForwardTranslator::translateRunPeriodControlSpecialDa
   s = modelObject.getString(OS_RunPeriodControl_SpecialDaysFields::StartDate);
   if( s )
   {
-    QString temp = toQString(s.get());
-    temp.replace("5th", "Last");
-    idfObject.setString(RunPeriodControl_SpecialDaysFields::StartDate,temp.toStdString());
+    const auto temp = openstudio::replace(s.get(), "5th", "Last");
+    idfObject.setString(RunPeriodControl_SpecialDaysFields::StartDate,temp);
   }
 
   s = modelObject.getString(OS_RunPeriodControl_SpecialDaysFields::Duration);

--- a/openstudiocore/src/gbxml/ForwardTranslator.cpp
+++ b/openstudiocore/src/gbxml/ForwardTranslator.cpp
@@ -88,6 +88,13 @@
 
 #include <regex>
 
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio {
 namespace gbxml {
 
@@ -117,7 +124,7 @@ namespace gbxml {
 
     openstudio::filesystem::ofstream file(path, std::ios_base::binary);
     if (file.is_open()){
-      openstudio::filesystem::write(file, doc->toString(2));
+      file << doc->toString(2).toStdString();
       file.close();
       return true;
     }

--- a/openstudiocore/src/gbxml/ForwardTranslator.cpp
+++ b/openstudiocore/src/gbxml/ForwardTranslator.cpp
@@ -91,7 +91,7 @@
 ///
 /// TODO: Remove this helper when Qt is fully removed
 ///
-auto toQString(const std::string &s) {
+static auto toQString(const std::string &s) {
   return QString::fromUtf8(s.data(), s.size());
 };
 

--- a/openstudiocore/src/gbxml/MapEnvelope.cpp
+++ b/openstudiocore/src/gbxml/MapEnvelope.cpp
@@ -57,7 +57,7 @@
 ///
 /// TODO: Remove this helper when Qt is fully removed
 ///
-auto toQString = [](const std::string &s) {
+static auto toQString(const std::string &s) {
   return QString::fromUtf8(s.data(), s.size());
 };
 

--- a/openstudiocore/src/gbxml/MapEnvelope.cpp
+++ b/openstudiocore/src/gbxml/MapEnvelope.cpp
@@ -54,6 +54,13 @@
 #include <QDomDocument>
 #include <QDomElement>
 
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+auto toQString = [](const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio {
 namespace gbxml {
 

--- a/openstudiocore/src/gbxml/ReverseTranslator.cpp
+++ b/openstudiocore/src/gbxml/ReverseTranslator.cpp
@@ -605,7 +605,7 @@ namespace gbxml {
         QString spaceId1 = adjacentSpaceElements.at(0).toElement().attribute("spaceIdRef");
         QString spaceId2 = adjacentSpaceElements.at(1).toElement().attribute("spaceIdRef");
         if (spaceId1 == spaceId2){
-          LOG(Warn, "Surface has two adjacent spaces which are the same space '" << toString(spaceId2) << "', will not be translated.");
+          LOG(Warn, "Surface has two adjacent spaces which are the same space '" << spaceId2.toStdString() << "', will not be translated.");
           return boost::none;
         }
       }else if (adjacentSpaceElements.size() > 2){
@@ -817,12 +817,12 @@ namespace gbxml {
                   // one of the spaces lists this as a wall or some other surfaceType
                   // we could try to reapply the surfaceType from the gbXML back here, but then we would be in the same problem as before
                   // at least now we have a surface type that matches the vertex outward normal
-                  LOG(Warn, "Adjacent surfaceTypes '" << toString(spaceSurfaceType) << "' and  '" << toString(adjacentSpaceSurfaceType) << "' listed for '" << surface.name().get() << "' do not match vertices");
+                  LOG(Warn, "Adjacent surfaceTypes '" << spaceSurfaceType.toStdString() << "' and  '" << adjacentSpaceSurfaceType.toStdString() << "' listed for '" << surface.name().get() << "' do not match vertices");
 
                 } else if (spaceSurfaceType == adjacentSpaceSurfaceType) {
 
                   // both spaceSurfaceType and adjacentSpaceSurfaceType are either InteriorFloor or Ceiling, not allowed
-                  LOG(Warn, "Duplicate surfaceType '" << toString(spaceSurfaceType) << "' listed for '" << surface.name().get() << "'");
+                  LOG(Warn, "Duplicate surfaceType '" << spaceSurfaceType.toStdString() << "' listed for '" << surface.name().get() << "'");
 
                 } else {
 
@@ -841,7 +841,7 @@ namespace gbxml {
 
                       // Schema says, "The outward normal of the surface, as defined by the right hand rule of the coordinates in the planar geometry element,
                       // is always pointing away from the first AdjacentSpaceID listed." but this does not match surfaceType in the first AdjacentSpaceID
-                      LOG(Warn, "Outward normal for '" << surface.name().get() << "' does not match surfaceType '" << toString(spaceSurfaceType) << "' attribute of first AdjacentSpaceID");
+                      LOG(Warn, "Outward normal for '" << surface.name().get() << "' does not match surfaceType '" << spaceSurfaceType.toStdString() << "' attribute of first AdjacentSpaceID");
 
                       // construction listed in order for first space which is now the adjacent space
                       reverseConstruction = true;
@@ -861,7 +861,7 @@ namespace gbxml {
 
                       // Schema says, "The outward normal of the surface, as defined by the right hand rule of the coordinates in the planar geometry element,
                       // is always pointing away from the first AdjacentSpaceID listed." but this does not match surfaceType in the first AdjacentSpaceID
-                      LOG(Warn, "Outward normal for '" << surface.name().get() << "' does not match surfaceType attribute '" << toString(spaceSurfaceType) << "' of first AdjacentSpaceID");
+                      LOG(Warn, "Outward normal for '" << surface.name().get() << "' does not match surfaceType attribute '" << spaceSurfaceType.toStdString() << "' of first AdjacentSpaceID");
 
                       // construction listed in order for first space which is now the adjacent space
                       reverseConstruction = true;
@@ -1048,11 +1048,11 @@ namespace gbxml {
 
     QString cadObjectId = element.text();
     if (!cadObjectId.isEmpty()) {
-      result.setFeature("CADObjectId", toString(cadObjectId));
+      result.setFeature("CADObjectId", cadObjectId.toStdString());
 
       QString programIdRef = element.attribute("programIdRef");
       if (!programIdRef.isEmpty()) {
-        result.setFeature("programIdRef", toString(programIdRef));
+        result.setFeature("programIdRef", programIdRef.toStdString());
       }
     }
 

--- a/openstudiocore/src/model_editor/Application.cpp
+++ b/openstudiocore/src/model_editor/Application.cpp
@@ -32,6 +32,8 @@
 #include <utilities/core/ApplicationPathHelpers.hpp>
 #include <utilities/core/String.hpp>
 
+#include "Utilities.hpp"
+
 #include <QSettings>
 
 #if _WIN32 || _MSC_VER

--- a/openstudiocore/src/model_editor/CMakeLists.txt
+++ b/openstudiocore/src/model_editor/CMakeLists.txt
@@ -58,6 +58,8 @@ set(${target_name}_src
   ViewWidget.cpp
   UserSettings.hpp
   UserSettings.cpp
+  Utilities.hpp
+  Utilities.cpp
   IGPrecisionDialog.hpp
   IGPrecisionDialog.cpp
   IGLineEdit.hpp
@@ -86,6 +88,7 @@ set(${target_name}_moc
   treemodel.h
   TreeView.hpp
   TreeViewWidget.hpp
+  Utilities.hpp
   ViewWidget.hpp
   IGPrecisionDialog.hpp
   IGLineEdit.hpp
@@ -172,6 +175,7 @@ set(${target_name}_test_src
   test/ModalDialogs_GTest.cpp
   test/PathWatcher_GTest.cpp
   test/QMetaTypes_GTest.cpp
+  test/Utilities_GTest.cpp
 )
 
 set(${target_name}_test_depends

--- a/openstudiocore/src/model_editor/EditorFrame.cpp
+++ b/openstudiocore/src/model_editor/EditorFrame.cpp
@@ -60,6 +60,7 @@
 #include "../utilities/core/Assert.hpp"
 
 #include "EditorFrame.hpp"
+#include "Utilities.hpp"
 
 
 namespace modeleditor

--- a/openstudiocore/src/model_editor/InspectorDialog.cpp
+++ b/openstudiocore/src/model_editor/InspectorDialog.cpp
@@ -31,6 +31,7 @@
 #include "InspectorDialog.hpp"
 #include "Application.hpp"
 #include "AccessPolicyStore.hpp"
+#include "Utilities.hpp"
 
 #include <model/Model.hpp>
 #include <model/Model_Impl.hpp>

--- a/openstudiocore/src/model_editor/InspectorGadget.cpp
+++ b/openstudiocore/src/model_editor/InspectorGadget.cpp
@@ -38,6 +38,8 @@
 #include "../model/ParentObject.hpp"
 #include "../model/ParentObject_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/core/Compare.hpp"
 #include "../utilities/core/StringHelpers.hpp"

--- a/openstudiocore/src/model_editor/ModalDialogs.cpp
+++ b/openstudiocore/src/model_editor/ModalDialogs.cpp
@@ -30,6 +30,7 @@
 #include "ModalDialogs.hpp"
 
 #include "Application.hpp"
+#include "Utilities.hpp"
 
 #include "../model/Model.hpp"
 #include "../model/Model_Impl.hpp"

--- a/openstudiocore/src/model_editor/ModelEditor.i
+++ b/openstudiocore/src/model_editor/ModelEditor.i
@@ -27,6 +27,7 @@
   #include <model_editor/ModalDialogs.hpp>
   #include <model_editor/OSProgressBar.hpp>
   #include <model_editor/PathWatcher.hpp>
+  #include <model_editor/Utilities.hpp>
  
   #include <model/Model.hpp>
   #include <model/ModelObject.hpp>
@@ -74,6 +75,8 @@
 %include <model_editor/AccessPolicyStore.hpp>
 
 %include <model_editor/InspectorGadget.hpp>
+
+%include <model_editor/Utilities.hpp>
 
 %feature("director") InspectorDialog;
 %include <model_editor/InspectorDialog.hpp>

--- a/openstudiocore/src/model_editor/OSProgressBar.cpp
+++ b/openstudiocore/src/model_editor/OSProgressBar.cpp
@@ -30,6 +30,7 @@
 #include "OSProgressBar.hpp"
 
 #include "Application.hpp"
+#include "Utilities.hpp"
 
 #include <cmath>
 #include <nano/nano_signal_slot.hpp>

--- a/openstudiocore/src/model_editor/PathWatcher.cpp
+++ b/openstudiocore/src/model_editor/PathWatcher.cpp
@@ -30,6 +30,8 @@
 #include "PathWatcher.hpp"
 #include "Application.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include <utilities/core/Checksum.hpp>
 #include <utilities/core/Assert.hpp>
 

--- a/openstudiocore/src/model_editor/Qt.i
+++ b/openstudiocore/src/model_editor/Qt.i
@@ -161,12 +161,12 @@ class QComboBox : public QWidget
 
 //class QString{};
 
-//%extend QString{
-//  // to std::string
-//  std::string __str__() const{
-//    return toString(*self);
-//  }
-//}
+%extend QString{
+  // to std::string
+  std::string __str__() const{
+    return toString(*self);
+  }
+}
 
 //class QModelIndex{};
 

--- a/openstudiocore/src/model_editor/UserSettings.cpp
+++ b/openstudiocore/src/model_editor/UserSettings.cpp
@@ -34,6 +34,8 @@
 #include "../utilities/core/Path.hpp"
 #include "../utilities/core/FilesystemHelpers.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include <QString>
 #include <QSettings>
 

--- a/openstudiocore/src/model_editor/Utilities.cpp
+++ b/openstudiocore/src/model_editor/Utilities.cpp
@@ -27,43 +27,77 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef UTILITIES_CORE_STRING_HPP
-#define UTILITIES_CORE_STRING_HPP
-
-#include "../UtilitiesAPI.hpp"
-
-#include <string>
-#include <vector>
-
-#include <QString>
-
-/** \file String.hpp
- *
- *  All strings are assumed to be UTF-8 encoded std::string.  Note that length of the std::string
- *  may therefore not match number of characters in the std::string. */
+#include "Utilities.hpp"
 
 namespace openstudio {
-
-  /** string to std::string. */
-  UTILITIES_API std::string toString(const std::string& s);
-
-  /** char* to std::string. */
-  UTILITIES_API std::string toString(const char* s);
-
-  /** wstring to std::string. */
-  UTILITIES_API std::string toString(const std::wstring& w);
-
-  /** wchar_t* to std::string. */
-  UTILITIES_API std::string toString(const wchar_t* w);
+  /** QString to UTF-8 encoded std::string. */
+  std::string toString(const QString& q)
+  {
+    const QByteArray& qb = q.toUtf8();
+    return std::string(qb.data());
+  }
 
 
-  /** Double to std::string at full precision. */
-  UTILITIES_API std::string toString(double v);
 
-  /** Load data in istream into string. */
-  UTILITIES_API std::string toString(std::istream& s);
+  /** QString to wstring. */
+  std::wstring toWString(const QString& q)
+  {
+#if (defined (_WIN32) || defined (_WIN64))
+    static_assert(sizeof(wchar_t) == sizeof(unsigned short), "Wide characters must have the same size as unsigned shorts");
+    std::wstring w(reinterpret_cast<const wchar_t *>(q.utf16()), q.length());
+    return w;
+#else
+    std::wstring w = q.toStdWString();
+    return w;
+#endif
+  }
+
+  /** UTF-8 encoded std::string to QString. */
+  QString toQString(const std::string& s)
+  {
+    return QString::fromUtf8(s.c_str());
+  }
+
+  /** wstring to QString. */
+  QString toQString(const std::wstring& w)
+  {
+#if (defined (_WIN32) || defined (_WIN64))
+    static_assert(sizeof(wchar_t) == sizeof(unsigned short), "Wide characters must have the same size as unsigned shorts");
+    return QString::fromUtf16(reinterpret_cast<const unsigned short *>(w.data()), w.length());
+#else
+    return QString::fromStdWString(w);
+#endif
+
+  }
+
+  UUID toUUID(const QString &str)
+  {
+    return toUUID(toString(str));
+  }
+
+  QString toQString(const UUID& uuid)
+  {
+    return toQString(toString(uuid));
+  }
+
+  /** path to QString. */
+  QString toQString(const path& p)
+  {
+#if (defined (_WIN32) || defined (_WIN64))
+    return QString::fromStdWString(p.generic_wstring());
+#endif
+    return QString::fromUtf8(p.generic_string().c_str());
+  }
+
+  /** QString to path*/
+  path toPath(const QString& q)
+  {
+#if (defined (_WIN32) || defined (_WIN64))
+    return path(q.toStdWString());
+#endif
+
+    return path(q.toStdString());
+  }
 
 
-} // openstudio
-
-#endif // UTILITIES_CORE_STRING_HPP
+}

--- a/openstudiocore/src/model_editor/Utilities.hpp
+++ b/openstudiocore/src/model_editor/Utilities.hpp
@@ -27,43 +27,42 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef UTILITIES_CORE_STRING_HPP
-#define UTILITIES_CORE_STRING_HPP
-
-#include "../UtilitiesAPI.hpp"
+#ifndef MODELEDITOR_UTILITIES_HPP
+#define MODELEDITOR_UTILITIES_HPP
 
 #include <string>
-#include <vector>
-
 #include <QString>
 
-/** \file String.hpp
- *
- *  All strings are assumed to be UTF-8 encoded std::string.  Note that length of the std::string
- *  may therefore not match number of characters in the std::string. */
+#include "ModelEditorAPI.hpp"
+
 
 namespace openstudio {
+  /** QString to UTF-8 encoded std::string. */
+  MODELEDITOR_API std::string toString(const QString& q);
 
-  /** string to std::string. */
-  UTILITIES_API std::string toString(const std::string& s);
+  /** QString to wstring. */
+  MODELEDITOR_API std::wstring toWString(const QString& q);
 
-  /** char* to std::string. */
-  UTILITIES_API std::string toString(const char* s);
+  /** UTF-8 encoded std::string to QString. */
+  MODELEDITOR_API QString toQString(const std::string& s);
 
-  /** wstring to std::string. */
-  UTILITIES_API std::string toString(const std::wstring& w);
-
-  /** wchar_t* to std::string. */
-  UTILITIES_API std::string toString(const wchar_t* w);
-
-
-  /** Double to std::string at full precision. */
-  UTILITIES_API std::string toString(double v);
-
-  /** Load data in istream into string. */
-  UTILITIES_API std::string toString(std::istream& s);
+  /** wstring to QString. */
+  MODELEDITOR_API QString toQString(const std::wstring& w);
 
 
-} // openstudio
+  /// create a UUID from a std::string, does not throw, may return a null UUID
+  MODELEDITOR_API UUID toUUID(const QString& str);
 
-#endif // UTILITIES_CORE_STRING_HPP
+  /// create a QString from a UUID
+  MODELEDITOR_API QString toQString(const UUID& uuid);
+
+  /** path to QString. */
+  MODELEDITOR_API QString toQString(const path& p);
+
+  /** QString to path*/
+  MODELEDITOR_API path toPath(const QString& q);
+
+
+}
+
+#endif

--- a/openstudiocore/src/model_editor/test/Utilities_GTest.cpp
+++ b/openstudiocore/src/model_editor/test/Utilities_GTest.cpp
@@ -1,0 +1,143 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <resources.hxx>
+
+#include "ModelEditorFixture.hpp"
+#include "../Utilities.hpp"
+
+#include <clocale>
+
+using openstudio::toString;
+using openstudio::toQString;
+using openstudio::toPath;
+
+
+TEST(ModelEditorFixture, SimpleConversions)
+{
+  std::string s("Hello world");
+  const char* const cStr = "Hello world";
+  const wchar_t* const wStr = L"Hello world";
+  std::wstring w(L"Hello world");
+  QString q("Hello world");
+  openstudio::path p = toPath("Hello world");
+
+  EXPECT_EQ(s, s);
+  EXPECT_EQ(s, cStr);
+  EXPECT_EQ(s, toString(w));
+  EXPECT_EQ(s, toString(wStr));
+  EXPECT_EQ(s, toString(q));
+  EXPECT_EQ(s, toString(p));
+  EXPECT_EQ(s, toString(toQString(s)));
+  EXPECT_EQ(s, toString(toPath(s)));
+  EXPECT_EQ(s, toString(toQString(toPath(s))));
+  EXPECT_TRUE(q == toQString(s));
+  EXPECT_TRUE(q == toQString(p));
+  EXPECT_TRUE(p == toPath(s));
+  EXPECT_TRUE(p == toPath(q));
+}
+
+
+TEST_F(ModelEditorFixture, Path_Conversions)
+{
+  std::string s;
+  std::wstring w;
+  openstudio::path p;
+
+  s = std::string("basic_path");
+  w = std::wstring(L"basic_path");
+  p = openstudio::path(s);
+  EXPECT_EQ(s, toQString(p).toStdString());
+  EXPECT_EQ(s, toQString(toString(p)).toStdString());
+  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
+  EXPECT_EQ(w, toQString(p).toStdWString());
+  //EXPECT_EQ(w, toString(p));
+  EXPECT_EQ(w, toQString(toString(p)).toStdWString());
+  //EXPECT_EQ(w, std::wstring(toQString(toString(p)).toUtf16()));
+  EXPECT_EQ(w, toPath(toQString(toString(p))).wstring());
+
+  p = openstudio::path(w);
+  EXPECT_EQ(s, toQString(p).toStdString());
+  EXPECT_EQ(s, toQString(toString(p)).toStdString());
+  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
+
+  p = openstudio::path(w);
+  EXPECT_EQ(s, toQString(p).toStdString());
+  EXPECT_EQ(s, toQString(toString(p)).toStdString());
+  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
+
+  // http://utf8everywhere.org/
+
+
+  // from http://www.nubaria.com/en/blog/?p=289
+
+  // Chinese characters for "zhongwen" ("Chinese language").
+  const char kChineseSampleText[] = { -28, -72, -83, -26, -106, -121, 0 };
+
+  // Arabic "al-arabiyya" ("Arabic").
+  const char kArabicSampleText[] = { -40, -89, -39, -124, -40, -71, -40, -79, -40, -88, -39, -118, -40, -87, 0 };
+
+  // Spanish word "canon" with an "n" with "~" on top and an "o" with an acute accent.
+  const char kSpanishSampleText[] = { 99, 97, -61, -79, -61, -77, 110, 0 };
+
+  std::string t;
+  QString q;
+
+  t = std::string(kChineseSampleText);
+  q = QString::fromUtf8(t.c_str());
+  p = toPath(t);
+  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
+  EXPECT_EQ(t, toString(p));
+  EXPECT_EQ(t, toString(toQString(toString(p))));
+  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
+
+  t = std::string(kArabicSampleText);
+  q = QString::fromUtf8(t.c_str());
+  p = toPath(t);
+  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
+  EXPECT_EQ(t, toString(toQString(toString(p))));
+  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
+
+  t = std::string(kSpanishSampleText);
+  q = QString::fromUtf8(t.c_str());
+  p = toPath(t);
+  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
+  EXPECT_EQ(t, toString(toQString(toString(p))));
+  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
+  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
+
+}
+

--- a/openstudiocore/src/openstudio_app/LibraryDialog.cpp
+++ b/openstudiocore/src/openstudio_app/LibraryDialog.cpp
@@ -28,6 +28,8 @@
 ***********************************************************************************************************************/
 
 #include "./LibraryDialog.hpp"
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Path.hpp"
 #include "../utilities/core/ApplicationPathHelpers.hpp"
 #include <QVBoxLayout>

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -36,6 +36,7 @@
 #include "../openstudio_lib/OSDocument.hpp"
 
 #include "../model_editor/AccessPolicyStore.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../shared_gui_components/WaitDialog.hpp"
 #include "../shared_gui_components/MeasureManager.hpp"

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -35,6 +35,7 @@
 #include "OpenStudioApp.hpp"
 #include "../model_editor/Application.hpp"
 #include "../model_editor/AccessPolicyStore.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../measure/OSArgument.hpp"
 

--- a/openstudiocore/src/openstudio_app/test/Resources_GTest.cpp
+++ b/openstudiocore/src/openstudio_app/test/Resources_GTest.cpp
@@ -38,6 +38,9 @@
 #include "../../model/SpaceLoad_Impl.hpp"
 #include "../../model/SpaceType.hpp"
 
+#include "../../model_editor/Utilities.hpp"
+
+
 #include "../../utilities/core/ApplicationPathHelpers.hpp"
 #include "../../utilities/core/PathHelpers.hpp"
 

--- a/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ApplyMeasureNowDialog.cpp
@@ -43,6 +43,7 @@
 #include "OSAppBase.hpp"
 #include "OSDocument.hpp"
 #include "OSItem.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../model/Model.hpp"
 #include "../model/Model_Impl.hpp"

--- a/openstudiocore/src/openstudio_lib/BuildingInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/BuildingInspectorView.cpp
@@ -38,6 +38,7 @@
 #include "ModelObjectItem.hpp"
 #include "OSDropZone.hpp"
 #include "OSVectorController.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../model/Building.hpp"
 #include "../model/Building_Impl.hpp"

--- a/openstudiocore/src/openstudio_lib/GeometryEditorView.cpp
+++ b/openstudiocore/src/openstudio_lib/GeometryEditorView.cpp
@@ -58,6 +58,8 @@
 #include "../model/ShadingSurface.hpp"
 #include "../model/ShadingSurface_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../gbxml/ReverseTranslator.hpp"
 #include "../energyplus/ReverseTranslator.hpp"
 #include "../osversion/VersionTranslator.hpp"
@@ -90,7 +92,14 @@
 #include <QProcessEnvironment>
 #include <QDesktopServices>
 
-int CHECKFORUPDATEMSEC = 5000;
+const int CHECKFORUPDATEMSEC = 5000;
+
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+static auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
 
 namespace openstudio {
 

--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -110,6 +110,9 @@
 #include "../model/Mixer.hpp"
 #include "../model/ThermalZone.hpp"
 #include "../model/ThermalZone_Impl.hpp"
+
+#include "../model_editor/Utilities.hpp"
+
 #include <algorithm>
 
 #include <utilities/idd/IddEnums.hxx>

--- a/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
+++ b/openstudiocore/src/openstudio_lib/HVACSystemsController.cpp
@@ -119,6 +119,9 @@
 #include "../model/ComponentData.hpp"
 #include "../model/ComponentData_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
+
 #include "../energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.hpp"
 
 #include "../utilities/core/Assert.hpp"

--- a/openstudiocore/src/openstudio_lib/InspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/InspectorView.cpp
@@ -127,6 +127,7 @@
 #include "../model/ZoneHVACWaterToAirHeatPump_Impl.hpp"
 
 #include "../model_editor/InspectorGadget.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../utilities/core/Assert.hpp"
 

--- a/openstudiocore/src/openstudio_lib/LocationTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/LocationTabView.cpp
@@ -59,6 +59,8 @@
 #include "../model/WeatherFile_Impl.hpp"
 #include "../model/YearDescription_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../energyplus/ReverseTranslator.hpp"
 
 //#include "../runmanager/lib/ConfigOptions.hpp"

--- a/openstudiocore/src/openstudio_lib/LoopChooserView.cpp
+++ b/openstudiocore/src/openstudio_lib/LoopChooserView.cpp
@@ -37,6 +37,10 @@
 #include "../model/Loop_Impl.hpp"
 #include "../model/PlantLoop.hpp"
 #include "../model/PlantLoop_Impl.hpp"
+
+#include "../model_editor/Utilities.hpp"
+
+
 #include <QCheckBox>
 #include <QHBoxLayout>
 #include <QStyleOption>

--- a/openstudiocore/src/openstudio_lib/ModelObjectInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectInspectorView.cpp
@@ -30,6 +30,8 @@
 #include "ModelObjectInspectorView.hpp"
 #include "ModelObjectItem.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../model/Model.hpp"
 #include "../model/Model_Impl.hpp"
 #include "../model/ModelObject_Impl.hpp"

--- a/openstudiocore/src/openstudio_lib/ModelObjectItem.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectItem.cpp
@@ -38,6 +38,9 @@
 #include "../model/ComponentData.hpp"
 #include "../model/ComponentData_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
+
 #include <QLabel>
 
 #include "../utilities/core/Assert.hpp"

--- a/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectListView.cpp
@@ -41,6 +41,9 @@
 #include "../model/UtilityBill.hpp"
 #include "../model/UtilityBill_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/bcl/LocalBCL.hpp"
 

--- a/openstudiocore/src/openstudio_lib/ModelObjectTreeItems.cpp
+++ b/openstudiocore/src/openstudio_lib/ModelObjectTreeItems.cpp
@@ -87,6 +87,8 @@
 #include "../model/DesignSpecificationOutdoorAir.hpp"
 #include "../model/DesignSpecificationOutdoorAir_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include <utilities/idd/OS_Building_FieldEnums.hxx>
 #include <utilities/idd/OS_BuildingStory_FieldEnums.hxx>
 #include <utilities/idd/OS_ThermalZone_FieldEnums.hxx>

--- a/openstudiocore/src/openstudio_lib/OSAppBase.cpp
+++ b/openstudiocore/src/openstudio_lib/OSAppBase.cpp
@@ -33,6 +33,7 @@
 #include "MainRightColumnController.hpp"
 #include "MainWindow.hpp"
 #include "OSDocument.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../shared_gui_components/EditController.hpp"
 #include "../shared_gui_components/MeasureManager.hpp"

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -71,6 +71,8 @@
 #include "../shared_gui_components/WaitDialog.hpp"
 
 #include "../model_editor/UserSettings.hpp"
+#include "../model_editor/Utilities.hpp"
+
 
 //#include "../analysis/Analysis.hpp"
 

--- a/openstudiocore/src/openstudio_lib/OSItem.cpp
+++ b/openstudiocore/src/openstudio_lib/OSItem.cpp
@@ -42,6 +42,8 @@
 #include "../utilities/bcl/LocalBCL.hpp"
 #include "../utilities/core/Assert.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include <QBoxLayout>
 #include <QDrag>
 #include <QLabel>

--- a/openstudiocore/src/openstudio_lib/RefrigerationController.cpp
+++ b/openstudiocore/src/openstudio_lib/RefrigerationController.cpp
@@ -57,7 +57,11 @@
 #include "../model/RefrigerationSubcoolerMechanical_Impl.hpp"
 #include "../model/RefrigerationSubcoolerLiquidSuction.hpp"
 #include "../model/RefrigerationSubcoolerLiquidSuction_Impl.hpp"
+
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Compare.hpp"
+
 #include "../shared_gui_components/GraphicsItems.hpp"
 #include <QGraphicsScene>
 #include <QGraphicsView>

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
@@ -30,6 +30,7 @@
 #include "ResultsTabView.hpp"
 #include "OSDocument.hpp"
 #include "OSAppBase.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include <QFile>
 #include <QBoxLayout>

--- a/openstudiocore/src/openstudio_lib/RunTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/RunTabView.cpp
@@ -62,6 +62,7 @@
 #include "../energyplus/ForwardTranslator.hpp"
 
 #include "../model_editor/Application.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include <QButtonGroup>
 #include <QDir>

--- a/openstudiocore/src/openstudio_lib/ScheduleDayView.cpp
+++ b/openstudiocore/src/openstudio_lib/ScheduleDayView.cpp
@@ -29,6 +29,7 @@
 
 #include "ScheduleDayView.hpp"
 #include "SchedulesView.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../shared_gui_components/OSCheckBox.hpp"
 #include "OSItem.hpp"

--- a/openstudiocore/src/openstudio_lib/ScheduleDialog.cpp
+++ b/openstudiocore/src/openstudio_lib/ScheduleDialog.cpp
@@ -35,6 +35,8 @@
 #include "../model/ScheduleTypeLimits_Impl.hpp"
 #include "../model/ScheduleDay.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/units/OSOptionalQuantity.hpp"
 #include "../utilities/units/Quantity.hpp"
 #include "../utilities/units/QuantityConverter.hpp"

--- a/openstudiocore/src/openstudio_lib/SchedulesView.cpp
+++ b/openstudiocore/src/openstudio_lib/SchedulesView.cpp
@@ -45,6 +45,8 @@
 #include "../model/ScheduleTypeLimits.hpp"
 #include "../model/ScheduleTypeLimits_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/time/Date.hpp"
 #include "../utilities/time/Time.hpp"
 #include "../utilities/units/QuantityConverter.hpp"

--- a/openstudiocore/src/openstudio_lib/ScriptItem.cpp
+++ b/openstudiocore/src/openstudio_lib/ScriptItem.cpp
@@ -30,6 +30,7 @@
 #include "ScriptItem.hpp"
 #include "OSAppBase.hpp"
 #include "OSDocument.hpp"
+#include "../model_editor/Utilities.hpp"
 
 //#include "../runmanager/lib/RunManager.hpp"
 //#include "../runmanager/lib/RubyJobUtils.hpp"

--- a/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpaceTypesGridView.cpp
@@ -102,6 +102,8 @@
 #include "../model/SteamEquipmentDefinition_Impl.hpp"
 #include "../model/SteamEquipment_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/idd/IddEnums.hxx"
 #include "../utilities/idd/OS_SpaceType_FieldEnums.hxx"
 

--- a/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
+++ b/openstudiocore/src/openstudio_lib/SpacesSubtabGridView.cpp
@@ -76,6 +76,8 @@
 #include "../model/ThermalZone.hpp"
 #include "../model/ThermalZone_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/idd/IddEnums.hxx"
 #include "../utilities/idd/OS_Space_FieldEnums.hxx"

--- a/openstudiocore/src/openstudio_lib/StandardOpaqueMaterialInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/StandardOpaqueMaterialInspectorView.cpp
@@ -31,6 +31,8 @@
 
 #include "../model/Model_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 
 #include <QStyleOption>

--- a/openstudiocore/src/openstudio_lib/StandardsInformationConstructionWidget.cpp
+++ b/openstudiocore/src/openstudio_lib/StandardsInformationConstructionWidget.cpp
@@ -31,6 +31,8 @@
 
 #include "OSItem.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../shared_gui_components/OSComboBox.hpp"
 #include "../shared_gui_components/OSLineEdit.hpp"
 #include "../shared_gui_components/OSSwitch.hpp"

--- a/openstudiocore/src/openstudio_lib/StandardsInformationMaterialWidget.cpp
+++ b/openstudiocore/src/openstudio_lib/StandardsInformationMaterialWidget.cpp
@@ -37,6 +37,8 @@
 #include "../model/Material.hpp"
 #include "../model/Material_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 
 #include <QGridLayout>

--- a/openstudiocore/src/openstudio_lib/UtilityBillFuelTypeListView.cpp
+++ b/openstudiocore/src/openstudio_lib/UtilityBillFuelTypeListView.cpp
@@ -38,6 +38,8 @@
 #include "../model/UtilityBill.hpp"
 #include "../model/UtilityBill_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 
 #include <iostream>

--- a/openstudiocore/src/openstudio_lib/VRFController.cpp
+++ b/openstudiocore/src/openstudio_lib/VRFController.cpp
@@ -47,6 +47,9 @@
 #include "../model/Component_Impl.hpp"
 #include "../model/ComponentData.hpp"
 #include "../model/ComponentData_Impl.hpp"
+
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Compare.hpp"
 #include "../shared_gui_components/GraphicsItems.hpp"
 #include <utilities/idd/OS_ComponentData_FieldEnums.hxx>

--- a/openstudiocore/src/openstudio_lib/VariablesTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/VariablesTabView.cpp
@@ -34,6 +34,8 @@
 #include "../model/ModelObject_Impl.hpp"
 #include "../model/OutputVariable_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/sql/SqlFileEnums.hpp"
 
 #include <QHBoxLayout>

--- a/openstudiocore/src/openstudio_lib/YearSettingsWidget.cpp
+++ b/openstudiocore/src/openstudio_lib/YearSettingsWidget.cpp
@@ -40,6 +40,8 @@
 #include "../model/WeatherFile.hpp"
 #include "../model/WeatherFile_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Compare.hpp"
 #include "../utilities/filetypes/EpwFile.hpp"
 #include "../utilities/idd/IddEnums.hxx"

--- a/openstudiocore/src/openstudio_lib/ZoneChooserView.cpp
+++ b/openstudiocore/src/openstudio_lib/ZoneChooserView.cpp
@@ -36,6 +36,9 @@
 #include "../model/AirLoopHVACZoneSplitter_Impl.hpp"
 #include "../model/AirLoopHVACZoneMixer.hpp"
 #include "../model/AirLoopHVACZoneMixer_Impl.hpp"
+
+#include "../model_editor/Utilities.hpp"
+
 #include <QCheckBox>
 #include <QHBoxLayout>
 #include <QStyleOption>

--- a/openstudiocore/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/openstudiocore/src/osversion/test/VersionTranslator_GTest.cpp
@@ -46,6 +46,8 @@
 #include "../../model/Version.hpp"
 #include "../../model/Version_Impl.hpp"
 
+#include "../../utilities/core/StringHelpers.hpp"
+
 #include "../../utilities/bcl/RemoteBCL.hpp"
 #include "../../utilities/bcl/LocalBCL.hpp"
 #include "../../utilities/bcl/BCLComponent.hpp"
@@ -72,8 +74,8 @@ void testExampleModel(int minor, int major) {
   for (openstudio::filesystem::directory_iterator it(resources); it != openstudio::filesystem::directory_iterator(); ++it) {
     if (openstudio::filesystem::is_directory(it->status())) {
 
-      QString stem = toQString(it->path().stem()).replace("_", ".");
-      VersionString vs(toString(stem));
+      const auto stem = openstudio::replace(openstudio::toString(it->path().stem()), "_", ".");
+      VersionString vs(stem);
       if (vs.major() == major && vs.minor() == minor){
 
         // run version translator on each example.osm
@@ -154,9 +156,8 @@ void testExampleComponent(int major, int minor) {
   openstudio::path resources = resourcesPath() / toPath("osversion");
   for (openstudio::filesystem::directory_iterator it(resources); it != openstudio::filesystem::directory_iterator(); ++it) {
     if (openstudio::filesystem::is_directory(it->status())) {
-
-      QString stem = toQString(it->path().stem()).replace("_", ".");
-      VersionString vs(toString(stem));
+      const auto stem = openstudio::replace(openstudio::toString(it->path().stem()), "_", ".");
+      VersionString vs(stem);
       if (vs.major() == major && vs.minor() == minor){
 
         // run version translator on each example.osm

--- a/openstudiocore/src/sdd/ForwardTranslator.cpp
+++ b/openstudiocore/src/sdd/ForwardTranslator.cpp
@@ -209,7 +209,7 @@ namespace sdd {
 
     openstudio::filesystem::ofstream file(path, std::ios_base::binary);
     if (file.is_open()){
-      openstudio::filesystem::write(file, doc->toString(2));
+      file << doc->toString(2).toStdString();
       file.close();
       return true;
     }
@@ -245,7 +245,8 @@ namespace sdd {
 
   QString ForwardTranslator::escapeName(const std::string& name)
   {
-    return toQString(name);
+    /// JMT: I don't think this function does what its name implies
+    return QString::fromStdString(name);
   }
 
   boost::optional<QDomDocument> ForwardTranslator::translateModel(const openstudio::model::Model& model)
@@ -280,7 +281,7 @@ namespace sdd {
       if (zones.size() > 0 && !zones[0].value().empty()){
 
         bool isNumber;
-        QString value = toQString(zones[0].value());
+        QString value = QString::fromStdString(zones[0].value());
         value.toInt(&isNumber);
         if (isNumber){
           value = QString("ClimateZone") + value;

--- a/openstudiocore/src/sdd/MapEnvelope.cpp
+++ b/openstudiocore/src/sdd/MapEnvelope.cpp
@@ -70,6 +70,13 @@
 #include <QDomDocument>
 #include <QDomElement>
 
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+static auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio {
 namespace sdd {
 

--- a/openstudiocore/src/sdd/MapGeometry.cpp
+++ b/openstudiocore/src/sdd/MapGeometry.cpp
@@ -116,6 +116,13 @@
 #include <QDomDocument>
 #include <QDomElement>
 
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+static auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio {
 namespace sdd {
 
@@ -1359,7 +1366,7 @@ namespace sdd {
       surface.setSunExposure("NoSun");
       surface.setWindExposure("NoWind");
     }else{
-      LOG(Error, "Unknown surface type '" << toString(tagName) << "'");
+      LOG(Error, "Unknown surface type '" << tagName.toStdString() << "'");
     }
 
     QDomElement perimExposedElement = element.firstChildElement("PerimExposed");
@@ -1588,7 +1595,7 @@ namespace sdd {
       translateConvectionCoefficients(element, doc, subSurface);
 
     }else{
-      LOG(Error, "Unknown subsurface type '" << toString(tagName) << "'");
+      LOG(Error, "Unknown subsurface type '" << tagName.toStdString() << "'");
     }
 
     // DLM: currently unhandled
@@ -1727,7 +1734,7 @@ namespace sdd {
       }
 
     }else{
-      LOG(Error, "Unknown shading surface type '" << toString(tagName) << "'");
+      LOG(Error, "Unknown shading surface type '" << tagName.toStdString() << "'");
     }
 
     return shadingSurface;

--- a/openstudiocore/src/sdd/MapHVAC.cpp
+++ b/openstudiocore/src/sdd/MapHVAC.cpp
@@ -233,6 +233,14 @@
 #include <cmath>
 #include <functional>
 
+
+///
+/// TODO: Remove this helper when Qt is fully removed
+///
+auto toQString(const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio {
 namespace sdd {
 
@@ -4084,7 +4092,7 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateTher
     }else if (typeElement.text() == "Plenum"){
       // no thermostat
     }else{
-      LOG(Error, "Unknown thermal zone type '" << toString(typeElement.text()) << "'");
+      LOG(Error, "Unknown thermal zone type '" << typeElement.text().toStdString() << "'");
     }
   }
 
@@ -4349,7 +4357,7 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateTher
   }
   boost::optional<std::string> daylightingControlType;
   if (!daylightingControlTypeElement.isNull()){
-    daylightingControlType = toString(daylightingControlTypeElement.text());
+    daylightingControlType = daylightingControlTypeElement.text().toStdString();
   }
   boost::optional<int> daylightingNumberOfControlSteps;
   if (!daylightingNumberOfControlStepsElement.isNull()){

--- a/openstudiocore/src/sdd/MapHVAC.cpp
+++ b/openstudiocore/src/sdd/MapHVAC.cpp
@@ -237,7 +237,7 @@
 ///
 /// TODO: Remove this helper when Qt is fully removed
 ///
-auto toQString(const std::string &s) {
+static auto toQString(const std::string &s) {
   return QString::fromUtf8(s.data(), s.size());
 };
 

--- a/openstudiocore/src/sdd/MapSchedules.cpp
+++ b/openstudiocore/src/sdd/MapSchedules.cpp
@@ -366,7 +366,7 @@ namespace sdd {
         return boost::none;
       }
 
-      MonthOfYear monthOfYear(toString(monthElement.text()));
+      MonthOfYear monthOfYear(monthElement.text().toStdString());
       unsigned day = dayElement.text().toUInt();
 
       result = model::RunPeriodControlSpecialDays(monthOfYear, day, model);
@@ -387,14 +387,14 @@ namespace sdd {
       }
 
       // fifth is treated equivalently to last
-      std::string specificationMethod = toString(specificationMethodElement.text());
+      std::string specificationMethod = specificationMethodElement.text().toStdString();
       if (specificationMethod == "Last"){
         specificationMethod = "Fifth";
       }
 
       NthDayOfWeekInMonth nth(specificationMethod);
-      DayOfWeek dayOfWeek(toString(dayOfWeekElement.text()));
-      MonthOfYear monthOfYear(toString(monthElement.text()));
+      DayOfWeek dayOfWeek(dayOfWeekElement.text().toStdString());
+      MonthOfYear monthOfYear(monthElement.text().toStdString());
 
       result = model::RunPeriodControlSpecialDays(nth, dayOfWeek, monthOfYear, model);
       result->setName(escapeName(nameElement.text()));

--- a/openstudiocore/src/sdd/ReverseTranslator.cpp
+++ b/openstudiocore/src/sdd/ReverseTranslator.cpp
@@ -178,7 +178,7 @@ namespace sdd {
       openstudio::filesystem::ifstream file(path, std::ios_base::binary);
       if (file.is_open()){
         QDomDocument doc;
-        bool ok = doc.setContent(toQString(openstudio::filesystem::read_as_string(file)));
+        bool ok = doc.setContent(QString::fromStdString(openstudio::filesystem::read_as_string(file)));
         file.close();
 
         if (ok) {
@@ -1883,7 +1883,7 @@ namespace sdd {
       std::string runPeriodName = "Run Period";
       QDomElement annualWeatherFileElement = element.firstChildElement("AnnualWeatherFile");
       if (!annualWeatherFileElement.isNull()){
-        runPeriodName = openstudio::toString(openstudio::toPath(annualWeatherFileElement.text()).stem());
+        runPeriodName = openstudio::toString(openstudio::toPath(annualWeatherFileElement.text().toStdString()).stem());
       }
 
       model::RunPeriod runPeriod = model.getUniqueModelObject<model::RunPeriod>();
@@ -1986,7 +1986,7 @@ namespace sdd {
       return result;
     }
 
-    openstudio::path ddyFilePath = toPath(ddWeatherFileElement.text());
+    openstudio::path ddyFilePath = toPath(ddWeatherFileElement.text().toStdString());
     if (!ddyFilePath.is_complete()){
       ddyFilePath = complete(ddyFilePath, m_path.parent_path());
     }
@@ -2024,7 +2024,7 @@ namespace sdd {
       return boost::none;
     }
 
-    openstudio::path epwFilePath = toPath(annualWeatherFileElement.text());
+    openstudio::path epwFilePath = toPath(annualWeatherFileElement.text().toStdString());
     if (!epwFilePath.is_complete()){
       epwFilePath = complete(epwFilePath, m_path.parent_path());
     }

--- a/openstudiocore/src/shared_gui_components/BCLMeasureDialog.cpp
+++ b/openstudiocore/src/shared_gui_components/BCLMeasureDialog.cpp
@@ -30,6 +30,7 @@
 #include "BCLMeasureDialog.hpp"
 
 #include "../model_editor/UserSettings.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/core/StringHelpers.hpp"

--- a/openstudiocore/src/shared_gui_components/Component.cpp
+++ b/openstudiocore/src/shared_gui_components/Component.cpp
@@ -29,6 +29,9 @@
 
 #include "Component.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
+
 #include "../utilities/bcl/BCLMeasure.hpp"
 #include "../utilities/bcl/LocalBCL.hpp"
 #include "../utilities/core/Assert.hpp"

--- a/openstudiocore/src/shared_gui_components/LocalLibraryController.cpp
+++ b/openstudiocore/src/shared_gui_components/LocalLibraryController.cpp
@@ -45,6 +45,7 @@
 #include "MeasureBadge.hpp"
 
 #include "../model_editor/UserSettings.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../utilities/bcl/LocalBCL.hpp"
 #include "../utilities/core/Assert.hpp"

--- a/openstudiocore/src/shared_gui_components/MeasureDragData.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureDragData.cpp
@@ -32,6 +32,9 @@
 #include <QDomElement>
 #include <QDomText>
 
+#include "../model_editor/Utilities.hpp"
+
+
 namespace openstudio {
 
 QString MeasureDragData::mimeType() { return "MeasureDragData"; }

--- a/openstudiocore/src/shared_gui_components/MeasureManager.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureManager.cpp
@@ -38,8 +38,8 @@
 #include "OSDialog.hpp"
 
 #include "../model_editor/Application.hpp"
-
 #include "../model_editor/UserSettings.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../measure/OSArgument.hpp"
 

--- a/openstudiocore/src/shared_gui_components/NetworkProxyDialog.cpp
+++ b/openstudiocore/src/shared_gui_components/NetworkProxyDialog.cpp
@@ -30,6 +30,7 @@
 #include "NetworkProxyDialog.hpp"
 
 #include "../model_editor/Application.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../utilities/core/String.hpp"
 

--- a/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
@@ -31,6 +31,8 @@
 
 #include "../model/ModelObject_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/core/Containers.hpp"
 

--- a/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
@@ -31,6 +31,8 @@
 
 #include "../model/ModelObject_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/core/Containers.hpp"
 

--- a/openstudiocore/src/shared_gui_components/OSLineEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSLineEdit.cpp
@@ -40,6 +40,8 @@
 #include "../model/ModelObject.hpp"
 #include "../model/ModelObject_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 
 #include <boost/optional.hpp>

--- a/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
@@ -29,6 +29,8 @@
 
 #include "OSQuantityEdit.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../model/ModelObject_Impl.hpp"
 
 #include "../utilities/core/Containers.hpp"

--- a/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
@@ -31,6 +31,8 @@
 
 #include "../model/ModelObject_Impl.hpp"
 
+#include "../model_editor/Utilities.hpp"
+
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/core/Containers.hpp"
 

--- a/openstudiocore/src/shared_gui_components/WorkflowController.cpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.cpp
@@ -38,6 +38,7 @@
 #include "LocalLibraryController.hpp"
 #include "WorkflowTools.hpp"
 #include "../model_editor/OSProgressBar.hpp"
+#include "../model_editor/Utilities.hpp"
 
 #include "../energyplus/ForwardTranslator.hpp"
 

--- a/openstudiocore/src/utilities/bcl/BCLXML.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLXML.cpp
@@ -326,8 +326,8 @@ namespace openstudio{
     return txt;
 
     // http://stackoverflow.com/questions/2083754/why-shouldnt-apos-be-used-to-escape-single-quotes
-    QString result = toQString(txt);//.replace("'", "#x27;");
-    return result.toStdString();
+//    QString result = toQString(txt);//.replace("'", "#x27;");
+//    return result.toStdString();
   }
 
   std::string BCLXML::decodeString(const std::string& txt)
@@ -336,8 +336,8 @@ namespace openstudio{
     // only thing that can't be in the text node on disk are '<' (should be '&lt;') and '&' (should be '&amp;')
     return txt;
 
-    QString result = toQString(txt);//.replace("#x27;", "'");
-    return result.toStdString();
+//    QString result = toQString(txt);//.replace("#x27;", "'");
+//    return result.toStdString();
   }
 
   std::string BCLXML::uid() const

--- a/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
+++ b/openstudiocore/src/utilities/bcl/RemoteBCL.cpp
@@ -40,6 +40,11 @@
 #define REMOTE_PRODUCTION_SERVER "https://bcl.nrel.gov"
 #define REMOTE_DEVELOPMENT_SERVER "http://bcl7.development.nrel.gov"
 
+// temporary placeholder 
+auto toQString = [](const std::string &s) {
+  return QString::fromUtf8(s.data(), s.size());
+};
+
 namespace openstudio{
 
   std::ostream& operator<<(std::ostream& os, const pugi::xml_document& element)

--- a/openstudiocore/src/utilities/core/Core.i
+++ b/openstudiocore/src/utilities/core/Core.i
@@ -24,7 +24,6 @@
   %ignore openstudio::toString(const std::string&);
   %ignore openstudio::toString(const std::wstring&);
   %ignore openstudio::toString(const char *);
-  %ignore openstudio::toQString(const std::wstring& w);
 #endif
 
 %ignore openstudio::getApplicationSourceDirectory();

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
@@ -162,10 +162,10 @@ namespace openstudio {
       }
     }
 
-    void write(openstudio::filesystem::ofstream &t_file, const QString &s)
-    {
-      t_file << openstudio::toString(s);
-    }
+//    void write(openstudio::filesystem::ofstream &t_file, const QString &s)
+//    {
+//      t_file << openstudio::toString(s);
+//    }
 
     time_t to_time_t(time_t t) {
       return t;

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.hpp
@@ -68,7 +68,7 @@ namespace openstudio {
     UTILITIES_API bool copy_file_no_throw(const openstudio::path &t_src, const openstudio::path &t_dest);
 
     // consider making this a operator<< overload. Did it this way for now to keep the changes straight
-    UTILITIES_API void write(openstudio::filesystem::ofstream &t_file, const QString &);
+    //UTILITIES_API void write(openstudio::filesystem::ofstream &t_file, const QString &);
 
     UTILITIES_API time_t last_write_time_as_time_t(const openstudio::path &t_path);
 

--- a/openstudiocore/src/utilities/core/Path.cpp
+++ b/openstudiocore/src/utilities/core/Path.cpp
@@ -56,16 +56,6 @@ std::ostream& operator<<(std::ostream& os, const path& p)
   return os;
 }
 
-/** QString to path*/
-path toPath(const QString& q)
-{
-  #if (defined (_WIN32) || defined (_WIN64))
-    return path(q.toStdWString());
-  #endif
-
-  return path(q.toStdString());
-}
-
 /** path to a temporary directory. */
 path tempDir()
 {
@@ -84,14 +74,6 @@ std::string toString(const path& p)
   return p.generic_string();
 }
 
-/** path to QString. */
-QString toQString(const path& p)
-{
-  #if (defined (_WIN32) || defined (_WIN64))
-    return QString::fromStdWString(p.generic_wstring());
-  #endif
-  return QString::fromUtf8(p.generic_string().c_str());
-}
 
 /** UTF-8 encoded char* to path*/
 path toPath(const char* s)

--- a/openstudiocore/src/utilities/core/Path.hpp
+++ b/openstudiocore/src/utilities/core/Path.hpp
@@ -37,8 +37,6 @@
 
 #include "Filesystem.hpp"
 
-// forward declarations
-class QString;
 
 namespace openstudio {
 
@@ -51,8 +49,6 @@ UTILITIES_API path tempDir();
 /** path to std::string. */
 UTILITIES_API std::string toString(const path& p);
 
-/** path to QString. */
-UTILITIES_API QString toQString(const path& p);
 
 /** UTF-8 encoded char* to path*/
 UTILITIES_API path toPath(const char* s);
@@ -60,8 +56,6 @@ UTILITIES_API path toPath(const char* s);
 /** UTF-8 encoded std::string to path*/
 UTILITIES_API path toPath(const std::string& s);
 
-/** QString to path*/
-UTILITIES_API path toPath(const QString& q);
 
 #ifdef _WIN32
 /** UTF-16 encoded std::wstring for opening fstreams*/

--- a/openstudiocore/src/utilities/core/Qt.i
+++ b/openstudiocore/src/utilities/core/Qt.i
@@ -45,12 +45,6 @@ class QObject
 
 class QString{};
 
-%extend QString{
-  // to std::string
-  std::string __str__() const{
-    return toString(*self);
-  }
-}
 
 class QDomNode{};
 

--- a/openstudiocore/src/utilities/core/String.cpp
+++ b/openstudiocore/src/utilities/core/String.cpp
@@ -116,11 +116,11 @@ std::string toString(const std::wstring &utf16_string)
 {
 #if _MSC_VER >= 1900
   std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
-  auto p = reinterpret_cast<const int16_t *>(utf16_string.data());
-  return convert.to_bytes(p, p + utf16_string.size());
+  return convert.to_bytes(utf16_string.data(), utf16_string.data() + utf16_string.size());
 #else
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-  return convert.to_bytes(utf16_string);
+  const std::u16string u16string{utf16_string.begin(), utf16_string.end()};
+  return convert.to_bytes(u16string);
 #endif
 }
 

--- a/openstudiocore/src/utilities/core/UUID.cpp
+++ b/openstudiocore/src/utilities/core/UUID.cpp
@@ -97,10 +97,6 @@ UUID createUUID()
   return UUID::random_generate();
 }
 
-UUID toUUID(const QString &str)
-{
-  return toUUID(toString(str));
-}
 
 UUID toUUID(const std::string& str)
 {
@@ -140,11 +136,6 @@ std::string toString(const UUID& uuid)
   boost::uuids::operator<<(ss, uuid);
   ss << '}';
   return ss.str();
-}
-
-QString toQString(const UUID& uuid)
-{
-  return toQString(toString(uuid));
 }
 
 

--- a/openstudiocore/src/utilities/core/UUID.hpp
+++ b/openstudiocore/src/utilities/core/UUID.hpp
@@ -50,14 +50,8 @@ namespace openstudio {
   /// create a UUID from a std::string, does not throw, may return a null UUID
   UTILITIES_API UUID toUUID(const std::string& str);
 
-  /// create a UUID from a std::string, does not throw, may return a null UUID
-  UTILITIES_API UUID toUUID(const QString& str);
-
   /// create a std::string from a UUID
   UTILITIES_API std::string toString(const UUID& uuid);
-
-  /// create a QString from a UUID
-  UTILITIES_API QString toQString(const UUID& uuid);
 
   /// create a unique name, prefix << " " << UUID.
   UTILITIES_API std::string createUniqueName(const std::string& prefix);
@@ -92,9 +86,9 @@ namespace openstudio {
 
     UTILITIES_API friend UUID openstudio::createUUID();
     UTILITIES_API friend UUID openstudio::toUUID(const std::string& str);
-    UTILITIES_API friend UUID openstudio::toUUID(const QString& str);
+    //UTILITIES_API friend UUID openstudio::toUUID(const QString& str);
     UTILITIES_API friend std::string openstudio::toString(const UUID& uuid);
-    UTILITIES_API friend QString openstudio::toQString(const UUID& uuid);
+    //UTILITIES_API friend QString openstudio::toQString(const UUID& uuid);
     UTILITIES_API friend std::string openstudio::createUniqueName(const std::string& prefix);
     UTILITIES_API friend std::string openstudio::removeBraces(const UUID& uuid);
     UTILITIES_API friend bool openstudio::operator!= (const UUID & lhs, const UUID & rhs);

--- a/openstudiocore/src/utilities/core/test/Path_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/Path_GTest.cpp
@@ -42,7 +42,6 @@
 using openstudio::path;
 using openstudio::toPath;
 using openstudio::toString;
-using openstudio::toQString;
 using openstudio::completePathToFile;
 using openstudio::setFileExtension;
 using openstudio::makeParentFolder;
@@ -378,33 +377,16 @@ TEST_F(CoreFixture, Path_Conversions)
   w = std::wstring(L"basic_path");
   p = path(s);
   EXPECT_EQ(s, p.string());
-  EXPECT_EQ(s, toQString(p).toStdString());
   EXPECT_EQ(s, toString(p));
-  EXPECT_EQ(s, toQString(toString(p)).toStdString());
-  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
   EXPECT_EQ(w, p.wstring());
-  EXPECT_EQ(w, toQString(p).toStdWString());
-  //EXPECT_EQ(w, toString(p));
-  EXPECT_EQ(w, toQString(toString(p)).toStdWString());
-  //EXPECT_EQ(w, std::wstring(toQString(toString(p)).toUtf16()));
-  EXPECT_EQ(w, toPath(toQString(toString(p))).wstring());
 
   p = path(w);
   EXPECT_EQ(s, p.string());
-  EXPECT_EQ(s, toQString(p).toStdString());
   EXPECT_EQ(s, toString(p));
-  EXPECT_EQ(s, toQString(toString(p)).toStdString());
-  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
 
   p = path(w);
   EXPECT_EQ(s, p.string());
-  EXPECT_EQ(s, toQString(p).toStdString());
   EXPECT_EQ(s, toString(p));
-  EXPECT_EQ(s, toQString(toString(p)).toStdString());
-  EXPECT_EQ(s, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(s, toPath(toQString(toString(p))).string());
 
   // http://utf8everywhere.org/
 
@@ -421,34 +403,18 @@ TEST_F(CoreFixture, Path_Conversions)
   const char kSpanishSampleText[] = {99, 97, -61, -79, -61, -77, 110, 0};
 
   std::string t;
-  QString q;
 
   t = std::string(kChineseSampleText);
-  q = QString::fromUtf8(t.c_str());
   p = toPath(t);
-  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
   EXPECT_EQ(t, toString(p));
-  EXPECT_EQ(t, toString(toQString(toString(p))));
-  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
 
   t = std::string(kArabicSampleText);
-  q = QString::fromUtf8(t.c_str());
   p = toPath(t);
-  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
   EXPECT_EQ(t, toString(p));
-  EXPECT_EQ(t, toString(toQString(toString(p))));
-  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
 
   t = std::string(kSpanishSampleText);
-  q = QString::fromUtf8(t.c_str());
   p = toPath(t);
-  EXPECT_EQ(t, std::string(toQString(p).toUtf8()));
   EXPECT_EQ(t, toString(p));
-  EXPECT_EQ(t, toString(toQString(toString(p))));
-  EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
-  EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
 
 }
 

--- a/openstudiocore/src/utilities/core/test/String_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/String_GTest.cpp
@@ -56,22 +56,15 @@ TEST(String, SimpleConversions)
   const char* const cStr = "Hello world";
   const wchar_t* const wStr = L"Hello world";
   std::wstring w(L"Hello world");
-  QString q("Hello world");
   path p = toPath("Hello world");
 
   EXPECT_EQ(s, s);
   EXPECT_EQ(s, cStr);
   EXPECT_EQ(s, toString(w));
   EXPECT_EQ(s, toString(wStr));
-  EXPECT_EQ(s, toString(q));
   EXPECT_EQ(s, toString(p));
-  EXPECT_EQ(s, toString(toQString(s)));
   EXPECT_EQ(s, toString(toPath(s)));
-  EXPECT_EQ(s, toString(toQString(toPath(s))));
-  EXPECT_TRUE(q == toQString(s));
-  EXPECT_TRUE(q == toQString(p));
   EXPECT_TRUE(p == toPath(s));
-  EXPECT_TRUE(p == toPath(q));
 }
 
 //TEST(String, UnicodeConversions)


### PR DESCRIPTION
## Remove More QString

This removes QString from utilities/core, which includes String.* and Path.* files.

It would potentially have lots of impact on the parts of OpenStudio that is using QDomDocument, so highly localized helper functions were added to prevent too much merge conflict impact for those working on it.
