### PR TITLE
Update URL/Path to not include 'file://'

### DIFF
--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -125,7 +125,8 @@ VersionTranslator::VersionTranslator()
   m_updateMethods[VersionString("2.6.2")] = &VersionTranslator::update_2_6_1_to_2_6_2;
   m_updateMethods[VersionString("2.7.0")] = &VersionTranslator::update_2_6_2_to_2_7_0;
   m_updateMethods[VersionString("2.7.1")] = &VersionTranslator::update_2_7_0_to_2_7_1;
-  m_updateMethods[VersionString("2.7.2")] = &VersionTranslator::defaultUpdate;
+  m_updateMethods[VersionString("2.7.2")] = &VersionTranslator::update_2_7_1_to_2_7_2;
+  //m_updateMethods[VersionString("2.7.3")] = &VersionTranslator::defaultUpdate;
 
   // List of previous versions that may be updated to this one.
   //   - To increment the translator, add an entry for the version just released (branched for

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -227,6 +227,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_6_1_to_2_6_2(const IdfFile& idf_2_6_1, const IddFileAndFactoryWrapper& idd_2_6_2);
   std::string update_2_6_2_to_2_7_0(const IdfFile& idf_2_6_2, const IddFileAndFactoryWrapper& idd_2_7_0);
   std::string update_2_7_0_to_2_7_1(const IdfFile& idf_2_7_0, const IddFileAndFactoryWrapper& idd_2_7_1);
+  std::string update_2_7_1_to_2_7_2(const IdfFile& idf_2_7_1, const IddFileAndFactoryWrapper& idd_2_7_2);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -519,22 +519,19 @@ namespace detail{
         return canonicalOrAbsolute(p);
       }
     }
+
+    // Extra check: if it starts with file://
+    std::string fileName = toString(file);
+    if (fileName.rfind("file://", 0) == 0) {
+      // We strip it, and try again
+      return findFile(toPath(fileName.substr(7)));
+    }
     return boost::none;
   }
 
   boost::optional<openstudio::path> WorkflowJSON_Impl::findFile(const std::string& fileName) const
   {
-    boost::optional<openstudio::path> result;
-
-    // if it starts with file://
-    if (fileName.rfind("file://", 0) == 0) {
-      // We strip it
-      result = findFile(toPath(fileName.substr(7)));
-    } else {
-      result = findFile(toPath(fileName));
-    }
-
-    return result;
+    return findFile(toPath(fileName));
   }
 
   std::vector<openstudio::path> WorkflowJSON_Impl::measurePaths() const

--- a/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowJSON.cpp
@@ -524,7 +524,17 @@ namespace detail{
 
   boost::optional<openstudio::path> WorkflowJSON_Impl::findFile(const std::string& fileName) const
   {
-    return findFile(toPath(fileName));
+    boost::optional<openstudio::path> result;
+
+    // if it starts with file://
+    if (fileName.rfind("file://", 0) == 0) {
+      // We strip it
+      result = findFile(toPath(fileName.substr(7)));
+    } else {
+      result = findFile(toPath(fileName));
+    }
+
+    return result;
   }
 
   std::vector<openstudio::path> WorkflowJSON_Impl::measurePaths() const


### PR DESCRIPTION
Update URL/Path fields to not include the `file://` prefix which is something related to QUrl and that's causing potential problems expetially in `WorkflowJSON::findFile` to find the epw file via `OS:WeatherFile` for eg.

Changelog:

* Added VersionTranslation 271 to 272 to remove `file://` in the OSM url fields (there are 3 of them, though the WeatherFile one is the only that's actually used)
* 6dea9dd + 27933f4 : Added an extra check in `WorkflowJSON::findFile(path&)`: if it fails to do it, check if path starts with `file://`, remove that portion, and try again. This is optional, but in some nrel_published measure such as ChangeBuildingLocation, WeatherFile url is actually set directly using `setString(10, 'file://#{filename})` so if the user is using an older version of the measure they could get into trouble.

Related PRs: https://github.com/NREL/OpenStudio-measures/pull/203 and https://github.com/NREL/OpenStudio-workflow-gem/pull/85