### PR TITLE
Fix OS App Issues with develop3

### DIFF
--- a/openstudiocore/src/model/FileOperations.hpp
+++ b/openstudiocore/src/model/FileOperations.hpp
@@ -45,13 +45,13 @@ namespace model {
 
   class Model;
 
-  // Recursively remove dirName.
+  // Recursively remove directory at path.
   // Returns true on success and false if there is an error.
-  //MODEL_API bool removeDir(const QString & dirName);
+  //MODEL_API bool removeDir(const openstudio::path &path);
 
-  // Recursively copies srcPath to dstPath;
-  // If dstPath already exists it will be removed.
-  //MODEL_API bool copyDir(const QString &srcPath, const QString &dstPath);
+  // Recursively copies sourceDir to destinationDir;
+  // If destinationDir - typically that's the Companion Folder - already exists it will be removed and recreated.
+  //MODEL_API bool replaceDir(const openstudio::path &sourceDir, const openstudio::path &destinationDir)
 
   /// Create a temporary directory for an openstudio model
   /// This is where changes to the files, etc are staged
@@ -69,7 +69,7 @@ namespace model {
   /// Returns true if existing WorkflowJSON was found.  If no existing WorkflowJSON is found, a new one is created in the temp dir.
   //MODEL_API bool attachWorkflow(openstudio::model::Model& model, const openstudio::path& modelTempDir);
 
-  /// Initialize a temporary directory for a given model, if savedPath is passed in then existing companion directories are copied to
+  /// Initialize a temporary directory for a given model, if savedPath is passed in then any existing companion directories are copied to
   /// the temporary directory.  Returns path to the temporary directory.
   /// This method combines calls to createModelTempDir, initializeModelTempDir, updateModelTempDir, and attachWorkflow.
   MODEL_API openstudio::path initializeModel(openstudio::model::Model model);

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -144,6 +144,10 @@ OpenStudioApp::OpenStudioApp( int & argc, char ** argv)
   QCoreApplication::setOrganizationDomain("nrel.gov");
   setApplicationName("OpenStudioApp");
 
+  // Don't use native menu bar, necessary on Ubuntu 16.04
+  // TODO: check for adverse side effects on other OSes
+  QCoreApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, true);
+
   readSettings();
 
   QFile f(":/library/OpenStudioPolicy.xml");

--- a/openstudiocore/src/openstudio_lib/GeometryEditorView.cpp
+++ b/openstudiocore/src/openstudio_lib/GeometryEditorView.cpp
@@ -1083,9 +1083,10 @@ EditorWebView::EditorWebView(bool isIP, const openstudio::model::Model& model, Q
   connect(m_page, &OSWebEnginePage::renderProcessTerminated, this, &EditorWebView::onRenderProcessTerminated);
 
   // Qt 5.8 and higher
-  //m_view->setAttribute(QWebEngineSettings::WebAttribute::AllowRunningInsecureContent, true);
+  m_view->settings()->setAttribute(QWebEngineSettings::AllowRunningInsecureContent, true);
+  // Force QWebEngineView to fill the rest of the space
+  m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-  //m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   m_view->setContextMenuPolicy(Qt::NoContextMenu);
 
   //mainLayout->addWidget(m_view, 10, Qt::AlignTop);

--- a/openstudiocore/src/openstudio_lib/GeometryPreviewView.cpp
+++ b/openstudiocore/src/openstudio_lib/GeometryPreviewView.cpp
@@ -59,7 +59,7 @@ GeometryPreviewView::GeometryPreviewView(bool isIP,
                                          QWidget * parent)
 : QWidget(parent)
 {
-  // TODO: DLM impliment units switching
+  // TODO: DLM implement units switching
   //connect(this, &GeometryPreviewView::toggleUnitsClicked, modelObjectInspectorView(), &ModelObjectInspectorView::toggleUnitsClicked);
 
   QVBoxLayout *layout = new QVBoxLayout;
@@ -125,9 +125,9 @@ PreviewWebView::PreviewWebView(bool isIP, const model::Model& model, QWidget *t_
   connect(m_view, &QWebEngineView::renderProcessTerminated, this, &PreviewWebView::onRenderProcessTerminated);
 
   // Qt 5.8 and higher
-  //m_view->setAttribute(QWebEngineSettings::WebAttribute::AllowRunningInsecureContent, true);
-
-  //m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  m_view->settings()->setAttribute(QWebEngineSettings::AllowRunningInsecureContent, true);
+  // Force QWebEngineView to fill the rest of the space
+  m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   m_view->setContextMenuPolicy(Qt::NoContextMenu);
 
   //mainLayout->addWidget(m_view, 10, Qt::AlignTop);

--- a/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
+++ b/openstudiocore/src/openstudio_lib/ResultsTabView.cpp
@@ -91,8 +91,8 @@ ResultsView::ResultsView(QWidget *t_parent)
 
   connect(m_openDViewBtn, &QPushButton::clicked, this, &ResultsView::openDViewClicked);
 
+  // Prepare the top portion inside a QHBoxLayout
   auto hLayout = new QHBoxLayout(this);
-  mainLayout->addLayout(hLayout);
 
   m_reportLabel = new QLabel("Reports: ",this);
   m_reportLabel->setObjectName("H2");
@@ -116,6 +116,11 @@ ResultsView::ResultsView(QWidget *t_parent)
 
   hLayout->addWidget(m_openDViewBtn, 0, Qt::AlignVCenter);
 
+  // Add the Top portion to the main layout
+  mainLayout->addLayout(hLayout);
+  // mainLayout->addStretch(0);
+
+  // create a web widget
   m_view = new QWebEngineView(this);
   m_view->settings()->setAttribute(QWebEngineSettings::WebAttribute::LocalContentCanAccessRemoteUrls, true);
   m_view->settings()->setAttribute(QWebEngineSettings::WebAttribute::SpatialNavigationEnabled, true);
@@ -126,9 +131,10 @@ ResultsView::ResultsView(QWidget *t_parent)
   connect(m_view, &QWebEngineView::renderProcessTerminated, this, &ResultsView::onRenderProcessTerminated);
 
   // Qt 5.8 and higher
-  //m_view->setAttribute(QWebEngineSettings::WebAttribute::AllowRunningInsecureContent, true);
+  m_view->settings()->setAttribute(QWebEngineSettings::AllowRunningInsecureContent, true);
+  // Force QWebEngineView to fill the rest of the space
+  m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-  //m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   m_view->setContextMenuPolicy(Qt::NoContextMenu);
 
   //mainLayout->addWidget(m_view, 10, Qt::AlignTop);
@@ -227,7 +233,7 @@ void ResultsView::searchForExistingResults(const openstudio::path &t_runDir, con
   std::vector<openstudio::path> reports;
 
   // Check that the directory does exists first
-  if (openstudio::filesystem::is_directory(t_runDir) 
+  if (openstudio::filesystem::is_directory(t_runDir)
     && openstudio::filesystem::exists(t_runDir)) {
     for ( openstudio::filesystem::recursive_directory_iterator end, dir(t_runDir);
           dir != end;

--- a/openstudiocore/src/openstudio_lib/openstudiolib.qss
+++ b/openstudiocore/src/openstudio_lib/openstudiolib.qss
@@ -689,3 +689,8 @@ QComboBox#ScheduleDialog {
     min-width: 215px;
     max-width: 215px;
 }
+
+/* Disable icons in buttons (especially standard buttons like OK/SAVE/etc) */
+QDialogButtonBox {
+    dialogbuttonbox-buttons-have-icons: 0;
+}

--- a/openstudiocore/src/utilities/bcl/BCLXML.cpp
+++ b/openstudiocore/src/utilities/bcl/BCLXML.cpp
@@ -95,8 +95,6 @@ namespace openstudio{
       }
     }
 
-    // added in schema version 3
-    m_error = decodeString(element.child("error").text().as_string());
 
     m_name = decodeString(element.child("name").text().as_string());
 
@@ -106,6 +104,15 @@ namespace openstudio{
 
     if (m_name.empty() || m_uid.empty() || m_versionId.empty()){
       LOG_AND_THROW("'" << toString(xmlPath) << "' is not a correct BCL XML");
+    }
+
+    // added in schema version 3
+    // error is only present if something went wrong, so we check if it exists first
+    // to avoid always initializing m_error to a string (even if empty)
+    // note: decodeString(element.child("error").text().as_string()) would always return a string even if 'error' key didn't exist
+    pugi::xml_node  errorElement = element.child("error");
+    if (errorElement) {
+      m_error = errorElement.text().as_string();
     }
 
     subelement = element.child("version_modified");

--- a/openstudiocore/src/utilities/core/Filesystem.hpp
+++ b/openstudiocore/src/utilities/core/Filesystem.hpp
@@ -82,6 +82,7 @@ namespace filesystem {
   using boost::filesystem::system_complete;
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::read_symlink;
+  using boost::filesystem::weakly_canonical;
 
 
 }

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
@@ -236,6 +236,7 @@ namespace openstudio {
         }
       };
 
+      // TODO: instead of trace, just comment out?
       if (const auto home = build_path("USERPROFILE"); !home.empty()) {
         LOG_FREE(Trace, "FilesystemHelpers", "home_path USERPROFILE: " << toString(home));
         return home;

--- a/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
+++ b/openstudiocore/src/utilities/core/FilesystemHelpers.cpp
@@ -106,7 +106,7 @@ namespace openstudio {
           const auto p = dir_itr->path();
           if (predicate(p)) {
             files.push_back(rebuild_path(advance_itr_copy(p.begin(), num_path_elems), p.end()));
-            LOG_FREE(Debug, "FilesystemHelpers", 
+            LOG_FREE(Debug, "FilesystemHelpers",
                 "directory_elements '" << openstudio::toString(p) << "' -> '" << openstudio::toString(files.back()) << "'");
           }
         }
@@ -237,17 +237,17 @@ namespace openstudio {
       };
 
       if (const auto home = build_path("USERPROFILE"); !home.empty()) {
-        LOG_FREE(Debug, "FilesystemHelpers", "home_path USERPROFILE: " << toString(home));
+        LOG_FREE(Trace, "FilesystemHelpers", "home_path USERPROFILE: " << toString(home));
         return home;
       }
 
       if (const auto home = build_path("HOMEDRIVE", "HOMEPATH"); !home.empty()) {
-        LOG_FREE(Debug, "FilesystemHelpers", "home_path HOMEDRIVE/HOMEPATH: " << toString(home));
+        LOG_FREE(Trace, "FilesystemHelpers", "home_path HOMEDRIVE/HOMEPATH: " << toString(home));
         return home;
       }
 
       if (const auto home = build_path("HOME"); !home.empty()) {
-        LOG_FREE(Debug, "FilesystemHelpers", "home_path HOME: " << toString(home));
+        LOG_FREE(Trace, "FilesystemHelpers", "home_path HOME: " << toString(home));
         return home;
       }
 


### PR DESCRIPTION
**Status: IN PROGRESS** (so that I can track progress)

**Changelog:**

* [x] Menu Bar wasn't working on Ubuntu 16.04 (worked on 18.04 though). Use `QCoreApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, true);` to make it work again:
    * Before:
![Before](https://user-images.githubusercontent.com/5479063/50900451-87662d80-1415-11e9-9a32-793304490d9e.png)
    * After: 
![image](https://user-images.githubusercontent.com/5479063/50900503-ab297380-1415-11e9-9712-081d6e7ee615.png)

* [x] Impossible to save a new model, or a model that just has the .osm but no companion folder, OS App crashes. 
    * Problem is that unlike `QDir` equivalent, `boost::filesystem::canonical()` used at [FileOperations.cpp#L92](https://github.com/NREL/OpenStudio/blob/df94a2183ddde851fad7e43f2dc0ef219d97e16a/openstudiocore/src/model/FileOperations.cpp#L92) actually imposes that the path exists, when the destination directory (=companion folder) could actually not exist until created. 
    * Replace this with `boost::filesystem::weakly_canonical()`

* [x] Top portion of WebEngine tabs (Geometry & Result tabs) had a lot of blank space, use setPolicy to expanding for these
![image](https://user-images.githubusercontent.com/5479063/50900979-20e20f00-1417-11e9-9028-05103ed594e3.png)
![image](https://user-images.githubusercontent.com/5479063/50902953-b46a0e80-141c-11e9-9477-54e0ff6b374f.png)

* [x] All measures appear with a "broken" icon, though they can be dragged and do work.
![image](https://user-images.githubusercontent.com/5479063/50903153-378b6480-141d-11e9-977a-13f219e37ce4.png)
    * This is due to new parsing of BCXML: whether the `error` key is present or not `m_error` is initialized (to an empty string if the key was missing). Adjsuted to check for presence of key before

* [x] DialogButtons suddenly have icons on Ubuntu (and they are ugly) (tested both 16.04 and 18.04)
![image](https://user-images.githubusercontent.com/5479063/50912206-e20d8280-1431-11e9-845b-6f2ef2198ba2.png)

* [x] Change a Debug message in FilesystemHelper::home_path() to a Trace: left a **TODO** to determine whether we shouldn't completely comment it out (seems it's useful for debugging but not often...) @macumber 