### PR TITLE
Update gitignore to ignore build folders throughout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,21 @@
 .bundle
 test_gems
 test_fails.txt
-/build/
-/build_debug/
-/build-debug/
-/build-meta/
-/build_release/
-/build-release/
-/build_64/
-/build-64/
-/build-relwithdebinfo/
-/build_relwithdebinfo/
-/build_profile/
-/build-profile/
-/core-build/
-/super-build/
+# Ignore build folders, no matter where in the tree they might be
+build/
+build_debug/
+build-debug/
+build-meta/
+build_release/
+build-release/
+build_64/
+build-64/
+build-relwithdebinfo/
+build_relwithdebinfo/
+build_profile/
+build-profile/
+core-build/
+super-build/
 
 *.sublime-workspace
 


### PR DESCRIPTION
I built in `OpenStudio/openstudiocore/build` since it felt more natural, and it's annoying to have thousands of untracked files.
