### PR TITLE
Fix #2798 - Show Uneditable measure name in addition to Display Name

### DIFF
--- a/openstudiocore/CMake/FindEnergyPlus.cmake
+++ b/openstudiocore/CMake/FindEnergyPlus.cmake
@@ -81,7 +81,7 @@ foreach(PATH ${ENERGYPLUS_POSSIBLE_PATHS})
     endif()
 
     # we just need to read the first part of this large file
-    file(READ "${ENERGYPLUS_IDD}" IDD_TEXT LIMIT 1000) 
+    file(READ "${ENERGYPLUS_IDD}" IDD_TEXT LIMIT 1000)
     string(REGEX MATCH "!IDD_BUILD [0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]" BUILD_SHA_LINE "${IDD_TEXT}")
     string(REGEX MATCH "[0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]" BUILD_SHA "${BUILD_SHA_LINE}")
     set(ENERGYPLUS_GE_8_2_0 TRUE)

--- a/openstudiocore/src/openstudio_lib/OSDocument.cpp
+++ b/openstudiocore/src/openstudio_lib/OSDocument.cpp
@@ -1397,7 +1397,8 @@ namespace openstudio {
           //if (!tags.empty()){
           //  srmStep.setTaxonomy(tags[0]);
           //}
-          srmStep.setName(srm->displayName());
+          srmStep.setName(srm->name());
+          srmStep.setDisplayName(srm->displayName());
           srmStep.setDescription(srm->description());
           srmStep.setModelerDescription(srm->modelerDescription());
           steps.push_back(srmStep);

--- a/openstudiocore/src/shared_gui_components/EditController.cpp
+++ b/openstudiocore/src/shared_gui_components/EditController.cpp
@@ -76,9 +76,10 @@ void EditController::setMeasureStepItem(measuretab::MeasureStepItem * measureSte
 
   // Ruby Measure Name
 
-  editRubyMeasureView->nameLineEdit->setText(m_measureStepItem->name());
+  editRubyMeasureView->nameLineEdit->setText(m_measureStepItem->displayName());
+  editRubyMeasureView->nameNonEditableLineEdit->setText(m_measureStepItem->name());
 
-  connect(editRubyMeasureView->nameLineEdit, &QLineEdit::textEdited, m_measureStepItem.data(), &measuretab::MeasureStepItem::setName);
+  connect(editRubyMeasureView->nameLineEdit, &QLineEdit::textEdited, m_measureStepItem.data(), &measuretab::MeasureStepItem::setDisplayName);
 
   // Measure Description
 

--- a/openstudiocore/src/shared_gui_components/EditView.cpp
+++ b/openstudiocore/src/shared_gui_components/EditView.cpp
@@ -67,6 +67,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   m_mainVLayout->setAlignment(Qt::AlignTop);
   scrollWidget->setLayout(m_mainVLayout);
 
+  // Editable Name, maps to 'displayName'
   QLabel * measureOptionTitleLabel = new QLabel("Name");
   measureOptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(measureOptionTitleLabel);
@@ -78,6 +79,17 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   nameLineEdit->setValidator(validator);
   m_mainVLayout->addWidget(nameLineEdit);
 
+  // Non Editable name, maps to 'name'
+  QLabel * measureOptionTitleLabel2 = new QLabel("Original Name");
+  measureOptionTitleLabel2->setObjectName("H2");
+  m_mainVLayout->addWidget(measureOptionTitleLabel2);
+
+  nameNonEditableLineEdit = new QLineEdit();
+  m_mainVLayout->addWidget(nameNonEditableLineEdit);
+  nameNonEditableLineEdit->setStyleSheet("background: #E6E6E6;");
+  nameNonEditableLineEdit->setReadOnly(true);
+
+  // Description
   QLabel * descriptionTitleLabel = new QLabel("Description");
   descriptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(descriptionTitleLabel);
@@ -89,6 +101,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   descriptionTextEdit->setTabChangesFocus(true);
   m_mainVLayout->addWidget(descriptionTextEdit);
 
+  // Modeler Description
   QLabel * modelerDescriptionTitleLabel = new QLabel("Modeler Description");
   modelerDescriptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(modelerDescriptionTitleLabel);
@@ -121,6 +134,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
 
   if(applyMeasureNow){
     nameLineEdit->setReadOnly(true);
+    nameNonEditableLineEdit->setVisible(false);
     descriptionTextEdit->setReadOnly(true);
     nameLineEdit->setDisabled(true);
     descriptionTextEdit->setDisabled(true);

--- a/openstudiocore/src/shared_gui_components/EditView.hpp
+++ b/openstudiocore/src/shared_gui_components/EditView.hpp
@@ -71,6 +71,8 @@ class EditRubyMeasureView : public QWidget
 
   QLineEdit * nameLineEdit;
 
+  QLineEdit * nameNonEditableLineEdit;
+
   QTextEdit * descriptionTextEdit;
 
   QTextEdit * modelerDescriptionTextEdit;

--- a/openstudiocore/src/shared_gui_components/MeasureManager.cpp
+++ b/openstudiocore/src/shared_gui_components/MeasureManager.cpp
@@ -683,15 +683,15 @@ boost::optional<measure::OSArgument> MeasureManager::getArgument(const measure::
 //  updateMeasures(t_project, toUpdate);
 //}
 
-std::string MeasureManager::suggestMeasureName(const BCLMeasure &t_measure)
+std::string MeasureManager::suggestMeasureDisplayName(const BCLMeasure &t_measure)
 {
   std::string baseName = t_measure.displayName();
 
   std::set<std::string> allNames;
   WorkflowJSON workflowJSON = m_app->currentModel()->workflowJSON();
   for (const auto& step : workflowJSON.workflowSteps()){
-    if (step.optionalCast<MeasureStep>()){
-      boost::optional<std::string> name = step.cast<MeasureStep>().name();
+    if (step.optionalCast<MeasureStep>()) {
+      boost::optional<std::string> name = step.cast<MeasureStep>().displayName();
       if (name){
         allNames.insert(*name);
       }

--- a/openstudiocore/src/shared_gui_components/MeasureManager.hpp
+++ b/openstudiocore/src/shared_gui_components/MeasureManager.hpp
@@ -143,7 +143,8 @@ class MeasureManager : public QObject
     //// Will throw if arguments cannot be computed.
     std::vector<measure::OSArgument> getArguments(const BCLMeasure &t_measure);
 
-    std::string suggestMeasureName(const BCLMeasure &t_measure);
+    // Suggest a Measure Display Name by looking at existing names, and adding an integer counter as needed
+    std::string suggestMeasureDisplayName(const BCLMeasure &t_measure);
 
     bool isMeasureSelected();
 

--- a/openstudiocore/src/shared_gui_components/WorkflowController.hpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.hpp
@@ -196,7 +196,7 @@ class MeasureStepItem : public OSListItem
 
   QString name() const;
 
-  //QString displayName() const;
+  QString displayName() const;
 
   MeasureType measureType() const;
 
@@ -227,7 +227,7 @@ class MeasureStepItem : public OSListItem
 
   void setName(const QString & name);
 
-  //void setDisplayName(const QString & displayName);
+  void setDisplayName(const QString & displayName);
 
   void setDescription(const QString & description);
 
@@ -239,7 +239,7 @@ class MeasureStepItem : public OSListItem
 
   void nameChanged(const QString & name);
 
-  //void displayNameChanged(const QString & displayName);
+  void displayNameChanged(const QString & displayName);
 
   void descriptionChanged();
 

--- a/openstudiocore/src/utilities/filetypes/WorkflowStep.cpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowStep.cpp
@@ -125,6 +125,10 @@ namespace detail{
       result["name"] = m_name.get();
     }
 
+    if (m_displayName){
+      result["display_name"] = m_displayName.get();
+    }
+
     if (m_description){
       result["description"] = m_description.get();
     }
@@ -192,6 +196,24 @@ namespace detail{
   void MeasureStep_Impl::resetName()
   {
     m_name.reset();
+    onUpdate();
+  }
+
+  boost::optional<std::string> MeasureStep_Impl::displayName() const
+  {
+    return m_displayName;
+  }
+
+  bool MeasureStep_Impl::setDisplayName(const std::string& displayName)
+  {
+    m_displayName = displayName;
+    onUpdate();
+    return true;
+  }
+
+  void MeasureStep_Impl::resetDisplayName()
+  {
+    m_displayName.reset();
     onUpdate();
   }
 
@@ -311,9 +333,18 @@ boost::optional<WorkflowStep> WorkflowStep::fromString(const std::string& s)
     MeasureStep measureStep(measureDirName.asString());
     result = measureStep;
 
+    std::string name;
     if (value.isMember("name")){
-      Json::Value name = value["name"];
-      measureStep.setName(name.asString());
+      Json::Value _name = value["name"];
+      name = _name.asString();
+      measureStep.setName(name);
+    }
+
+    if (value.isMember("display_name")){
+      Json::Value displayName = value["display_name"];
+      measureStep.setDisplayName(displayName.asString());
+    } else {
+      // TODO: Default to non editable name?
     }
 
     if (value.isMember("description")){
@@ -415,6 +446,21 @@ bool MeasureStep::setName(const std::string& name)
 void MeasureStep::resetName()
 {
   getImpl<detail::MeasureStep_Impl>()->resetName();
+}
+
+boost::optional<std::string> MeasureStep::displayName() const
+{
+  return getImpl<detail::MeasureStep_Impl>()->displayName();
+}
+
+bool MeasureStep::setDisplayName(const std::string& displayName)
+{
+  return getImpl<detail::MeasureStep_Impl>()->setDisplayName(displayName);
+}
+
+void MeasureStep::resetDisplayName()
+{
+  getImpl<detail::MeasureStep_Impl>()->resetDisplayName();
 }
 
 boost::optional<std::string> MeasureStep::description() const

--- a/openstudiocore/src/utilities/filetypes/WorkflowStep.hpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowStep.hpp
@@ -127,9 +127,15 @@ public:
 
   std::string measureDirName() const;
 
+  // This is the uneditable name
   boost::optional<std::string> name() const;
   bool setName(const std::string& name);
   void resetName();
+
+  // This is the display, editable, name
+  boost::optional<std::string> displayName() const;
+  bool setDisplayName(const std::string& displayName);
+  void resetDisplayName();
 
   boost::optional<std::string> description() const;
   bool setDescription(const std::string& description);

--- a/openstudiocore/src/utilities/filetypes/WorkflowStep_Impl.hpp
+++ b/openstudiocore/src/utilities/filetypes/WorkflowStep_Impl.hpp
@@ -89,9 +89,15 @@ namespace detail {
     std::string measureDirName() const;
     bool setMeasureDirName(const std::string& measureDirName);
 
+    // This is the uneditable name
     boost::optional<std::string> name() const;
     bool setName(const std::string& name);
     void resetName();
+
+    // This is the display, editable, name
+    boost::optional<std::string> displayName() const;
+    bool setDisplayName(const std::string& displayName);
+    void resetDisplayName();
 
     boost::optional<std::string> description() const;
     bool setDescription(const std::string& description);
@@ -120,7 +126,10 @@ namespace detail {
     REGISTER_LOGGER("openstudio.MeasureStep");
 
     std::string m_measureDirName;
+    // This is the uneditable measure name
     boost::optional<std::string> m_name;
+    // This is the editable one
+    boost::optional<std::string> m_displayName;
     boost::optional<std::string> m_description;
     boost::optional<std::string> m_modelerDescription;
     std::map<std::string, Variant> m_arguments;


### PR DESCRIPTION
Fix #2798 - Show Uneditable measure name in addition to Display Name

Upon dragging a new measure:

* `name` goes to "Original Name" and cannot be modified
* `display_name` will serve as default for the (Editable) 'Name' in the Edit Pane (if same display name is found, then add an integer counter to display name). Whatever is set there will be shown in the Measure List in the main pane, and will be saved in workflow.osw as well.

![rationale](https://user-images.githubusercontent.com/5479063/53742027-fdc46080-3e97-11e9-8482-574412d8dd76.png)

