### PR TITLE
Fix #974 - Add 'Adiabatic Surface Construction' to DefaultConstructionSet

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -2025,7 +2025,7 @@ OS:BuildingUnit,
        \default Residential
 
 OS:DefaultConstructionSet,
-       \min-fields 11
+       \min-fields 12
   A1, \field Handle
        \type handle
        \required-field
@@ -2057,7 +2057,10 @@ OS:DefaultConstructionSet,
   A10, \field Building Shading Construction Name
        \type object-list
        \object-list ConstructionNames
-  A11; \field Site Shading Construction Name
+  A11, \field Site Shading Construction Name
+       \type object-list
+       \object-list ConstructionNames
+  A12; \field Adiabatic Surface Construction Name
        \type object-list
        \object-list ConstructionNames
 

--- a/openstudiocore/src/model/DefaultConstructionSet.cpp
+++ b/openstudiocore/src/model/DefaultConstructionSet.cpp
@@ -250,6 +250,10 @@ namespace detail {
         defaultSurfaceConstructions = this->defaultGroundContactSurfaceConstructions();
       }else if (istringEqual("Surface", outsideBoundaryCondition)){
         defaultSurfaceConstructions = this->defaultInteriorSurfaceConstructions();
+      } else if (istringEqual("Adiabatic", outsideBoundaryCondition)) {
+        // Adiabatic is special - doesn't has multiple choices by orientation - so return directly
+        result = this->adiabaticSurfaceConstruction();
+        return result;
       }else{
        //Adiabatic
        //GroundFCfactorMethod
@@ -696,6 +700,48 @@ namespace detail {
     return true;
   }
 
+
+  // Adiabatic Surface Construction Methods
+  boost::optional<ConstructionBase> DefaultConstructionSet_Impl::adiabaticSurfaceConstruction() const
+  {
+    return getObject<ModelObject>().getModelObjectTarget<ConstructionBase>(OS_DefaultConstructionSetFields::AdiabaticSurfaceConstructionName);
+  }
+
+  bool DefaultConstructionSet_Impl::setAdiabaticSurfaceConstruction(const ConstructionBase& construction)
+  {
+    return setPointer(OS_DefaultConstructionSetFields::AdiabaticSurfaceConstructionName, construction.handle());
+  }
+
+  void DefaultConstructionSet_Impl::resetAdiabaticSurfaceConstruction()
+  {
+    setString(OS_DefaultConstructionSetFields::AdiabaticSurfaceConstructionName, "");
+  }
+
+  boost::optional<ModelObject> DefaultConstructionSet_Impl::adiabaticSurfaceConstructionAsModelObject() const {
+    OptionalModelObject result;
+    OptionalConstructionBase intermediate = adiabaticSurfaceConstruction();
+    if (intermediate) {
+      result = *intermediate;
+    }
+    return result;
+  }
+
+  bool DefaultConstructionSet_Impl::setAdiabaticSurfaceConstructionAsModelObject(const boost::optional<ModelObject>& modelObject) {
+    if (modelObject) {
+      OptionalConstructionBase intermediate = modelObject->optionalCast<ConstructionBase>();
+      if (intermediate) {
+        return setAdiabaticSurfaceConstruction(*intermediate);
+      }
+      else {
+        return false;
+      }
+    }
+    else {
+      resetAdiabaticSurfaceConstruction();
+    }
+    return true;
+  }
+
 } // detail
 
 DefaultConstructionSet::DefaultConstructionSet(const Model& model)
@@ -823,6 +869,18 @@ boost::optional<ConstructionBase> DefaultConstructionSet::getDefaultConstruction
 
 void DefaultConstructionSet::merge(const DefaultConstructionSet& other){
   getImpl<detail::DefaultConstructionSet_Impl>()->merge(other);
+}
+
+boost::optional<ConstructionBase> DefaultConstructionSet::adiabaticSurfaceConstruction() const{
+  return getImpl<detail::DefaultConstructionSet_Impl>()->adiabaticSurfaceConstruction();
+}
+
+bool DefaultConstructionSet::setAdiabaticSurfaceConstruction(const ConstructionBase& construction){
+ return getImpl<detail::DefaultConstructionSet_Impl>()->setAdiabaticSurfaceConstruction(construction);
+}
+
+void DefaultConstructionSet::resetAdiabaticSurfaceConstruction(){
+  getImpl<detail::DefaultConstructionSet_Impl>()->resetAdiabaticSurfaceConstruction();
 }
 
 /// @cond

--- a/openstudiocore/src/model/DefaultConstructionSet.cpp
+++ b/openstudiocore/src/model/DefaultConstructionSet.cpp
@@ -255,7 +255,6 @@ namespace detail {
         result = this->adiabaticSurfaceConstruction();
         return result;
       }else{
-       //Adiabatic
        //GroundFCfactorMethod
        //OtherSideCoefficients
        //OtherSideConditionsModel

--- a/openstudiocore/src/model/DefaultConstructionSet.hpp
+++ b/openstudiocore/src/model/DefaultConstructionSet.hpp
@@ -85,6 +85,8 @@ class MODEL_API DefaultConstructionSet : public ResourceObject {
 
   boost::optional<ConstructionBase> siteShadingConstruction() const;
 
+  boost::optional<ConstructionBase> adiabaticSurfaceConstruction() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -124,6 +126,10 @@ class MODEL_API DefaultConstructionSet : public ResourceObject {
   bool setSiteShadingConstruction(const ConstructionBase& construction);
 
   void resetSiteShadingConstruction();
+
+  bool setAdiabaticSurfaceConstruction(const ConstructionBase& construction);
+
+  void resetAdiabaticSurfaceConstruction();
 
   //@}
 

--- a/openstudiocore/src/model/DefaultConstructionSet_Impl.hpp
+++ b/openstudiocore/src/model/DefaultConstructionSet_Impl.hpp
@@ -47,16 +47,6 @@ namespace detail {
   /** DefaultConstructionSet_Impl is a ResourceObject_Impl that is the implementation class for DefaultConstructionSet.*/
   class MODEL_API DefaultConstructionSet_Impl : public ResourceObject_Impl {
 
-
-
-
-
-
-
-
-
-
-
    public:
     /** @name Constructors and Destructors */
     //@{
@@ -100,6 +90,8 @@ namespace detail {
 
     boost::optional<ConstructionBase> siteShadingConstruction() const;
 
+    boost::optional<ConstructionBase> adiabaticSurfaceConstruction() const;
+
     //@}
     /** @name Setters */
     //@{
@@ -140,6 +132,10 @@ namespace detail {
 
     void resetSiteShadingConstruction();
 
+    bool setAdiabaticSurfaceConstruction(const ConstructionBase& construction);
+
+    void resetAdiabaticSurfaceConstruction();
+
     //@}
 
     /// Returns the default construction for this planar surface if available.
@@ -161,6 +157,7 @@ namespace detail {
     boost::optional<ModelObject> spaceShadingConstructionAsModelObject() const;
     boost::optional<ModelObject> buildingShadingConstructionAsModelObject() const;
     boost::optional<ModelObject> siteShadingConstructionAsModelObject() const;
+    boost::optional<ModelObject> adiabaticSurfaceConstructionAsModelObject() const;
 
     bool setDefaultExteriorSurfaceConstructionsAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setDefaultInteriorSurfaceConstructionsAsModelObject(const boost::optional<ModelObject>& modelObject);
@@ -171,6 +168,7 @@ namespace detail {
     bool setSpaceShadingConstructionAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setBuildingShadingConstructionAsModelObject(const boost::optional<ModelObject>& modelObject);
     bool setSiteShadingConstructionAsModelObject(const boost::optional<ModelObject>& modelObject);
+    bool setAdiabaticSurfaceConstructionAsModelObject(const boost::optional<ModelObject>& modelObject);
 
   };
 

--- a/openstudiocore/src/model/Surface.cpp
+++ b/openstudiocore/src/model/Surface.cpp
@@ -473,9 +473,18 @@ namespace detail {
 
         if (istringEqual("Adiabatic", outsideBoundaryCondition)){
           // remove all subsurfaces
+          int n_subsurfaces = 0;
           for (auto subSurface : subSurfaces()){
             subSurface.remove();
+            ++n_subsurfaces;
           }
+          if (n_subsurfaces > 0) {
+            // Note JM 2019-03-05: Warn user, it's not obvious that this is happening and they might try to access again
+            // one of these subsurfaces which are now disconnected objects
+            LOG(Warn, "When setting the Outside Boundary Condition for Surface '" << this->nameString()
+                   << "' to 'Adiabatic', we removed " << n_subsurfaces << " SubSurfaces.");
+          }
+
         }
       }else if(adjacentSurface){
         // restore the adjacent surface if set boundary condition fails

--- a/openstudiocore/src/model/Surface.cpp
+++ b/openstudiocore/src/model/Surface.cpp
@@ -481,8 +481,8 @@ namespace detail {
           if (n_subsurfaces > 0) {
             // Note JM 2019-03-05: Warn user, it's not obvious that this is happening and they might try to access again
             // one of these subsurfaces which are now disconnected objects
-            LOG(Warn, "When setting the Outside Boundary Condition for Surface '" << this->nameString()
-                   << "' to 'Adiabatic', we removed " << n_subsurfaces << " SubSurfaces.");
+            LOG(Warn, "Setting the Outside Boundary Condition for Surface '" << this->nameString()
+                   << "' to 'Adiabatic', removed " << n_subsurfaces << " SubSurfaces.");
           }
 
         }

--- a/openstudiocore/src/model/test/DefaultConstructionSet_GTest.cpp
+++ b/openstudiocore/src/model/test/DefaultConstructionSet_GTest.cpp
@@ -126,6 +126,13 @@ TEST_F(ModelFixture, DefaultConstructionSet)
   EXPECT_EQ(construction.handle(), defaultConstructionSet.siteShadingConstruction()->handle());
   defaultConstructionSet.resetSiteShadingConstruction();
   EXPECT_FALSE(defaultConstructionSet.siteShadingConstruction());
+
+  EXPECT_FALSE(defaultConstructionSet.adiabaticSurfaceConstruction());
+  EXPECT_TRUE(defaultConstructionSet.setAdiabaticSurfaceConstruction(construction));
+  ASSERT_TRUE(defaultConstructionSet.adiabaticSurfaceConstruction());
+  EXPECT_EQ(construction.handle(), defaultConstructionSet.adiabaticSurfaceConstruction()->handle());
+  defaultConstructionSet.resetAdiabaticSurfaceConstruction();
+  EXPECT_FALSE(defaultConstructionSet.adiabaticSurfaceConstruction());
 }
 
 TEST_F(ModelFixture, DefaultConstructionSet_ExteriorSurfaces)
@@ -475,6 +482,33 @@ TEST_F(ModelFixture, DefaultConstructionSet_ShadingSurface)
   ASSERT_TRUE(defaultConstructionSet.getDefaultConstruction(surface));
   EXPECT_EQ(construction.handle(), defaultConstructionSet.getDefaultConstruction(surface)->handle());
   defaultConstructionSet.resetSpaceShadingConstruction();
+  EXPECT_FALSE(defaultConstructionSet.getDefaultConstruction(surface));
+}
+
+TEST_F(ModelFixture, DefaultConstructionSet_AdiabaticSurface)
+{
+  Model model;
+
+  Point3dVector points;
+  points.push_back(Point3d(0,1,0));
+  points.push_back(Point3d(0,0,0));
+  points.push_back(Point3d(1,0,0));
+  Space space(model);
+  Surface surface(points, model);
+  surface.setSpace(space);
+  EXPECT_TRUE(surface.setOutsideBoundaryCondition("Adiabatic"));
+
+  DefaultConstructionSet defaultConstructionSet(model);
+  Construction construction(model);
+
+  EXPECT_FALSE(defaultConstructionSet.adiabaticSurfaceConstruction());
+  EXPECT_FALSE(defaultConstructionSet.getDefaultConstruction(surface));
+  EXPECT_TRUE(defaultConstructionSet.setAdiabaticSurfaceConstruction(construction));
+  ASSERT_TRUE(defaultConstructionSet.adiabaticSurfaceConstruction());
+  EXPECT_EQ(construction.handle(), defaultConstructionSet.adiabaticSurfaceConstruction()->handle());
+  ASSERT_TRUE(defaultConstructionSet.getDefaultConstruction(surface));
+  EXPECT_EQ(construction.handle(), defaultConstructionSet.getDefaultConstruction(surface)->handle());
+  defaultConstructionSet.resetAdiabaticSurfaceConstruction();
   EXPECT_FALSE(defaultConstructionSet.getDefaultConstruction(surface));
 }
 

--- a/openstudiocore/src/openstudio_lib/DefaultConstructionSetInspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/DefaultConstructionSetInspectorView.cpp
@@ -949,6 +949,53 @@ void SiteShadingVC::onDrop(const OSItemId& itemId)
   }
 }
 
+
+// AdiabaticSurfaceVC
+
+void AdiabaticSurfaceVC::onChangeRelationship(const model::ModelObject& modelObject, int index, Handle newHandle, Handle oldHandle)
+{
+  if (index == OS_DefaultConstructionSetFields::AdiabaticSurfaceConstructionName){
+    emit itemIds(makeVector());
+  }
+}
+
+std::vector<OSItemId> AdiabaticSurfaceVC::makeVector()
+{
+  std::vector<OSItemId> result;
+  if (m_modelObject){
+    model::DefaultConstructionSet defaultConstructionSet = m_modelObject->cast<model::DefaultConstructionSet>();
+    boost::optional<model::ConstructionBase> constructionBase = defaultConstructionSet.adiabaticSurfaceConstruction();
+    if (constructionBase){
+      result.push_back(modelObjectToItemId(*constructionBase, false));
+    }
+  }
+  return result;
+}
+
+void AdiabaticSurfaceVC::onRemoveItem(OSItem* item)
+{
+  if (m_modelObject){
+    model::DefaultConstructionSet defaultConstructionSet = m_modelObject->cast<model::DefaultConstructionSet>();
+    defaultConstructionSet.resetAdiabaticSurfaceConstruction();
+  }
+}
+
+void AdiabaticSurfaceVC::onReplaceItem(OSItem * currentItem, const OSItemId& replacementItemId)
+{
+  onDrop(replacementItemId);
+}
+
+void AdiabaticSurfaceVC::onDrop(const OSItemId& itemId)
+{
+  if (m_modelObject){
+    model::DefaultConstructionSet defaultConstructionSet = m_modelObject->cast<model::DefaultConstructionSet>();
+    boost::optional<model::ConstructionBase> constructionBase = this->addToModel<model::ConstructionBase>(itemId);
+    if (constructionBase){
+      defaultConstructionSet.setAdiabaticSurfaceConstruction(*constructionBase);
+    }
+  }
+}
+
 DefaultConstructionSetInspectorView::DefaultConstructionSetInspectorView(const model::Model& model,
                                                                          QWidget * parent)
   : ModelObjectInspectorView(model, true, parent),
@@ -978,6 +1025,7 @@ DefaultConstructionSetInspectorView::DefaultConstructionSetInspectorView(const m
   m_spaceShadingDZ(nullptr),
   m_buildingShadingDZ(nullptr),
   m_siteShadingDZ(nullptr),
+  m_adiabaticSurfaceDZ(nullptr),
 
   m_exteriorWallConstructionVC(nullptr),
   m_exteriorFloorConstructionVC(nullptr),
@@ -1003,6 +1051,7 @@ DefaultConstructionSetInspectorView::DefaultConstructionSetInspectorView(const m
   m_spaceShadingVC(nullptr),
   m_buildingShadingVC(nullptr),
   m_siteShadingVC(nullptr),
+  m_adiabaticSurfaceVC(nullptr),
 
   m_vectorControllers(std::vector<ModelObjectVectorController *>()),
   m_dropZones(std::vector<OSDropZone *>())
@@ -1419,7 +1468,18 @@ DefaultConstructionSetInspectorView::DefaultConstructionSetInspectorView(const m
   gridLayout->addWidget(label,row,leftCol);
   gridLayout->addWidget(m_interiorPartitionsDZ,row+1,leftCol);
 
-  OS_ASSERT(m_vectorControllers.size() == 24);
+  label = new QLabel();
+  label->setText("Adiabatic Surfaces");
+  label->setObjectName("H2");
+  //label->setContentsMargins(padding,0,padding,0);
+  m_adiabaticSurfaceVC = new AdiabaticSurfaceVC();
+  m_vectorControllers.push_back(m_adiabaticSurfaceVC);
+  m_adiabaticSurfaceDZ = new OSDropZone(m_adiabaticSurfaceVC);
+  m_dropZones.push_back(m_adiabaticSurfaceDZ);
+  gridLayout->addWidget(label, row, middleCol);
+  gridLayout->addWidget(m_adiabaticSurfaceDZ, row+1, middleCol);
+
+  OS_ASSERT(m_vectorControllers.size() == 25);
 
   configDropZones();
 
@@ -1614,6 +1674,9 @@ void DefaultConstructionSetInspectorView::attach(openstudio::model::DefaultConst
 
   m_siteShadingVC->attach(defaultConstructionSet);
   m_siteShadingVC->reportItems();
+
+  m_adiabaticSurfaceVC->attach(defaultConstructionSet);
+  m_adiabaticSurfaceVC->reportItems();
 
   m_defaultConstructionSet = defaultConstructionSet;
 

--- a/openstudiocore/src/openstudio_lib/DefaultConstructionSetInspectorView.hpp
+++ b/openstudiocore/src/openstudio_lib/DefaultConstructionSetInspectorView.hpp
@@ -266,6 +266,21 @@ protected:
   virtual void onDrop(const OSItemId& itemId) override;
 };
 
+class AdiabaticSurfaceVC : public ModelObjectVectorController
+{
+  Q_OBJECT
+
+public:
+  virtual ~AdiabaticSurfaceVC() {}
+
+protected:
+  virtual void onChangeRelationship(const model::ModelObject& modelObject, int index, Handle newHandle, Handle oldHandle) override;
+  virtual std::vector<OSItemId> makeVector() override;
+  virtual void onRemoveItem(OSItem* item) override;
+  virtual void onReplaceItem(OSItem * currentItem, const OSItemId& replacementItemId) override;
+  virtual void onDrop(const OSItemId& itemId) override;
+};
+
 class DefaultConstructionSetInspectorView : public ModelObjectInspectorView
 {
   Q_OBJECT
@@ -311,6 +326,7 @@ class DefaultConstructionSetInspectorView : public ModelObjectInspectorView
     OSDropZone * m_spaceShadingDZ;
     OSDropZone * m_buildingShadingDZ;
     OSDropZone * m_siteShadingDZ;
+    OSDropZone * m_adiabaticSurfaceDZ;
 
     WallConstructionVC * m_exteriorWallConstructionVC;
     FloorConstructionVC * m_exteriorFloorConstructionVC;
@@ -336,6 +352,7 @@ class DefaultConstructionSetInspectorView : public ModelObjectInspectorView
     SpaceShadingVC * m_spaceShadingVC;
     BuildingShadingVC * m_buildingShadingVC;
     SiteShadingVC * m_siteShadingVC;
+    AdiabaticSurfaceVC * m_adiabaticSurfaceVC;
 
     std::vector<ModelObjectVectorController *> m_vectorControllers;
     std::vector<OSDropZone *> m_dropZones;


### PR DESCRIPTION
Fix #974 - Add 'Adiabatic Surface Construction' to DefaultConstructionSet

**Changelog:**

* `IDDChange`: add the 'Adiabatic Surface Construction' field to the IDD for `OS:DefaultConstructionSet` as last field (takes in a Construction directly)
* Added to Model API (+Gtest), and OS App. Tested that inheritance in gridview works too. Demo in gif

![974_demo](https://user-images.githubusercontent.com/5479063/53800089-3d448880-3f3c-11e9-9833-813f73724570.gif)

* Added regression test in https://github.com/NREL/OpenStudio-resources/pull/67
*  FT didn't need any work since it relies on `Surface::construction`. VT isn't needed because it's added as a last field in IDD (tested too).
* Added a warning in `Surface::setOutsideBoundaryCondition('Adiabatic')` to tell user that this deletes the `SubSurfaces` as it wasn't clear to me and I did end up having a crash when testing.
    * Before:
```ruby
m = OpenStudio::Model::exampleModel
ss = m.getSubSurfaces[0]
s = ss.surface.get
s.setOutsideBoundaryCondition("Adiabatic")
puts ss
[utilities.idf.WorkspaceObject] <2> Attempt to write a disconnected WorkspaceObject out to Idf.
RuntimeError: /home/bldadmin/openstudio/openstudiocore/src/utilities/idf/WorkspaceObject.cpp@827 : Attempt to write a disconnected WorkspaceObject out to Idf.
```
    * Now:
```ruby
s.setOutsideBoundaryCondition("Adiabatic")
[openstudio.model.Surface] <0> When setting the Outside Boundary Condition for Surface 'Surface 10' to 'Adiabatic', we removed 1 SubSurfaces.
```