### PR TITLE
Fix #72 -  Passing non OSM/OSC/IDF files to load shouldn't return an initialized IdfFile/Model

### DIFF
--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -109,11 +109,7 @@ path setFileExtension(const path& p,
 {
   path result(p);
   path wext = toPath(ext);
-  std::string pext = openstudio::filesystem::extension(p);
-  if (!pext.empty()) {
-    // remove '.' from pext
-    pext = std::string(++pext.begin(),pext.end());
-  }
+  std::string pext = getFileExtension(p);
   if (!pext.empty()) {
     if (pext != wext.string()) {
       if (warnOnMismatch) {

--- a/openstudiocore/src/utilities/idf/IdfFile.cpp
+++ b/openstudiocore/src/utilities/idf/IdfFile.cpp
@@ -381,9 +381,21 @@ OptionalIdfFile IdfFile::load(const path& p,
   path wp(p);
 
   if (iddFileType == IddFileType::OpenStudio) {
+
     // can be Model or Component
+    std::string ext = getFileExtension(p);
+    if (! ( openstudio::istringEqual(ext, "osm") ||
+            openstudio::istringEqual(ext, "osc")) ) {
+      LOG_FREE(Warn,"openstudio.setFileExtension","Path p, '" << toString(p)
+                 << "', has an unexpected file extension. Was expecting 'osm' or 'osc'.");
+    }
+
+    // This isn't issuing warnings because we pass false (we have to, since it can be either osm or osc)
+    // hence why we do check above
     wp = completePathToFile(wp,path(),modelFileExtension(),false);
-    if (wp.empty()) { wp = completePathToFile(wp,path(),componentFileExtension(),false); }
+    if (wp.empty()) {
+      wp = completePathToFile(wp,path(),componentFileExtension(),false);
+    }
   }
   else {
     wp = completePathToFile(wp,path(),"idf",true);

--- a/openstudiocore/src/utilities/idf/Test/IdfFile_GTest.cpp
+++ b/openstudiocore/src/utilities/idf/Test/IdfFile_GTest.cpp
@@ -86,11 +86,7 @@ TEST_F(IdfFixture, IdfFile_BasicTests_LoadedFile)
 }
 
 TEST_F(IdfFixture, IdfFile_Header) {
-  std::stringstream ss;
-  OptionalIdfFile oFile = IdfFile::load(ss,IddFileType(IddFileType::EnergyPlus));
-  ss.clear();
-  ASSERT_TRUE(oFile);
-  IdfFile file = *oFile;
+  IdfFile file(IddFileType::EnergyPlus);
   std::string header = "! A one-line header. ";
   file.setHeader(header);
   EXPECT_EQ(header,file.header());
@@ -98,6 +94,7 @@ TEST_F(IdfFixture, IdfFile_Header) {
   header = "Not actually a header, should get ! pre-pended.";
   file.setHeader(header);
   EXPECT_NE(header,file.header());
+  std::stringstream ss;
   ss << "! " << header;
   EXPECT_EQ(ss.str(),file.header());
 


### PR DESCRIPTION
Fix #72 -  Passing non OSM/OSC/IDF files to load shouldn't return an initialized IdfFile/Model

**Changelog:**

* `IdfFile::m_load` returns False unless it can parse at least ONE valid IDF object
* Added a warning when trying to load an `OpenStudio::Model:Model` that doesn"t have `osc` or `osm` extension (just like OpenStudio::IdfFile::load would issue a warning if extension isn't `idf`)

```ruby
_m = OpenStudio::Model::Model::load("CMakeCache.txt")
[openstudio.setFileExtension] <0> Path p, 'CMakeCache.txt', has an unexpected file extension. Was expecting 'osm' or 'osc'.

[utilities.idf.IdfFile] <0> Unrecognizable object type '//Dependencies for the target'. Defaulting to 'Catchall'.
[utilities.idf.IdfFile] <0> Cannot find object type 'Catchall' in Idd. Placing data in Catchall object.

...

[utilities.idf.IdfFile] <0> Unrecognizable object type '__pkg_config_checked__OPENSSL:INTERNAL=1'. Defaulting to 'Catchall'.
[utilities.idf.IdfFile] <0> Cannot find object type 'Catchall' in Idd. Placing data in Catchall object.
[utilities.idf.IdfFile] <1> Could not parse a single valid object in file.


_m.empty?
=> true
```
