### PR TITLE
Fix #3079 - Force unique names to match E+ new convention

### DIFF
--- a/openstudiocore/src/utilities/idd/IddObject.cpp
+++ b/openstudiocore/src/utilities/idd/IddObject.cpp
@@ -307,6 +307,12 @@ namespace detail {
     std::vector<std::string> result;
     if (OptionalUnsigned index = nameFieldIndex()) {
       result = m_fields[*index].properties().references;
+      // To ensure uniqueness of name within a given class, we add a fake reference if need be
+      // https://github.com/NREL/OpenStudio/issues/3079
+      if (result.empty()) {
+        std::string ref = name();
+        result.push_back(ref + "UniqueNames");
+      }
     }
     return result;
   }

--- a/openstudiocore/src/utilities/idd/Test/IddObject_GTest.cpp
+++ b/openstudiocore/src/utilities/idd/Test/IddObject_GTest.cpp
@@ -159,3 +159,28 @@ TEST_F(IddFixture,IddObject_nameField) {
   ASSERT_TRUE(i);
   ASSERT_EQ(0u,i.get());
 }
+
+
+// E+ no longer allows non-unique names, so we need to check that we enforce a strict naming policy
+// To do so, we we attribute a \reference to all objects that aren't part of a reference group
+// cf: https://github.com/NREL/OpenStudio/issues/3079
+TEST_F(IddFixture, IddObject_uniqueNames) {
+
+  std::vector<IddFileType> fts = {
+    IddFileType(IddFileType::OpenStudio),
+    IddFileType(IddFileType::EnergyPlus)
+  };
+
+  for (const auto& ft: fts) {
+    std::vector<IddObject> objects = IddFactory::instance().getObjects(ft);
+    for (const auto& obj: objects) {
+      if (obj.hasNameField()) {
+        std::stringstream ss;
+        for (const auto& s: obj.references()) {
+          ss << s << ",";
+        }
+        EXPECT_GE(obj.references().size(), 1) << "Failed for " << obj.name() << ", it has the following references: " << ss.str();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix #3079 - Force unique names to match E+ new convention

Added unit test to match the ruby code in #3079.

Per conversion with @macumber I have modified `IddObject::references()` method to include a fake reference group when the object has none.