### PR TITLE
Fix #2798 - Show Uneditable measure name in addition to Display Name

### DIFF
--- a/openstudiocore/src/shared_gui_components/EditController.cpp
+++ b/openstudiocore/src/shared_gui_components/EditController.cpp
@@ -75,7 +75,6 @@ void EditController::setMeasureStepItem(measuretab::MeasureStepItem * measureSte
   editView->setView(editRubyMeasureView);
 
   // Ruby Measure Name
-
   editRubyMeasureView->nameLineEdit->setText(m_measureStepItem->name());
   connect(editRubyMeasureView->nameLineEdit, &QLineEdit::textEdited, m_measureStepItem.data(), &measuretab::MeasureStepItem::setName);
 
@@ -83,13 +82,10 @@ void EditController::setMeasureStepItem(measuretab::MeasureStepItem * measureSte
   editRubyMeasureView->nameNonEditableLineEdit->setText(m_measureStepItem->measureDirectory());
 
   // Measure Description
-
   editRubyMeasureView->descriptionTextEdit->setText(m_measureStepItem->description());
-
   connect(editRubyMeasureView->descriptionTextEdit, &QTextEdit::textChanged, this, &EditController::updateDescription);
 
   // Measure Modeler Description
-
   editRubyMeasureView->modelerDescriptionTextEdit->setText(m_measureStepItem->modelerDescription());
 
   // Inputs

--- a/openstudiocore/src/shared_gui_components/EditController.cpp
+++ b/openstudiocore/src/shared_gui_components/EditController.cpp
@@ -77,8 +77,10 @@ void EditController::setMeasureStepItem(measuretab::MeasureStepItem * measureSte
   // Ruby Measure Name
 
   editRubyMeasureView->nameLineEdit->setText(m_measureStepItem->name());
-
   connect(editRubyMeasureView->nameLineEdit, &QLineEdit::textEdited, m_measureStepItem.data(), &measuretab::MeasureStepItem::setName);
+
+  // Measure Directory, uneditable so no connect needed
+  editRubyMeasureView->nameNonEditableLineEdit->setText(m_measureStepItem->measureDirectory());
 
   // Measure Description
 
@@ -128,6 +130,7 @@ void EditController::reset()
   m_measureStepItem = nullptr;
 
   editRubyMeasureView->nameLineEdit->disconnect();
+  // Note: no need to disconnect nameNonEditableLineEdit since it wasn't connected to begin with
 
   editRubyMeasureView->descriptionTextEdit->disconnect();
 }

--- a/openstudiocore/src/shared_gui_components/EditView.cpp
+++ b/openstudiocore/src/shared_gui_components/EditView.cpp
@@ -134,10 +134,12 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
 
   if(applyMeasureNow){
     nameLineEdit->setReadOnly(true);
-    nameNonEditableLineEdit->setVisible(false);
     descriptionTextEdit->setReadOnly(true);
+
     nameLineEdit->setDisabled(true);
     descriptionTextEdit->setDisabled(true);
+    nameNonEditableLineEdit->setDisabled(true);
+    modelerDescriptionTextEdit->setDisabled(true);
   }
 }
 

--- a/openstudiocore/src/shared_gui_components/EditView.cpp
+++ b/openstudiocore/src/shared_gui_components/EditView.cpp
@@ -67,6 +67,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   m_mainVLayout->setAlignment(Qt::AlignTop);
   scrollWidget->setLayout(m_mainVLayout);
 
+  // Editable Name, maps to 'name'
   QLabel * measureOptionTitleLabel = new QLabel("Name");
   measureOptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(measureOptionTitleLabel);
@@ -78,10 +79,21 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   nameLineEdit->setValidator(validator);
   m_mainVLayout->addWidget(nameLineEdit);
 
+  // Non Editable name, maps to 'measure_dir_name'
+  QLabel * measureOptionTitleLabel2 = new QLabel("Measure Directory Name");
+  measureOptionTitleLabel2->setObjectName("H2");
+  m_mainVLayout->addWidget(measureOptionTitleLabel2);
+
+  nameNonEditableLineEdit = new QLineEdit();
+  m_mainVLayout->addWidget(nameNonEditableLineEdit);
+  nameNonEditableLineEdit->setStyleSheet("background: #E6E6E6;");
+  nameNonEditableLineEdit->setReadOnly(true);
+
   QLabel * descriptionTitleLabel = new QLabel("Description");
   descriptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(descriptionTitleLabel);
 
+  // Description
   descriptionTextEdit = new QTextEdit();
   descriptionTextEdit->setFixedHeight(70);
   descriptionTextEdit->setAcceptRichText(false);
@@ -89,6 +101,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
   descriptionTextEdit->setTabChangesFocus(true);
   m_mainVLayout->addWidget(descriptionTextEdit);
 
+  // Modeler Description
   QLabel * modelerDescriptionTitleLabel = new QLabel("Modeler Description");
   modelerDescriptionTitleLabel->setObjectName("H2");
   m_mainVLayout->addWidget(modelerDescriptionTitleLabel);
@@ -121,6 +134,7 @@ EditRubyMeasureView::EditRubyMeasureView(bool applyMeasureNow)
 
   if(applyMeasureNow){
     nameLineEdit->setReadOnly(true);
+    nameNonEditableLineEdit->setVisible(false);
     descriptionTextEdit->setReadOnly(true);
     nameLineEdit->setDisabled(true);
     descriptionTextEdit->setDisabled(true);

--- a/openstudiocore/src/shared_gui_components/EditView.hpp
+++ b/openstudiocore/src/shared_gui_components/EditView.hpp
@@ -69,7 +69,11 @@ class EditRubyMeasureView : public QWidget
   EditRubyMeasureView(bool applyMeasureNow);
   virtual ~EditRubyMeasureView() {}
 
+  // Editable name, maps to OSW 'name'
   QLineEdit * nameLineEdit;
+
+  // Non Editable name, maps to OSW 'measure_dir_name'
+  QLineEdit * nameNonEditableLineEdit;
 
   QTextEdit * descriptionTextEdit;
 

--- a/openstudiocore/src/shared_gui_components/WorkflowController.cpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.cpp
@@ -308,7 +308,6 @@ void MeasureStepController::addItemForDroppedMeasure(QDropEvent *event)
   //  measureStep.setTaxonomy(tags[0]);
   //}
   measureStep.setName(name);
-  //measureStep.setDisplayName(name); // DLM: TODO
   measureStep.setDescription(projectMeasure->description());
   measureStep.setModelerDescription(projectMeasure->modelerDescription());
 
@@ -403,15 +402,17 @@ QString MeasureStepItem::name() const
   return result;
 }
 
-//QString MeasureStepItem::displayName() const
-//{
-//  // DLM: TODO, add display name
-//  QString result;
-//  if (boost::optional<std::string> name = m_step.name()){
-//    return result = QString::fromStdString(*name);
-//  }
-//  return result;
-//}
+QString MeasureStepItem::measureDirectory() const {
+  QString result;
+  // TODO: JM 2019-03-21 Should I ensure that I get just the measure directory NAME and not a path?
+  // Within OS App there's no risk since the measure_dir_name doesn't include "../../" or absolute path
+  // (QFileInfo.fileName)
+  if (boost::optional<std::string> name = m_step.measureDirName()){
+    return result = QString::fromStdString(*name);
+  }
+  return result;
+}
+
 
 MeasureType MeasureStepItem::measureType() const
 {

--- a/openstudiocore/src/shared_gui_components/WorkflowController.hpp
+++ b/openstudiocore/src/shared_gui_components/WorkflowController.hpp
@@ -213,6 +213,9 @@ class MeasureStepItem : public OSListItem
   // arguments includes the full list of arguments calculated for the given model along with any values specified in the OSW
   std::vector<measure::OSArgument> arguments() const;
 
+  // Returns the name of the measure directory in question (not a path, just the last level)
+  QString measureDirectory() const;
+
   bool hasIncompleteArguments() const;
 
   std::vector<measure::OSArgument> incompleteArguments() const;


### PR DESCRIPTION
(Initially tried another approach in #3438, after discussion I am starting from a clean slate)

Fix #2798 - Show Uneditable measure name in addition to Display Name

Upon dragging a new measure:

* New: OSW 'measure_dir_name" goes to "Measure Directory Name" and cannot be modified
* OSW 'name' goes to "Name" as usual


![image](https://user-images.githubusercontent.com/5479063/54770642-f32df900-4c03-11e9-9316-cb94b6a512e5.png)

![image](https://user-images.githubusercontent.com/5479063/54770651-fa550700-4c03-11e9-8c2e-9c68c19eda55.png)


