### PR TITLE
Fix #3487 - Consistent Setpoint Temperature Node for CoilHeatingElectric

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingElectric.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingElectric.cpp
@@ -110,11 +110,13 @@ boost::optional<IdfObject> ForwardTranslator::translateCoilHeatingElectric( Coil
     if( boost::optional<Node> node = mo->optionalCast<Node>() )
     {
       idfObject.setString(Coil_Heating_ElectricFields::AirOutletNodeName,node->name().get());
+      // For now we write the temp setpoint node as the Coil Outlet Node
+      idfObject.setString(Coil_Heating_ElectricFields::TemperatureSetpointNodeName,node->name().get());
     }
   }
 
   // Temperature Setpoint Node Name
-
+  // If it was hardset we actually use that, otherwise keep above default (coil outlet)
   if( boost::optional<Node> node = modelObject.temperatureSetpointNode() )
   {
     idfObject.setString(Coil_Heating_ElectricFields::TemperatureSetpointNodeName,node->name().get());

--- a/openstudiocore/src/model/CoilHeatingElectric.cpp
+++ b/openstudiocore/src/model/CoilHeatingElectric.cpp
@@ -230,24 +230,12 @@ namespace detail {
     {
       if( ! airLoop->demandComponent(node.handle()) )
       {
-        if( StraightComponent_Impl::addToNode( node ) )
-        {
-          if( boost::optional<Node> node = outletModelObject()->optionalCast<Node>() )
-          {
-            setTemperatureSetpointNode(node.get());
-          }
-          return true;
-        }
+        return StraightComponent_Impl::addToNode( node );
       }
     }
 
     if ( auto oa = node.airLoopHVACOutdoorAirSystem() ) {
-      if ( StraightComponent_Impl::addToNode( node ) ) {
-        if ( auto _node = outletModelObject()->optionalCast<Node>() ) {
-          setTemperatureSetpointNode(_node.get());
-        }
-        return true;
-      }
+      return StraightComponent_Impl::addToNode( node );
     }
 
     return false;

--- a/openstudiocore/src/model/CoilHeatingElectric.hpp
+++ b/openstudiocore/src/model/CoilHeatingElectric.hpp
@@ -104,7 +104,7 @@ class MODEL_API CoilHeatingElectric : public StraightComponent {
 
   /** Creates a new equivalent duct object if an object is not already attached. */
   AirflowNetworkEquivalentDuct getAirflowNetworkEquivalentDuct(double length, double diameter);
-  
+
   /** Returns the attached equivalent duct object, if any. */
   boost::optional<AirflowNetworkEquivalentDuct> airflowNetworkEquivalentDuct() const;
 


### PR DESCRIPTION
Fix #3487

* Change the coils addToNode methods to not set the 'Temperature Setpoint Node' field like it does now (it's an optional field)
    
* In the energyplus Forward Translator, if the field is blank at translation time, then set it to the supply outlet node of the coil (where a SPM:MixedAir will be created for you too)

Chose not to show the 'Temperature Setpoint Node' in OS App. I think this is going to be confusing for most users, and if an advanced user wants to set it, she can use the bindings to do so.