### PR TITLE
update cmake path and remove --no-option npm arg

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -1579,7 +1579,7 @@ else()
 endif()
 
 # Install additional Documents, such as release notes
-install(FILES "${CMAKE_SOURCE_DIR}/../doc/ReleaseNotes/OpenStudio_Release_Notes_2_8_0_20181012.pdf" DESTINATION .)
+install(FILES "${CMAKE_SOURCE_DIR}/../developer/doc/ReleaseNotes/OpenStudio_Release_Notes_2_8_0_20181012.pdf" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/../LICENSE.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/../CHANGELOG.md" DESTINATION .)
 install(FILES "${CMAKE_SOURCE_DIR}/../copyright.txt" DESTINATION .)

--- a/openstudiocore/pat/BuildPat.bat.in
+++ b/openstudiocore/pat/BuildPat.bat.in
@@ -4,7 +4,7 @@ setx GYP_MSVS_VERSION 2013
 rmdir "${CMAKE_CURRENT_BINARY_DIR}/OpenStudio-PAT" /S /Q 2>nul
 move "${CMAKE_CURRENT_BINARY_DIR}/OpenStudio-PAT-${PAT_SHA}" "${CMAKE_CURRENT_BINARY_DIR}/OpenStudio-PAT"
 chdir "${CMAKE_CURRENT_BINARY_DIR}/OpenStudio-PAT"
-cmd /C "${NPM_COMMAND}" install --msvs_version=2013 --no-optional
+cmd /C "${NPM_COMMAND}" install --msvs_version=2013
 cmd /C "${NPM_COMMAND}" install bower
 cmd /C "${CMAKE_CURRENT_BINARY_DIR}/OpenStudio-PAT/node_modules/.bin/bower" install
 cmd /C "${NPM_COMMAND}" run release


### PR DESCRIPTION
Updating CMake path for release note docs as these have been moved from /docs to /developer/docs. 
Also updating the args for npm as the --no-optional was creating an error during the Windows 2019 build process. 
