### PR TITLE
Fix #3158: symlink path problems

### DIFF
--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -345,7 +345,7 @@ std::vector<std::string> OpenStudioApp::buildCompLibraries()
   // Get the first Qlabel waitDialog (0 = stretch, 1 = "Loading model", 2 = "This may take a minute...", 3=hidden lable,   = stretch)
   waitDialog()->m_firstLine->setText("Loading Library Files");
   waitDialog()->m_secondLine->setText("(Manage library files in Preferences->Change default libraries)");
- 
+
   // DLM: this was causing a crash because waitDialog is created on the main thread but this is called on the wait thread.
   // Because this is just the wait dialog let's just keep the line always visible.
   // Make it visible
@@ -1390,7 +1390,7 @@ std::vector<openstudio::path> OpenStudioApp::libraryPaths() const {
   QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
 
   openstudio::path resPath = resourcesPath();
-
+  std::cout << "resourcesPath = " << resPath << std::endl;
   int size = settings.beginReadArray("library");
   for (int i = 0; i < size; ++i) {
     settings.setArrayIndex(i);

--- a/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
+++ b/openstudiocore/src/openstudio_app/OpenStudioApp.cpp
@@ -1390,7 +1390,6 @@ std::vector<openstudio::path> OpenStudioApp::libraryPaths() const {
   QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
 
   openstudio::path resPath = resourcesPath();
-  std::cout << "resourcesPath = " << resPath << std::endl;
   int size = settings.beginReadArray("library");
   for (int i = 0; i < size; ++i) {
     settings.setArrayIndex(i);

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       // If can't convert to int (such as when you pass true), use a default
       n_seconds = 60;
     }
-	LOG_FREE(Warn, "OpenStudioApp.main", "Will sleep for " << n_seconds << " seconds now");
+    LOG_FREE(Warn, "OpenStudioApp.main", "Will sleep for " << n_seconds << " seconds now");
     std::this_thread::sleep_for(std::chrono::seconds(n_seconds));
   }
 #else

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -60,6 +60,9 @@
 #define WSAAPI
 #include "../utilities/core/Path.hpp"
 
+#include <thread>
+#include <chrono>
+
 // OS App is linked to the dynamic plugins
 //Q_IMPORT_PLUGIN(QSQLiteDriverPlugin);
 //#if defined(Q_OS_OSX)
@@ -132,6 +135,19 @@ int main(int argc, char *argv[])
 // DLM: set env var 'QT_FATAL_WARNINGS' to error on qt warnings for debugging
 #if _DEBUG || (__GNUC__ && !NDEBUG)
   bool debugging = true;
+
+  // Give you a chance to attach your debugger to the OS App before it dies out.
+  // Sometimes launching the OSApp via your debugger isn't wanted (eg: it resolves the symlink before actually launching the OSApp)
+  if (qEnvironmentVariableIsSet("OPENSTUDIO_APPLICATION_SLEEP_AT_START") && !qEnvironmentVariableIsEmpty("OPENSTUDIO_APPLICATION_SLEEP_AT_START")) {
+    bool ok;
+    int n_seconds = qEnvironmentVariableIntValue("OPENSTUDIO_APPLICATION_SLEEP_AT_START", &ok);
+    if (!ok) {
+      // If can't convert to int (such as when you pass true), use a default
+      n_seconds = 60;
+    }
+    std::cout << "Will sleep for " << n_seconds << " seconds now" << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(n_seconds));
+  }
 #else
   bool debugging = (qEnvironmentVariableIsSet("OPENSTUDIO_APPLICATION_DEBUG") && !qEnvironmentVariableIsEmpty("OPENSTUDIO_APPLICATION_DEBUG"));
 #endif

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       // If can't convert to int (such as when you pass true), use a default
       n_seconds = 60;
     }
-    LOG_FREE(Warn, "Will sleep for " << n_seconds << " seconds now");
+	LOG_FREE(Warn, "OpenStudioApp.main", "Will sleep for " << n_seconds << " seconds now");
     std::this_thread::sleep_for(std::chrono::seconds(n_seconds));
   }
 #else

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
       // If can't convert to int (such as when you pass true), use a default
       n_seconds = 60;
     }
-    std::cout << "Will sleep for " << n_seconds << " seconds now" << std::endl;
+    LOG_FREE(Warn, "Will sleep for " << n_seconds << " seconds now");
     std::this_thread::sleep_for(std::chrono::seconds(n_seconds));
   }
 #else

--- a/openstudiocore/src/openstudio_app/main.cpp
+++ b/openstudiocore/src/openstudio_app/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
   }
 
   // Output content of argc/argv
-  LOG_FREE(Debug, "OpenStudioApp.main", "main received argc=" << argc << "arguments")
+  LOG_FREE(Debug, "OpenStudioApp.main", "main received argc=" << argc << " arguments")
   for (int i=0; i < argc; ++i) {
     LOG_FREE(Debug, "OpenStudioApp.main", "Argument " << i << "=" << argv[i]);
   }

--- a/openstudiocore/src/utilities/core/ApplicationPathHelpers.cxx.in
+++ b/openstudiocore/src/utilities/core/ApplicationPathHelpers.cxx.in
@@ -78,22 +78,34 @@ namespace openstudio {
   }
 
   openstudio::path getApplicationPath() {
-
+    openstudio::path path;
     #if defined _WIN32
       TCHAR szPath[MAX_PATH];
       if( GetModuleFileName( nullptr, szPath, MAX_PATH ) ) {
         LOG_FREE(Debug, "ApplicationPathHelpers", "getApplicationPath, szPath = '" << szPath << "'");
-        return completeAndNormalize(toPath(szPath));
+        path = toPath(szPath);
       }
     #else
       Dl_info info;
       if (dladdr("main", &info)) {
         LOG_FREE(Debug, "ApplicationPathHelpers", "getApplicationPath, info.dli_fname = '" << info.dli_fname << "'");
-        return completeAndNormalize(toPath(info.dli_fname));
+        path = toPath(info.dli_fname);
       }
     #endif
+    // TODO: JM 2019-04-18 Another option is to always start by calling findInSystemPath and modify the findInSystemPath to prepend the PATH list with '.'
+    openstudio::path applicationPath = completeAndNormalize(path);
+    if( !openstudio::filesystem::exists( applicationPath ) || openstudio::filesystem::is_directory( applicationPath ) ) {
+        LOG_FREE(Debug, "ApplicationPathHelpers", "getApplicationPath failed as is, trying in to locate in systemPath");
+        path = findInSystemPath(path);
+        applicationPath = completeAndNormalize(path);
+    }
+    if( !openstudio::filesystem::exists( applicationPath ) || openstudio::filesystem::is_directory( applicationPath ) ) {
+        LOG_FREE_AND_THROW("ApplicationPathHelpers", "getApplicationPath failed!");
+    }
 
-    return openstudio::path();
+    LOG_FREE(Debug, "ApplicationPathHelpers", "getApplicationPath, found '" << applicationPath << "'");
+
+    return applicationPath;
   }
 
   openstudio::path getApplicationDirectory() {
@@ -141,36 +153,32 @@ namespace openstudio {
 
   openstudio::path getOpenStudioModule()
   {
-    openstudio::path openstudioDirPath;
+    openstudio::path path;
     #if defined _WIN32
       TCHAR szPath[MAX_PATH];
       if( GetModuleFileName( GetCurrentModule(), szPath, MAX_PATH ) ) {
         LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule, szPath = '" << szPath << "'");
-        openstudioDirPath = completeAndNormalize(toPath(szPath));
+        path = toPath(szPath);
       }
     #else
       Dl_info info;
       if (dladdr("GetCurrentModule", &info)) {
         LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule, info.dli_fname = '" << info.dli_fname << "'");
-        auto path = toPath(info.dli_fname);
-        if ( path.parent_path().empty() ) {
-          std::istringstream pathstream( getenv("PATH") );
-          std::string pathstring;
-          while ( std::getline(pathstream, pathstring, ':') ) {
-            LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule, searching for '" << path << "' in '" << pathstring << "'");
-            auto maybepath = toPath(pathstring) / path;
-            if( openstudio::filesystem::exists( maybepath ) && !openstudio::filesystem::is_directory( maybepath ) ) {
-              openstudioDirPath = completeAndNormalize(maybepath);
-              break;
-            }
-          }
-        } else {
-            openstudioDirPath = completeAndNormalize(path);
-        }
+        path = toPath(info.dli_fname);
       }
     #endif
-    LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule, found '" << openstudioDirPath << "'");
-    return openstudioDirPath;
+    openstudio::path openstudioPath = completeAndNormalize(path);
+    if( !openstudio::filesystem::exists( openstudioPath ) || openstudio::filesystem::is_directory( openstudioPath ) ) {
+        LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule failed as is, trying in to locate in systemPath");
+        path = findInSystemPath(path);
+        openstudioPath = completeAndNormalize(path);
+    }
+    if( !openstudio::filesystem::exists( openstudioPath ) || openstudio::filesystem::is_directory( openstudioPath ) ) {
+        LOG_FREE_AND_THROW("ApplicationPathHelpers", "getOpenStudioModule failed!");
+    }
+
+    LOG_FREE(Debug, "ApplicationPathHelpers", "getOpenStudioModule, found '" << openstudioPath << "'");
+    return openstudioPath;
   }
 
   openstudio::path getOpenStudioModuleDirectory()

--- a/openstudiocore/src/utilities/core/ApplicationPathHelpers.cxx.in
+++ b/openstudiocore/src/utilities/core/ApplicationPathHelpers.cxx.in
@@ -92,9 +92,24 @@ namespace openstudio {
         path = toPath(info.dli_fname);
       }
     #endif
-    // TODO: JM 2019-04-18 Another option is to always start by calling findInSystemPath and modify the findInSystemPath to prepend the PATH list with '.'
+
+    // Note JM 2019-04-24:
+    // Let's call assume the GetModuleFileName (windows, though that doesn't really happen)
+    // or (more likely) dladdr (Unix) returns just 'OpenStudioApplicationSymlink' (and not '/path/to/OpenStudioApplicationSymlink' or './OpenStudioApplicationSymlink')
+    // You first try to locate that OpenStudioApplicationSymlink in the current directory
+
+    // (Another option would be to always start by calling findInSystemPath and modify the findInSystemPath to prepend the PATH list with '.')
+
     openstudio::path applicationPath = completeAndNormalize(path);
     if( !openstudio::filesystem::exists( applicationPath ) || openstudio::filesystem::is_directory( applicationPath ) ) {
+        // It that didn't work, it means it's in the system PATH. So you have to look for it in your PATH by calling findInSystemPath
+        // There's no way around it IMHO.
+        // Note: This wouldn't be a concern unless you are launching a symlink that lives in your PATH, and outside the directory where the symlink is
+        // * ./OpenStudioApplicationSymlink will work
+        // * /home/OpenStudioApplicationSymlink will work
+        // * OpenStudioApplicationSymlink itself will not work (if you aren't in the same folder as the symlink)
+
+
         LOG_FREE(Debug, "ApplicationPathHelpers", "getApplicationPath failed as is, trying in to locate in systemPath");
         path = findInSystemPath(path);
         applicationPath = completeAndNormalize(path);

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -260,11 +260,11 @@ path completeAndNormalize(const path& p) {
 
     if ( linkpath.is_absolute() ) {
       temp = linkpath;
-      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: Absolute temp = linkpath");
+      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp is an absolute symlink (= linkpath)");
 
     } else {
       temp = temp.parent_path() / linkpath;
-      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: Relative temp = " << temp);
+      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp is a relative symlink, pointing to = " << temp);
 
     }
   }
@@ -275,7 +275,9 @@ path completeAndNormalize(const path& p) {
   }
   path result;
 
-  // TODO: what is this? Looks like it's trying to resolve it manually...
+  // TODO: In develop3, which has boost 1.68, we can replace it with boost::filesystem::weakly_canonical
+  // temp right now is absolute, but it isn't canonical.
+  // This block resolves a canonical path, even if it doesn't exist (yet?) on disk.
   for(openstudio::path::iterator it=temp.begin(); it!=temp.end(); ++it) {
     if (*it == toPath("..")) {
       if (openstudio::filesystem::is_symlink(result) || (result.filename() == toPath(".."))) {

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -202,21 +202,80 @@ path relativePath(const path& p,const path& base) {
   return result;
 }
 
+path findInSystemPath(const path& p) {
+
+#if defined _WIN32
+  const char delimiter = ';';
+#else
+  const char delimiter = ':';
+#endif
+
+  path result;
+  // Ensure that this is just a name and not a path
+  if ( p.parent_path().empty() ) {
+    std::istringstream pathstream( getenv("PATH") );
+    LOG_FREE(Debug, "PathHelpers", "findInSystemPath, searching for '" << p << "' in PATH'");
+
+    std::string pathstring;
+    while ( std::getline(pathstream, pathstring, delimiter) ) {
+      LOG_FREE(Trace, "PathHelpers", "findInSystemPath, searching for '" << p << "' in '" << pathstring << "'");
+
+      auto maybepath = toPath(pathstring) / p;
+      if( openstudio::filesystem::exists( maybepath ) && !openstudio::filesystem::is_directory( maybepath ) ) {
+        LOG_FREE(Debug, "PathHelpers", "findInSystemPath, found '" << p << "' in PATH: '" << pathstring);
+        result = maybepath;
+        break;
+      }
+    }
+    if (result.empty()) {
+      LOG_FREE(Debug, "PathHelpers", "findInSystemPath, p wasn't found in PATH, leaving as is");
+      result = p;
+    }
+
+  } else {
+    LOG_FREE(Debug, "PathHelpers", "findInSystemPath, p isn't just a name, leaving as is");
+    result = p;
+  }
+
+
+  return result;
+
+}
+
 path completeAndNormalize(const path& p) {
+
   path temp = openstudio::filesystem::system_complete(p);
-  if ( openstudio::filesystem::is_symlink(temp) ) {
+
+  LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: looking for p = " << p);
+  LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp = " << temp);
+
+  // TODO: is there a point continuing if temp doesn't exist?
+  if( !openstudio::filesystem::exists( temp )) { // || openstudio::filesystem::is_directory( temp ) ) {
+    LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp doesn't exists");
+  }
+
+  while ( openstudio::filesystem::is_symlink(temp) ) {
     auto linkpath = openstudio::filesystem::read_symlink(temp);
+    LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: It's a symlink, linkpath = " << linkpath);
+
     if ( linkpath.is_absolute() ) {
       temp = linkpath;
+      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: Absolute temp = linkpath");
+
     } else {
       temp = temp.parent_path() / linkpath;
+      LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: Relative temp = " << temp);
+
     }
   }
+  // TODO: can this actually happen?
   if (temp.empty() && !p.empty()) {
+    LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp is empty, reseting to p");
     temp = p;
   }
   path result;
 
+  // TODO: what is this? Looks like it's trying to resolve it manually...
   for(openstudio::path::iterator it=temp.begin(); it!=temp.end(); ++it) {
     if (*it == toPath("..")) {
       if (openstudio::filesystem::is_symlink(result) || (result.filename() == toPath(".."))) {
@@ -230,6 +289,8 @@ path completeAndNormalize(const path& p) {
       result /= *it;
     }
   }
+
+  LOG_FREE(Debug, "PathHelpers", "completeAndNormalize: result = " << result);
 
   return result;
 }

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -202,13 +202,16 @@ path relativePath(const path& p,const path& base) {
   return result;
 }
 
-path findInSystemPath(const path& p) {
+const char pathDelimiter() {
+  #if defined _WIN32
+    const char delimiter = ';';
+  #else
+    const char delimiter = ':';
+  #endif
+  return delimiter;
+}
 
-#if defined _WIN32
-  const char delimiter = ';';
-#else
-  const char delimiter = ':';
-#endif
+path findInSystemPath(const path& p) {
 
   path result;
   // Ensure that this is just a name and not a path
@@ -217,7 +220,7 @@ path findInSystemPath(const path& p) {
     LOG_FREE(Debug, "PathHelpers", "findInSystemPath, searching for '" << p << "' in PATH'");
 
     std::string pathstring;
-    while ( std::getline(pathstream, pathstring, delimiter) ) {
+    while ( std::getline(pathstream, pathstring, pathDelimiter()) ) {
       LOG_FREE(Trace, "PathHelpers", "findInSystemPath, searching for '" << p << "' in '" << pathstring << "'");
 
       auto maybepath = toPath(pathstring) / p;

--- a/openstudiocore/src/utilities/core/PathHelpers.cpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.cpp
@@ -263,7 +263,13 @@ path completeAndNormalize(const path& p) {
       LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp is an absolute symlink (= linkpath)");
 
     } else {
+      // Note JM 2019-04-24: temp will end up absolute but not canonical yet
+      // eg:
+      // temp="/home/a_folder/a_symlink"
+      // linkpath="../another_folder/a_file"
       temp = temp.parent_path() / linkpath;
+      // eg: temp ="/home/a_folder/../another_folder/a_file"
+
       LOG_FREE(Trace, "PathHelpers", "completeAndNormalize: temp is a relative symlink, pointing to = " << temp);
 
     }
@@ -276,7 +282,7 @@ path completeAndNormalize(const path& p) {
   path result;
 
   // TODO: In develop3, which has boost 1.68, we can replace it with boost::filesystem::weakly_canonical
-  // temp right now is absolute, but it isn't canonical.
+  // Note JM 2019-04-24: temp right now is absolute, but it isn't necessarilly canonical.
   // This block resolves a canonical path, even if it doesn't exist (yet?) on disk.
   for(openstudio::path::iterator it=temp.begin(); it!=temp.end(); ++it) {
     if (*it == toPath("..")) {

--- a/openstudiocore/src/utilities/core/PathHelpers.hpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.hpp
@@ -121,6 +121,9 @@ UTILITIES_API bool isNetworkPath(const path& p);
   * Currently only implemented for Windows, returns false on other platforms. */
 UTILITIES_API bool isNetworkPathAvailable(const path& p);
 
+/** Tries to locate a file in your PATH, returning unchanged if p isn't just a filename (has a parent_path) or if not found */
+UTILITIES_API path findInSystemPath(const path& p);
+
 } // openstudio
 
 #endif //UTILITIES_CORE_PATHHELPERS_HPP

--- a/openstudiocore/src/utilities/core/PathHelpers.hpp
+++ b/openstudiocore/src/utilities/core/PathHelpers.hpp
@@ -124,6 +124,9 @@ UTILITIES_API bool isNetworkPathAvailable(const path& p);
 /** Tries to locate a file in your PATH, returning unchanged if p isn't just a filename (has a parent_path) or if not found */
 UTILITIES_API path findInSystemPath(const path& p);
 
+/** Returns the delimiter for the $PATH env variable. Basically ";" on windows, ":" otherwise */
+UTILITIES_API const char pathDelimiter();
+
 } // openstudio
 
 #endif //UTILITIES_CORE_PATHHELPERS_HPP

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -39,7 +39,7 @@
 // TODO: GTEST 1.9 should have a GTEST_SKIP macro we could use
 #define SKIP(TEST_NAME) \
 do{\
-   std::cout << "[  SKIPPED ] " << #TEST_NAME << ": smylink tests can only be run with administrator rights on windows (elevated cmd.exe)" << std::endl;\
+   std::cout << "[  SKIPPED ] " << #TEST_NAME << ": symlink tests can only be run with administrator rights on windows (elevated cmd.exe)" << std::endl;\
    return;\
 } while(0)
 

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -150,7 +150,7 @@ TEST(ApplicationPathHelpers, completeAndNormalizeMultipleSymlinks) {
   EXPECT_EQ(toString(ori_path), toString(foundPath));
 
   for (const auto& p: toClean) {
-    // boost::filesystem::remove(p);
+    boost::filesystem::remove(p);
   }
 
 

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -36,6 +36,13 @@
 #include <thread>
 #include <future>
 
+// TODO: GTEST 1.9 should have a GTEST_SKIP macro we could use
+#define SKIP(TEST_NAME) \
+do{\
+   std::cout << "[  SKIPPED ] " << #TEST_NAME << ": smylink tests can only be run with administrator rights on windows (elevated cmd.exe)" << std::endl;\
+   return;\
+} while(0)
+
 #if defined(_WIN32)
 #include <Windows.h>
 
@@ -144,7 +151,7 @@ TEST(ApplicationPathHelpers, findInSystemPath) {
 TEST(ApplicationPathHelpers, completeAndNormalizeMultipleSymlinks) {
 
   if (!IsElevated()) {
-    FAIL() << "This test can only be run with administrator rights on windows (elevated cmd.exe)";
+   SKIP(completeAndNormalizeMultipleSymlinks);
   }
 
   std::vector<openstudio::path> toClean;
@@ -236,7 +243,7 @@ int launch_another_instance_from_symlink(const path& symlink_path) {
 TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Setup) {
 
   if (!IsElevated()) {
-    FAIL() << "This test can only be run with administrator rights on windows (elevated cmd.exe)";
+    SKIP(completeAndNormalizeMultipleSymlinks);
   }
 
   openstudio::path symlink_path_dir = getApplicationBuildDirectory() / toPath("Testing/Temporary");

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -156,6 +156,16 @@ TEST(ApplicationPathHelpers, completeAndNormalizeMultipleSymlinks) {
 
 }
 
+// Want to make sure what getOpenStudioModule actually returns
+TEST(ApplicationPathHelpers, Simple_test_forThisModule) {
+    path openstudioModulePath = getOpenStudioModule();
+    EXPECT_TRUE(exists(openstudioModulePath));
+    // The expected path is the utilities one, but resolved for symlinks (we don't want to hardcode the version eg openstudio_utilities_tests-2.8.0)
+    openstudio::path expectedOpenstudioModulePath = getApplicationBuildDirectory() / toPath("Products/openstudio_utilities_tests");
+    expectedOpenstudioModulePath = completeAndNormalize(expectedOpenstudioModulePath);
+    EXPECT_EQ(toString(expectedOpenstudioModulePath), toString(openstudioModulePath));
+}
+
 void launch_another_instance_from_symlink(const path& symlink_path) {
   std::string cmd = toString(symlink_path.filename()) + " --gtest_filter=*PathWhenSymlinkInPathUnixOnly_Run*";
   std::system(cmd.c_str());
@@ -186,15 +196,6 @@ TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Setup) {
 
   unsetenv("PathWhenSymlinkInPathUnixOnly_Setup");
   setenv("PATH", current_path, 1);
-}
-
-TEST(ApplicationPathHelpers, Dumb_test) {
-    path openstudioModulePath = getOpenStudioModule();
-    EXPECT_TRUE(exists(openstudioModulePath));
-    // The expected path is the utilities one, but resolved for symlinks (we don't want to hardcode the version eg openstudio_utilities_tests-2.8.0)
-    openstudio::path expectedOpenstudioModulePath = getApplicationBuildDirectory() / toPath("Products/openstudio_utilities_tests");
-    expectedOpenstudioModulePath = completeAndNormalize(expectedOpenstudioModulePath);
-    EXPECT_EQ(toString(expectedOpenstudioModulePath), toString(openstudioModulePath));
 }
 
 TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Run) {

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -83,15 +83,6 @@ bool IsElevated() {
 }
 #endif
 
-const char getPlatformDelimiterForPath() {
-  #if defined _WIN32
-    const char delimiter = ';';
-  #else
-    const char delimiter = ':';
-  #endif
-  return delimiter;
-}
-
 
 using namespace openstudio;
 
@@ -132,7 +123,7 @@ TEST(ApplicationPathHelpers, findInSystemPath) {
 
   // Append the containing dir to the PATH
   auto current_path = std::getenv("PATH");
-  std::string new_path = toString(dummy_dir) + getPlatformDelimiterForPath() + current_path;
+  std::string new_path = toString(dummy_dir) + openstudio::pathDelimiter() + current_path;
   setenv("PATH", new_path.c_str(), 1);
   setenv("PathWhenSymlinkInPathUnixOnly_Setup", "true", 1);
 
@@ -270,7 +261,7 @@ TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Setup) {
   boost::filesystem::create_symlink(openstudioUtilitiesTestPath, symlink_path);
 
   auto current_path = std::getenv("PATH");
-  std::string new_path = toString(symlink_path_dir) + getPlatformDelimiterForPath() + current_path;
+  std::string new_path = toString(symlink_path_dir) + openstudio::pathDelimiter() + current_path;
 
   setenv("PATH", new_path.c_str(), 1);
   setenv("PathWhenSymlinkInPathUnixOnly_Setup", "true", 1);

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -125,7 +125,7 @@ TEST(ApplicationPathHelpers, findInSystemPath) {
   auto current_path = std::getenv("PATH");
   std::string new_path = toString(dummy_dir) + openstudio::pathDelimiter() + current_path;
   setenv("PATH", new_path.c_str(), 1);
-  setenv("PathWhenSymlinkInPathUnixOnly_Setup", "true", 1);
+  setenv("PathWhenSymlinkInPath_Setup", "true", 1);
 
   // Locate the file with only its name
   absolute_path_to_dummy = findInSystemPath(dummy_file_path.filename());
@@ -227,11 +227,11 @@ TEST(ApplicationPathHelpers, Simple_test_forThisModule) {
 }
 
 int launch_another_instance_from_symlink(const path& symlink_path) {
-  std::string cmd = toString(symlink_path.filename()) + " --gtest_filter=*PathWhenSymlinkInPathUnixOnly_Run*";
+  std::string cmd = toString(symlink_path.filename()) + " --gtest_filter=*PathWhenSymlinkInPath_Run*";
   return std::system(cmd.c_str());
 }
 
-TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Setup) {
+TEST(ApplicationPathHelpers, PathWhenSymlinkInPath_Setup) {
 
   if (!IsElevated()) {
     SKIP(completeAndNormalizeMultipleSymlinks);
@@ -264,27 +264,27 @@ TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Setup) {
   std::string new_path = toString(symlink_path_dir) + openstudio::pathDelimiter() + current_path;
 
   setenv("PATH", new_path.c_str(), 1);
-  setenv("PathWhenSymlinkInPathUnixOnly_Setup", "true", 1);
+  setenv("PathWhenSymlinkInPath_Setup", "true", 1);
 
-  // We run a system call to the symlink name (not its path), with a gtest_filter set to PathWhenSymlinkInPathUnixOnly_Run
+  // We run a system call to the symlink name (not its path), with a gtest_filter set to PathWhenSymlinkInPath_Run
   // and we ensure we actually can get the right executable. We check the return code to make sure it worked (in case it can't find the symlink for
   // eg)
   auto future = std::async(launch_another_instance_from_symlink, symlink_path);
   EXPECT_EQ(0, future.get());
 
-  unsetenv("PathWhenSymlinkInPathUnixOnly_Setup");
+  unsetenv("PathWhenSymlinkInPath_Setup");
   setenv("PATH", current_path, 1);
 }
 
-TEST(ApplicationPathHelpers, PathWhenSymlinkInPathUnixOnly_Run) {
+TEST(ApplicationPathHelpers, PathWhenSymlinkInPath_Run) {
 
   // If you want to see more info, uncomment the logger lines
   // openstudio::Logger::instance().standardOutLogger().enable();
   // openstudio::Logger::instance().standardOutLogger().setLogLevel(Trace);
 
   //EXPECT_TRUE(false) << std::getenv("PATH");
-  //EXPECT_TRUE(false) << std::getenv("PathWhenSymlinkInPathUnixOnly_Setup");
-  if (std::getenv("PathWhenSymlinkInPathUnixOnly_Setup")) {
+  //EXPECT_TRUE(false) << std::getenv("PathWhenSymlinkInPath_Setup");
+  if (std::getenv("PathWhenSymlinkInPath_Setup")) {
     path openstudioModulePath = getOpenStudioModule();
     EXPECT_TRUE(exists(openstudioModulePath));
      // The expected path is the utilities one, but resolved for symlinks (we don't want to hardcode the version eg openstudio_utilities_tests-2.8.0)

--- a/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
+++ b/openstudiocore/src/utilities/core/test/ApplicationPathHelpers_GTest.cpp
@@ -234,7 +234,7 @@ int launch_another_instance_from_symlink(const path& symlink_path) {
 TEST(ApplicationPathHelpers, PathWhenSymlinkInPath_Setup) {
 
   if (!IsElevated()) {
-    SKIP(completeAndNormalizeMultipleSymlinks);
+    SKIP(PathWhenSymlinkInPath_Setup);
   }
 
   openstudio::path symlink_path_dir = getApplicationBuildDirectory() / toPath("Testing/Temporary");


### PR DESCRIPTION
Fix #3158 and Fix #2802: symlink path problems

The problem was arising when you launch the uderlying executable (whatever the executable actually, could be OpenStudioApp, or openstudio, or openstudio_utilities_tests, etc) from the terminal when two conditions are met:
* You call something that is found in your PATH, and NOT in the current directory you are under
* That something is actually a symlink

I added some unit tests, some of which are Unix only because they rely on symlinks (while symlinks are possible on windows I don't think it'll work on all machines out of the box).
I also added one "weird" test that runs another test in another thread... I could see this being frown upon, but I don't see any other way to test this very specific thing otherwise.

Side note: now if you have built in Debug, you can now pass an environment variable `OPENSTUDIO_APPLICATION_SLEEP_AT_START` to make OS App sleep and give you time to attach a debugger to it before it crashes: 

* if OPENSTUDIO_APPLICATION_SLEEP_AT_START=X where X is an integer, then it sleeps for X seconds
* if OPENSTUDIO_APPLICATION_SLEEP_AT_START is set but not an int (such as "TRUE"), then it sleeps for 60 seconds

This was needed orginally to debug because launching OS App would crash too quickly for me to find the process and attach to it, and if I launched OSApp symlink via lldb ( `lldb OpenStudioApp` )lldb would resolve the symlink before launching the process, which made it impossible to produce the bug.