### PR TITLE
Fix 3524: errors in Building::remove

### DIFF
--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -126,6 +126,12 @@ namespace detail {
     SpaceVector spaces = this->spaces();
     result.insert(result.end(), spaces.begin(), spaces.end());
 
+    // TODO: JM 2019-05-13: handle HVAC (#2449)
+    // AirLoopHVACs should be considered de facto part of the building
+    // PlantLoops may merit more attention:
+    // if a PlantLoop doesn't serve an AirLoopHVAC or a ThermalZone, should it be considered part of the Building?
+    // eg: a PlantLoop serving only a LoadProfile:Plant?
+
     return result;
   }
 

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -574,6 +574,12 @@ namespace detail {
     return result;
   }
 
+  BuildingStoryVector Building_Impl::buildingStories() const
+  {
+    // all Building Stories in workspace implicitly belong to building
+    return this->model().getConcreteModelObjects<BuildingStory>();
+  }
+
   OptionalFacility Building_Impl::facility() const
   {
     return this->model().getOptionalUniqueModelObject<Facility>();
@@ -994,6 +1000,11 @@ namespace detail {
     return result;
   }
 
+  std::vector<ModelObject> Building_Impl::buildingStoriesAsModelObjects() const {
+    ModelObjectVector result = castVector<ModelObject>(buildingStories());
+    return result;
+  }
+
   boost::optional<ModelObject> Building_Impl::facilityAsModelObject() const {
     OptionalModelObject result;
     OptionalFacility intermediate = facility();
@@ -1260,6 +1271,11 @@ void Building::resetDefaultScheduleSet()
 OutputMeterVector Building::meters() const
 {
   return getImpl<detail::Building_Impl>()->meters();
+}
+
+BuildingStoryVector Building::buildingStories() const
+{
+  return getImpl<detail::Building_Impl>()->buildingStories();
 }
 
 OptionalFacility Building::facility() const

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -168,6 +168,9 @@ namespace detail {
       result.insert(result.end(), tmp.begin(), tmp.end());
     }
 
+    tmp = ParentObject_Impl::remove();
+    result.insert(result.end(), tmp.begin(), tmp.end());
+
     return result;
   }
 

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -111,7 +111,7 @@ namespace detail {
     result.insert(result.end(),meters.begin(),meters.end());
 
     // building stories
-    BuildingStoryVector stories = model().getConcreteModelObjects<BuildingStory>();
+    BuildingStoryVector stories = this->buildingStories();
     result.insert(result.end(),stories.begin(),stories.end());
 
     // exterior shading groups
@@ -179,7 +179,7 @@ namespace detail {
       }
 
       // BuildingStory instances
-      auto t_stories = model().getConcreteModelObjects<BuildingStory>();
+      auto t_stories = buildingStories();
       // Map of the source model story handle to the target model story "cloned" ModelObject
       std::map<Handle,BuildingStory> m_storyMap;
 

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -129,6 +129,18 @@ namespace detail {
     return result;
   }
 
+  // TODO: this is far from perfect, currently this is just trying to address a known issue #3524
+  // Ideally all corner cases would be handled correctly, and HVAC too
+  std::vector<IdfObject> Building_Impl::remove() {
+
+    // thermal zones
+    for (ThermalZone& z: this->thermalZones()) {
+      z.remove();
+    }
+
+    return ParentObject_Impl::remove();
+  }
+
   ModelObject Building_Impl::clone(Model t_model) const
   {
     boost::optional<Building> result;

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -133,12 +133,42 @@ namespace detail {
   // Ideally all corner cases would be handled correctly, and HVAC too
   std::vector<IdfObject> Building_Impl::remove() {
 
-    // thermal zones
-    for (ThermalZone& z: this->thermalZones()) {
-      z.remove();
+    // A result vector, and a temporary vector to insert into the result one
+    std::vector<IdfObject> result;
+    std::vector<IdfObject> tmp;
+
+    // Spaces
+    for (auto& s: this->spaces()) {
+      tmp = s.remove();
+      result.insert(result.end(), tmp.begin(), tmp.end());
     }
 
-    return ParentObject_Impl::remove();
+    // thermal zones
+    for (auto& z: this->thermalZones()) {
+      tmp = z.remove();
+      result.insert(result.end(), tmp.begin(), tmp.end());
+    }
+
+    // exterior shading groups
+    for (auto& sg: this->shadingSurfaceGroups()) {
+      tmp = sg.remove();
+      result.insert(result.end(), tmp.begin(), tmp.end());
+
+    }
+
+    // building stories
+    for (auto& bs: this->buildingStories()) {
+      tmp = bs.remove();
+      result.insert(result.end(), tmp.begin(), tmp.end());
+    }
+
+    // meters
+    for (auto& m: this->meters()) {
+      tmp = m.remove();
+      result.insert(result.end(), tmp.begin(), tmp.end());
+    }
+
+    return result;
   }
 
   ModelObject Building_Impl::clone(Model t_model) const

--- a/openstudiocore/src/model/Building.hpp
+++ b/openstudiocore/src/model/Building.hpp
@@ -42,6 +42,7 @@ namespace model {
 
 class Facility;
 class OutputMeter;
+class BuildingStory;
 class ShadingSurfaceGroup;
 class Surface;
 class Space;
@@ -190,6 +191,9 @@ class MODEL_API Building : public ParentObject {
 
   /// Returns all OutputMeter objects at the Building level.
   std::vector<OutputMeter> meters() const;
+
+    /// Returns all \link BuildingStory BuildingStories\endlink objects in the Building
+  std::vector<BuildingStory> buildingStories() const;
 
   /// Returns the parent Facility object if it exists.
   boost::optional<Facility> facility() const;

--- a/openstudiocore/src/model/Building_Impl.hpp
+++ b/openstudiocore/src/model/Building_Impl.hpp
@@ -43,6 +43,7 @@ namespace model {
 
 class Facility;
 class OutputMeter;
+class BuildingStory;
 class ShadingSurfaceGroup;
 class Surface;
 class Space;
@@ -171,6 +172,8 @@ namespace detail {
 
     std::vector<OutputMeter> meters() const;
 
+    std::vector<BuildingStory> buildingStories() const;
+
     boost::optional<Facility> facility() const;
 
     std::vector<Space> spaces() const;
@@ -247,6 +250,7 @@ namespace detail {
     boost::optional<ModelObject> defaultConstructionSetAsModelObject() const;
     boost::optional<ModelObject> defaultScheduleSetAsModelObject() const;
     std::vector<ModelObject> metersAsModelObjects() const;
+    std::vector<ModelObject> buildingStoriesAsModelObjects() const;
     boost::optional<ModelObject> facilityAsModelObject() const;
     std::vector<ModelObject> spacesAsModelObjects() const;
     std::vector<ModelObject> shadingSurfaceGroupsAsModelObjects() const;

--- a/openstudiocore/src/model/Building_Impl.hpp
+++ b/openstudiocore/src/model/Building_Impl.hpp
@@ -77,6 +77,8 @@ namespace detail {
 
     virtual boost::optional<ParentObject> parent() const override;
 
+    virtual std::vector<IdfObject> remove() override;
+
     virtual std::vector<ModelObject> children() const override;
 
     virtual ModelObject clone(Model model) const override;

--- a/openstudiocore/src/model/test/Building_GTest.cpp
+++ b/openstudiocore/src/model/test/Building_GTest.cpp
@@ -489,7 +489,7 @@ TEST_F(ModelFixture, Building_remove) {
   EXPECT_EQ(0, m.getModelObjects<PortList>().size());
   EXPECT_EQ(0, m.getModelObjects<ThermalZone>().size());
 
-  // TODO: JM 2019-05-13 Once HVAC is handled, we should adjust this portion.
+  // TODO: JM 2019-05-13 Once HVAC is handled (#2449), we should adjust this portion.
   // For now this tests that at least we don't end up with bad connections
   ASSERT_EQ(1, m.getModelObjects<AirLoopHVAC>().size());
   EXPECT_NO_THROW(m.getModelObjects<AirLoopHVAC>()[0].components());
@@ -523,7 +523,7 @@ TEST_F(ModelFixture, Building_remove_exampleModel) {
   EXPECT_EQ(0, m.getModelObjects<BuildingStory>().size());
   EXPECT_EQ(ori_meters, m.getModelObjects<OutputMeter>().size());
 
-  // TODO: JM 2019-05-13 Once HVAC is handled, we should adjust this portion.
+  // TODO: JM 2019-05-13 Once HVAC is handled (#2449), we should adjust this portion.
   // For now this tests that at least we don't end up with bad connections
   ASSERT_EQ(1, m.getModelObjects<AirLoopHVAC>().size());
   EXPECT_NO_THROW(m.getModelObjects<AirLoopHVAC>()[0].components());

--- a/openstudiocore/src/model/test/Building_GTest.cpp
+++ b/openstudiocore/src/model/test/Building_GTest.cpp
@@ -458,3 +458,27 @@ TEST_F(ModelFixture, Building_Rotations)
   EXPECT_NEAR(cos(degToRad(degrees)), spaceGroup.siteTransformation().matrix()(0, 0), 0.0001);
 
 }
+
+TEST_F(ModelFixture, Building_remove) {
+
+  Model m;
+  ThermalZone z(m);
+  AirLoopHVAC a(m);
+
+  a.addBranchForZone(z);
+  // 4 basic AirLoopHVAC nodes (supply/demand inlet/outlet Nodes)
+  // One AirLoopHVAC branch node before and one after ThermalZones
+  // 1 Zone Air Node
+  EXPECT_EQ(7u, m.getModelObjects<Node>().size());
+  // Zone Inlet Port List, Zone Return Air Port List, Zone Air Exhaust Port List
+  EXPECT_EQ(3u, m.getModelObjects<PortList>().size());
+  EXPECT_EQ(1u, m.getModelObjects<ThermalZone>().size());
+
+  m.getUniqueModelObject<Building>().remove();
+  // 4 basic airLoopHVAC Nodes plus the Drop node between demand splitter and mixer
+  EXPECT_EQ(5u, m.getModelObjects<Node>().size());
+  // Zone Inlet Port List, Zone Return Air Port List, Zone Air Exhaust Port List
+  EXPECT_EQ(0u, m.getModelObjects<PortList>().size());
+  EXPECT_EQ(0u, m.getModelObjects<ThermalZone>().size());
+
+}

--- a/openstudiocore/src/model/test/Building_GTest.cpp
+++ b/openstudiocore/src/model/test/Building_GTest.cpp
@@ -59,6 +59,10 @@
 #include "../PeopleDefinition.hpp"
 #include "../Schedule.hpp"
 #include "../LifeCycleCost.hpp"
+#include "../Node.hpp"
+#include "../Node_Impl.hpp"
+#include "../PortList.hpp"
+#include "../PortList_Impl.hpp"
 
 #include "../../utilities/data/Attribute.hpp"
 #include "../../utilities/geometry/Geometry.hpp"
@@ -469,16 +473,16 @@ TEST_F(ModelFixture, Building_remove) {
   // 4 basic AirLoopHVAC nodes (supply/demand inlet/outlet Nodes)
   // One AirLoopHVAC branch node before and one after ThermalZones
   // 1 Zone Air Node
-  EXPECT_EQ(7u, m.getModelObjects<Node>().size());
+  EXPECT_EQ(7, m.getModelObjects<Node>().size());
   // Zone Inlet Port List, Zone Return Air Port List, Zone Air Exhaust Port List
-  EXPECT_EQ(3u, m.getModelObjects<PortList>().size());
-  EXPECT_EQ(1u, m.getModelObjects<ThermalZone>().size());
+  EXPECT_EQ(3, m.getModelObjects<PortList>().size());
+  EXPECT_EQ(1, m.getModelObjects<ThermalZone>().size());
 
   m.getUniqueModelObject<Building>().remove();
   // 4 basic airLoopHVAC Nodes plus the Drop node between demand splitter and mixer
-  EXPECT_EQ(5u, m.getModelObjects<Node>().size());
+  EXPECT_EQ(5, m.getModelObjects<Node>().size());
   // Zone Inlet Port List, Zone Return Air Port List, Zone Air Exhaust Port List
-  EXPECT_EQ(0u, m.getModelObjects<PortList>().size());
-  EXPECT_EQ(0u, m.getModelObjects<ThermalZone>().size());
+  EXPECT_EQ(0, m.getModelObjects<PortList>().size());
+  EXPECT_EQ(0, m.getModelObjects<ThermalZone>().size());
 
 }

--- a/openstudiocore/src/model/test/Building_GTest.cpp
+++ b/openstudiocore/src/model/test/Building_GTest.cpp
@@ -59,10 +59,14 @@
 #include "../PeopleDefinition.hpp"
 #include "../Schedule.hpp"
 #include "../LifeCycleCost.hpp"
+#include "../AirLoopHVAC.hpp"
+#include "../AirLoopHVAC_Impl.hpp"
 #include "../Node.hpp"
 #include "../Node_Impl.hpp"
 #include "../PortList.hpp"
 #include "../PortList_Impl.hpp"
+#include "../OutputMeter.hpp"
+#include "../OutputMeter_Impl.hpp"
 
 #include "../../utilities/data/Attribute.hpp"
 #include "../../utilities/geometry/Geometry.hpp"
@@ -485,4 +489,42 @@ TEST_F(ModelFixture, Building_remove) {
   EXPECT_EQ(0, m.getModelObjects<PortList>().size());
   EXPECT_EQ(0, m.getModelObjects<ThermalZone>().size());
 
+  // TODO: JM 2019-05-13 Once HVAC is handled, we should adjust this portion.
+  // For now this tests that at least we don't end up with bad connections
+  ASSERT_EQ(1, m.getModelObjects<AirLoopHVAC>().size());
+  EXPECT_NO_THROW(m.getModelObjects<AirLoopHVAC>()[0].components());
+
+}
+
+TEST_F(ModelFixture, Building_remove_exampleModel) {
+
+  Model m = exampleModel();
+
+  EXPECT_NE(0, m.getModelObjects<Space>().size());
+  EXPECT_NE(0, m.getModelObjects<ThermalZone>().size());
+  EXPECT_NE(0, m.getModelObjects<ShadingSurfaceGroup>().size());
+  EXPECT_NE(0, m.getModelObjects<BuildingStory>().size());
+
+  // Creates three meters, but facility-level ones only
+  unsigned ori_meters = m.getModelObjects<OutputMeter>().size();
+  // Add one Building level one
+  OutputMeter meter(m);
+  meter.setName("Electricity:Building");
+  EXPECT_EQ(InstallLocationType::Building, meter.installLocationType().get().value());
+
+  EXPECT_NO_THROW(m.getUniqueModelObject<Building>().remove());
+
+  EXPECT_EQ(0, m.getModelObjects<Space>().size());
+  EXPECT_EQ(0, m.getModelObjects<ThermalZone>().size());
+
+  // There is one Site Shading group that should be left untouched
+  // The other two are Space and Building level, so should be removed
+  EXPECT_EQ(1, m.getModelObjects<ShadingSurfaceGroup>().size());
+  EXPECT_EQ(0, m.getModelObjects<BuildingStory>().size());
+  EXPECT_EQ(ori_meters, m.getModelObjects<OutputMeter>().size());
+
+  // TODO: JM 2019-05-13 Once HVAC is handled, we should adjust this portion.
+  // For now this tests that at least we don't end up with bad connections
+  ASSERT_EQ(1, m.getModelObjects<AirLoopHVAC>().size());
+  EXPECT_NO_THROW(m.getModelObjects<AirLoopHVAC>()[0].components());
 }


### PR DESCRIPTION
Implement a full `Building::remove` method to delete objects rather than default to ParentObject::remove which will not call individual ModelObject::remove methods (and therefore in particular will delete a thermalZone but not properly disconnect it first leading to a crash)