### PR TITLE
Fix crash on mac related to os edit

### DIFF
--- a/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSDoubleEdit.cpp
@@ -62,7 +62,6 @@ OSDoubleEdit2::OSDoubleEdit2( QWidget * parent )
 
 OSDoubleEdit2::~OSDoubleEdit2()
 {
-  unbind();
 }
 
 void OSDoubleEdit2::bind(model::ModelObject& modelObject,

--- a/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSIntegerEdit.cpp
@@ -57,7 +57,6 @@ OSIntegerEdit2::OSIntegerEdit2( QWidget * parent )
 
 OSIntegerEdit2::~OSIntegerEdit2()
 {
-  unbind();
 }
 
 void OSIntegerEdit2::bind(model::ModelObject& modelObject,

--- a/openstudiocore/src/shared_gui_components/OSLineEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSLineEdit.cpp
@@ -65,7 +65,6 @@ OSLineEdit2::OSLineEdit2( QWidget * parent )
 
 OSLineEdit2::~OSLineEdit2()
 {
-  unbind();
 }
 
 void OSLineEdit2::bind(model::ModelObject& modelObject,

--- a/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSQuantityEdit.cpp
@@ -93,7 +93,6 @@ OSQuantityEdit2::OSQuantityEdit2(const std::string& modelUnits, const std::strin
 
 OSQuantityEdit2::~OSQuantityEdit2()
 {
-  unbind();
 }
 
 void OSQuantityEdit2::bind(bool isIP,

--- a/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
+++ b/openstudiocore/src/shared_gui_components/OSUnsignedEdit.cpp
@@ -58,7 +58,6 @@ OSUnsignedEdit2::OSUnsignedEdit2( QWidget * parent )
 
 OSUnsignedEdit2::~OSUnsignedEdit2()
 {
-  unbind();
 }
 
 void OSUnsignedEdit2::bind(model::ModelObject& modelObject,


### PR DESCRIPTION
The issue stems from the destructor of OSEdit classes
calling unbind. The unbind method does three things.

1. resets the member variables related to the ModelObject that is bound
2. removes some qt signal connections
3. calls setEnabled(false)

You can see these steps here https://github.com/NREL/OpenStudio/blob/1ae1cec65b25421bd2dabcb7501618a00338645b/openstudiocore/src/shared_gui_components/OSLineEdit.cpp#L152

During destruction of the widget it is item 3 that causes the issue,
because as the widget calls the setEnabled method, the focus event is triggered
and that causes a bunch of refreshing logic that we don't want because the overall
view is in a half destroyed state.

The solution is simply to not call unbind when the OSEdit classes are destroyed.
This is defensbile because

1. member state does not need to be reset because it is soon to be destroyed.
2. qt connections will be removed by QObject destructor https://doc.qt.io/archives/qt-4.8/qobject.html#dtor.QObject
3. setEnable (the source of the issue) does not need to be called because the widget is soon to be
nuked anyway.

close #3434

## OpenStudio Pull Request Template

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStrudio Pull Request protocol.
