### PR TITLE
Fix #3600: display plantLoop supply equipment in the same order as the resulting PlantEquipmentList after ForwardTranslaton

### DIFF
--- a/openstudiocore/src/openstudio_lib/GridItem.cpp
+++ b/openstudiocore/src/openstudio_lib/GridItem.cpp
@@ -981,6 +981,11 @@ void ReverseVerticalBranchItem::layout()
   setVGridLength( j );
 }
 
+/* Sort the (parallel) branches by:
+ * - ThermalZone name if applicable,
+ * - First component's name after the initial Node if more than one component
+ * - Only component (=a node) otherwise
+ */
 bool sortBranches(std::vector<ModelObject> i, std::vector<ModelObject> j)
 {
   OS_ASSERT(! i.empty());
@@ -1240,7 +1245,15 @@ HorizontalBranchGroupItem::HorizontalBranchGroupItem( model::Splitter & splitter
         }
       }
 
-      std::sort(allBranchComponents.begin(),allBranchComponents.end(),sortBranches);
+      // Note JM 2019-07-16: If this is the demand side, we order it by the thermal zone names (airLoopHVAC),
+      // or the component after the node names,makes it easier to find stuff
+      // If this is the supply side (which only affects PlantLoop in effect, since a single duct doesn't have parallel branches,
+      // and a dual duct uses vertical branches - but might as well not call a sort function that will do nothing for AirLoopHVAC),
+      // we don't want to do it because we want it to display in the same order
+      // that will end up in the PlantEquipmentList after Forward Translatation (affects Load Distribution substantially!)
+      if (!isSupplySide) {
+        std::sort(allBranchComponents.begin(),allBranchComponents.end(),sortBranches);
+      }
       for(auto it = allBranchComponents.begin();
           it != allBranchComponents.end();
           ++it)


### PR DESCRIPTION
Fix #3600: display plantLoop supply equipment in the same order as added **and** as the resulting `PlantEquipmentList` after ForwardTranslaton

See https://github.com/NREL/OpenStudio/issues/3600#issuecomment-511755968 for diagnostic and root cause.

Objects are now displayed in the same order as I added them:

![image](https://user-images.githubusercontent.com/5479063/61287739-db3b4000-a7c5-11e9-9e1f-17fd89400ced.png)

I set the two HX to Control Type "CoolingSetpointModulated" (a **cooling** one). Tested that after FT I also get the same order:

```
PlantEquipmentList,
  Plant Loop 1 Cooling Equipment List,    !- Name
  HeatExchanger:FluidToFluid,             !- Equipment Object Type 1
  Fluid-to-Fluid HX,                      !- Equipment Name 1
  Chiller:Electric:EIR,                   !- Equipment Object Type 2
  Chiller - Air Cooled,                   !- Equipment Name 2
  HeatExchanger:FluidToFluid,             !- Equipment Object Type 3
  Fluid-to-Fluid HX 1;                    !- Equipment Name 3

```


