### PR TITLE
Add new Fields in AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass 

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10318,6 +10318,7 @@ OS:AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass,
         \key CoolingPriority
         \key HeatingPriority
         \key ZonePriority
+        \key LoadPriority
         \required-field
    N7 , \field Minimum Outlet Air Temperature During Cooling Operation
         \type real
@@ -10335,6 +10336,18 @@ OS:AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass,
         \key Multimode
         \key CoolReheat
         \required-field
+   A17, \field Plenum or Mixer Inlet Node Name
+        \type object-list
+        \reference ConnectionNames
+        \note Enter the name of the bypass duct node connected to a plenum or mixer.
+        \note This field is required when this HVAC System is connected to a plenum or mixer.
+        \note This is a different node name than that entered in the Bypass Duct Splitter Node Name field.
+   N9 ; \field Minimum Runtime Before Operating Mode Change
+        \type real
+        \units hr
+        \minimum 0.0
+        \required-field
+        \note This is the minimum amount of time the unit operates in cooling or heating mode before changing modes.
 
 OS:AirLoopHVAC:UnitarySystem,
        \memo AirloopHVAC:UnitarySystem is a generic HVAC system type that allows any

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10330,7 +10330,7 @@ OS:AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass,
         \units C
         \minimum> 0.0
         \required-field
-   A16; \field Dehumidification Control Type
+   A16, \field Dehumidification Control Type
         \type choice
         \key None
         \key Multimode

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10338,7 +10338,8 @@ OS:AirLoopHVAC:UnitaryHeatCool:VAVChangeoverBypass,
         \required-field
    A17, \field Plenum or Mixer Inlet Node Name
         \type object-list
-        \reference ConnectionNames
+        \required-field
+        \object-list ConnectionNames
         \note Enter the name of the bypass duct node connected to a plenum or mixer.
         \note This field is required when this HVAC System is connected to a plenum or mixer.
         \note This is a different node name than that entered in the Bypass Duct Splitter Node Name field.

--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -545,6 +545,7 @@ set(${target_name}_test_src
   Test/AirflowNetwork_GTest.cpp
 
   Test/AirLoopHVACUnitarySystem_GTest.cpp
+  Test/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_GTest.cpp
   Test/AirTerminalDualDuctConstantVolume_GTest.cpp
   Test/AirTerminalDualDuctVAVOutdoorAir_GTest.cpp
   Test/AirTerminalSingleDuctConstantVolumeFourPipeBeam_GTest.cpp

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
@@ -39,6 +39,7 @@
 #include "../../model/ThermalZone_Impl.hpp"
 #include "../../model/Schedule.hpp"
 #include "../../model/Schedule_Impl.hpp"
+#include "../../model/Mixer.hpp"
 #include <utilities/idd/AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypass_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_DX_SingleSpeed_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_DX_TwoSpeed_FieldEnums.hxx>
@@ -250,6 +251,10 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatCoo
     unitarySystem.setString(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::DehumidificationControlType,s.get());
   }
 
+  // Minimum Runtime Before Operating Mode Change
+  unitarySystem.setDouble(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::MinimumRuntimeBeforeOperatingModeChange,
+                          modelObject.minimumRuntimeBeforeOperatingModeChange());
+
   if( _fan && _coolingCoil && _heatingCoil )
   {
     std::string fanOutletNodeName;
@@ -361,6 +366,14 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitaryHeatCoo
     m_idfObjects.push_back(_oaNodeList);
     _outdoorAirMixer.setString(OutdoorAir_MixerFields::ReliefAirStreamNodeName,baseName + " Relief Air Node");
     _outdoorAirMixer.setString(OutdoorAir_MixerFields::ReturnAirStreamNodeName,bypassDuctMixerNodeName);
+
+
+    // Plenum or Mixer
+    if (boost::optional<Mixer> returnPathComponent = modelObject.plenumorMixer()) {
+      // In this case, do translate the node
+      unitarySystem.setString(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName,
+                              modelObject.plenumorMixerNode().name().get());
+    }
   }
 
   return unitarySystem;

--- a/openstudiocore/src/energyplus/Test/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_GTest.cpp
@@ -1,0 +1,226 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+
+#include "../../model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/CoilHeatingElectric.hpp"
+#include "../../model/CoilCoolingDXSingleSpeed.hpp"
+#include "../../model/FanConstantVolume.hpp"
+#include "../../model/Schedule.hpp"
+#include "../../model/Node.hpp"
+#include "../../model/Node_Impl.hpp"
+#include "../../model/AirLoopHVAC.hpp"
+#include "../../model/AirLoopHVACZoneMixer.hpp"
+#include "../../model/AirLoopHVACReturnPlenum.hpp"
+#include "../../model/AirLoopHVACReturnPlenum_Impl.hpp"
+#include "../../model/ThermalZone.hpp"
+
+#include "../../utilities/idf/IdfObject.hpp"
+#include "../../utilities/idf/IdfExtensibleGroup.hpp"
+
+
+#include <utilities/idd/AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypass_FieldEnums.hxx>
+#include <utilities/idd/AirLoopHVAC_ZoneMixer_FieldEnums.hxx>
+#include <utilities/idd/AirLoopHVAC_ReturnPlenum_FieldEnums.hxx>
+#include <utilities/idd/IddEnums.hxx>
+
+#include <resources.hxx>
+
+#include <sstream>
+#include <algorithm>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+/**
+ * Tests only the minimumRuntimeBeforeOperatingModeChange and the plenumorMixer of the ForwardTranslator which I exposed after the fact
+ **/
+TEST_F(EnergyPlusFixture,ForwardTranslator_AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_plenumorMixer)
+{
+  ForwardTranslator ft;
+
+  Model m;
+  FanConstantVolume fan(m);
+  CoilHeatingElectric heatingCoil(m);
+  CoilCoolingDXSingleSpeed coolingCoil(m);
+
+  AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass unitary(m, fan, coolingCoil ,heatingCoil);
+
+  EXPECT_TRUE(unitary.setMinimumRuntimeBeforeOperatingModeChange(0.25));
+  EXPECT_EQ(0.25, unitary.minimumRuntimeBeforeOperatingModeChange());
+
+  AirLoopHVAC a(m);
+  ThermalZone z(m);
+  ThermalZone plenumZone(m);
+  EXPECT_TRUE(a.addBranchForZone(z));
+  EXPECT_TRUE(z.setReturnPlenum(plenumZone));
+  AirLoopHVACZoneMixer mixer = a.zoneMixer();
+
+  auto modelObjects = a.demandComponents(z, mixer);
+  auto plenums = subsetCastVector<AirLoopHVACReturnPlenum>(modelObjects);
+  ASSERT_EQ(1u, plenums.size());
+  AirLoopHVACReturnPlenum plenum = plenums[0];
+
+
+  Node supplyOutletNode = a.supplyOutletNode();
+  unitary.addToNode(supplyOutletNode);
+
+  // Nested lambda helper to check if we find a specific node name in the extensible fields (=Inlet nodes) of the AirLoopHVAC:ZoneMixer or
+  // AirLoopHVAC:ReturnPlenum fields (they have the same extensible groups structure)
+  auto checkIfFoundInExtensibleGroups = [](const WorkspaceObject& idf_object, const std::string& plenumNodeName, unsigned extFieldIndex) {
+    std::vector<IdfExtensibleGroup> groups = idf_object.extensibleGroups();
+    auto it = std::find_if(groups.begin(), groups.end(), [&plenumNodeName, extFieldIndex](IdfExtensibleGroup eg)
+      {
+        if (boost::optional<std::string> _inletNodeName = eg.getString(extFieldIndex)) {
+          if (openstudio::istringEqual(plenumNodeName, _inletNodeName.get())) {
+            return true;
+          }
+        }
+        return false;
+      }
+    );
+    return it != groups.end();
+  };
+
+  // Not connected
+  {
+    EXPECT_EQ(1u, mixer.inletModelObjects().size());
+    EXPECT_EQ(1u, plenum.inletModelObjects().size());
+    EXPECT_FALSE(unitary.plenumorMixer());
+
+    Workspace workspace = ft.translateModel(m);
+
+    std::vector<WorkspaceObject> idf_unitarys = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypass);
+    std::vector<WorkspaceObject> idf_zonemixers = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ZoneMixer);
+    std::vector<WorkspaceObject> idf_returnplenums = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ReturnPlenum);
+    EXPECT_EQ(1u, idf_unitarys.size());
+    EXPECT_EQ(1u, idf_zonemixers.size());
+    EXPECT_EQ(1u, idf_returnplenums.size());
+    EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::AirLoopHVAC).size());
+
+    WorkspaceObject idf_unitary = idf_unitarys[0];
+    WorkspaceObject idf_zonemixer = idf_zonemixers[0];
+    WorkspaceObject idf_returnplenum = idf_returnplenums[0];
+
+    // Check the FT of the new numeric field too
+    EXPECT_EQ(0.25, idf_unitary.getDouble(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::MinimumRuntimeBeforeOperatingModeChange).get());
+
+    // Both objects should only have one inlet node
+    EXPECT_EQ(1u, idf_zonemixer.numExtensibleGroups());
+    EXPECT_EQ(1u, idf_returnplenum.numExtensibleGroups());
+
+    boost::optional<std::string> _plenumNodeName = idf_unitary.getString(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName, false, true);
+    EXPECT_FALSE(_plenumNodeName);
+  }
+
+
+  // Connected to AirLoopHVAC:ZoneMixer
+  {
+    EXPECT_TRUE(unitary.setPlenumorMixer(mixer));
+    EXPECT_EQ(2u, mixer.inletModelObjects().size());
+    EXPECT_EQ(1u, plenum.inletModelObjects().size());
+    ASSERT_TRUE(unitary.plenumorMixer());
+    EXPECT_EQ(mixer.handle(), unitary.plenumorMixer()->handle());
+
+    Workspace workspace = ft.translateModel(m);
+
+    std::vector<WorkspaceObject> idf_unitarys = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypass);
+    std::vector<WorkspaceObject> idf_zonemixers = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ZoneMixer);
+    std::vector<WorkspaceObject> idf_returnplenums = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ReturnPlenum);
+    EXPECT_EQ(1u, idf_unitarys.size());
+    EXPECT_EQ(1u, idf_zonemixers.size());
+    EXPECT_EQ(1u, idf_returnplenums.size());
+    EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::AirLoopHVAC).size());
+
+    WorkspaceObject idf_unitary = idf_unitarys[0];
+    WorkspaceObject idf_zonemixer = idf_zonemixers[0];
+    WorkspaceObject idf_returnplenum = idf_returnplenums[0];
+
+    // The ZoneMixer should now have two inlet nodes, and we can find plenum node in its extensible fields
+    EXPECT_EQ(2u, idf_zonemixer.numExtensibleGroups());
+    EXPECT_EQ(1u, idf_returnplenum.numExtensibleGroups());
+
+    boost::optional<std::string> _plenumNodeName = idf_unitary.getString(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName, false, true);
+    ASSERT_TRUE(_plenumNodeName);
+
+    EXPECT_TRUE(
+        checkIfFoundInExtensibleGroups(idf_zonemixer, _plenumNodeName.get(), AirLoopHVAC_ZoneMixerExtensibleFields::InletNodeName)
+    ) << "Expected to find Plenum Node Name='" << _plenumNodeName.get() << "' in the AirLoopHVAC:ZoneMixer extensible fields";
+
+    EXPECT_FALSE(
+        checkIfFoundInExtensibleGroups(idf_returnplenum, _plenumNodeName.get(), AirLoopHVAC_ReturnPlenumExtensibleFields::InletNodeName)
+    ) << "Did not expect to find Plenum Node Name='" << _plenumNodeName.get() << "' in the AirLoopHVAC:ReturnPlenum extensible fields";
+
+  }
+
+  // Connected to AirLoopHVAC:ReturnPlenum
+  {
+    EXPECT_TRUE(unitary.setPlenumorMixer(plenum));
+    EXPECT_EQ(1u, mixer.inletModelObjects().size());
+    EXPECT_EQ(2u, plenum.inletModelObjects().size());
+    ASSERT_TRUE(unitary.plenumorMixer());
+    EXPECT_EQ(plenum, unitary.plenumorMixer().get());
+
+    Workspace workspace = ft.translateModel(m);
+
+    std::vector<WorkspaceObject> idf_unitarys = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypass);
+    std::vector<WorkspaceObject> idf_zonemixers = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ZoneMixer);
+    std::vector<WorkspaceObject> idf_returnplenums = workspace.getObjectsByType(IddObjectType::AirLoopHVAC_ReturnPlenum);
+    EXPECT_EQ(1u, idf_unitarys.size());
+    EXPECT_EQ(1u, idf_zonemixers.size());
+    EXPECT_EQ(1u, idf_returnplenums.size());
+    EXPECT_EQ(1u, workspace.getObjectsByType(IddObjectType::AirLoopHVAC).size());
+
+    WorkspaceObject idf_unitary = idf_unitarys[0];
+    WorkspaceObject idf_zonemixer = idf_zonemixers[0];
+    WorkspaceObject idf_returnplenum = idf_returnplenums[0];
+
+    EXPECT_EQ(1u, idf_zonemixer.numExtensibleGroups());
+    EXPECT_EQ(2u, idf_returnplenum.numExtensibleGroups());
+
+    boost::optional<std::string> _plenumNodeName = idf_unitary.getString(AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName, false, true);
+    ASSERT_TRUE(_plenumNodeName);
+
+    EXPECT_FALSE(
+        checkIfFoundInExtensibleGroups(idf_zonemixer, _plenumNodeName.get(), AirLoopHVAC_ZoneMixerExtensibleFields::InletNodeName)
+    ) << "Expected to find Plenum Node Name='" << _plenumNodeName.get() << "' in the AirLoopHVAC:ZoneMixer extensible fields";
+
+    EXPECT_TRUE(
+        checkIfFoundInExtensibleGroups(idf_returnplenum, _plenumNodeName.get(), AirLoopHVAC_ReturnPlenumExtensibleFields::InletNodeName)
+    ) << "Did not expect to find Plenum Node Name='" << _plenumNodeName.get() << "' in the AirLoopHVAC:ReturnPlenum extensible fields";
+  }
+
+}

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
@@ -703,7 +703,7 @@ AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::AirLoopHVACUnitaryHeatCoolVAVChan
   setDehumidificationControlType("None");
   // This field is a bit weird, in the sense that if it's not present in the IDF it's 0, if it's present and blank it's 0.25
   // In order to try to maintain historical behavior, default to 0
-  setMinimumRuntimeBeforeOperatingModeChange(0);
+  setMinimumRuntimeBeforeOperatingModeChange(0.0);
 
   // Create a node for the Plenum or Mixer Air
   Node node(model);

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
@@ -707,7 +707,7 @@ AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::AirLoopHVACUnitaryHeatCoolVAVChan
 
   // Create a node for the Plenum or Mixer Air
   Node node(model);
-  model.connect(*this, OS_AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName, node, node.inletPort());
+  model.connect(*this, this->plenumorMixerAirPort(), node, node.inletPort());
 }
 
 IddObjectType AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::iddObjectType() {
@@ -928,8 +928,14 @@ bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setDehumidificationControlTy
 double AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::minimumRuntimeBeforeOperatingModeChange() const {
   return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->minimumRuntimeBeforeOperatingModeChange();
 }
+
 bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setMinimumRuntimeBeforeOperatingModeChange(double runtime) {
   return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->setMinimumRuntimeBeforeOperatingModeChange(runtime);
+}
+
+unsigned AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::plenumorMixerAirPort() const
+{
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->plenumorMixerAirPort();
 }
 
 Node AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::plenumorMixerNode() const {

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.cpp
@@ -31,8 +31,11 @@
 #include "AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl.hpp"
 #include "Model.hpp"
 #include "Model_Impl.hpp"
+#include "Mixer.hpp"
+#include "Mixer_Impl.hpp"
 #include "Schedule.hpp"
 #include "Schedule_Impl.hpp"
+#include "Node.hpp"
 #include "ScheduleTypeLimits.hpp"
 #include "ScheduleTypeRegistry.hpp"
 #include <utilities/idd/IddFactory.hxx>
@@ -434,6 +437,15 @@ namespace detail {
     unitaryClone.setHeatingCoil(heatingCoilClone);
     unitaryClone.setCoolingCoil(coolingCoilClone);
 
+    // We need this because "connect" is first going to try to disconnect from anything
+    // currently attached.  At this point unitaryClone is left pointing (through a connection) to the old air node,
+    // (because of ModelObject::clone behavior) so connecting to the new node will remove the connection joining
+    // the original unitary and the original node.
+    unitaryClone.setString(this->plenumorMixerAirPort(), "");
+    // Create a node for the Plenum or Mixer Air
+    Node node(model);
+    model.connect(unitaryClone, unitaryClone.plenumorMixerAirPort(), node, node.inletPort());
+
     return unitaryClone;
   }
 
@@ -464,6 +476,14 @@ namespace detail {
       result.insert(result.end(), removedHeatingCoils.begin(), removedHeatingCoils.end());
     }
 
+    // Removes branch on Plenum corresponding to this object
+    resetPlenumorMixer();
+    // delete the node
+    Node mixerNode = plenumorMixerNode();
+    mixerNode.disconnect();
+    std::vector<IdfObject> removedNode = mixerNode.remove();
+    result.insert(result.end(), removedNode.begin(), removedNode.end());
+
     std::vector<IdfObject> removedUnitarySystem = StraightComponent_Impl::remove();
     result.insert(result.end(), removedUnitarySystem.begin(), removedUnitarySystem.end());
 
@@ -485,6 +505,80 @@ namespace detail {
     }
 
     return result;
+  }
+
+  double AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::minimumRuntimeBeforeOperatingModeChange() const {
+    boost::optional<int> value = getDouble(OS_AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::MinimumRuntimeBeforeOperatingModeChange, true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::setMinimumRuntimeBeforeOperatingModeChange(double runtime) {
+    bool result = setDouble(OS_AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::MinimumRuntimeBeforeOperatingModeChange, runtime);
+    return result;
+  }
+
+
+  unsigned AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::plenumorMixerAirPort() const
+  {
+    return OS_AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerInletNodeName;
+  }
+
+  Node AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::plenumorMixerNode() const {
+    return this->connectedObject(this->plenumorMixerAirPort())->cast<Node>();
+    return getObject<ModelObject>().getModelObjectTarget<Mixer>(OS_AirLoopHVAC_UnitaryHeatCool_VAVChangeoverBypassFields::PlenumorMixerObjectName);
+  }
+
+
+  boost::optional<Mixer> AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::plenumorMixer() const {
+    boost::optional<Mixer> result;
+
+    if (mo = plenumorMixerNode.outletModelObject()) {
+      result = mo.optionalCast<Mixer>();
+      OS_ASSERT(result);
+    }
+
+    return result;
+  }
+
+  bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::setPlenumorMixer(const Mixer& returnPathComponent) {
+
+    if ((returnPathComponent.iddObjectType() != IddObjectType::OS_AirLoopHVAC_ZoneMixer) &&
+        (returnPathComponent.iddObjectType() != IddObjectType::OS_AirLoopHVAC_ReturnPlenum))
+    {
+      LOG(Error, briefDescription() << " can only be connected to an AirLoopHVACZoneMixer or an AirLoopHVACReturnPlenum.");
+      return false;
+    }
+
+    bool result = false;
+
+    if ((boost::optional<AirLoopHVAC> mixerLoop = returnPathComponent.airLoopHVAC()) && (boost::optional<AirLoopHVAC> thisLoop = this->airLoopHVAC())) {
+      if (mixerLoop == thisLoop) {
+        result = true;
+      }
+    }
+
+
+    if (result) {
+      // Reset any existing plenum or mixer
+      resetPlenumorMixer();
+      Node mixerNode = plenumorMixerNode();
+       _model.connect(mixerNode, mixerNode.outletPort(), returnPathComponent, returnPathComponent.nextInletPort());
+    } else {
+      LOG(Warn, briefDescription() << " cannot be connected with a " << returnPathComponent.briefDescription()
+             << " unless they are both on the same AirLoopHVAC.")
+
+    }
+
+    return result;
+  }
+
+  void AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::resetPlenumorMixer() {
+    Node mixerNode = plenumorMixerNode();
+    if (boost::optional<Mixer> existingMixer = plenumorMixer()) {
+      existingMixer->removePortForBranch(existingMixer->branchIndexForInletModelObject(mixerNode));
+    }
+    this->model().disconnect(mixerNode, mixerNode.outletPort());
   }
 
   boost::optional<double> AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl::autosizedSystemAirFlowRateDuringCoolingOperation() const {
@@ -605,6 +699,13 @@ AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::AirLoopHVACUnitaryHeatCoolVAVChan
   setMinimumOutletAirTemperatureDuringCoolingOperation(8.0);
   setMaximumOutletAirTemperatureDuringHeatingOperation(50.0);
   setDehumidificationControlType("None");
+  // This field is a bit weird, in the sense that if it's not present in the IDF it's 0, if it's present and blank it's 0.25
+  // In order to try to maintain historical behavior, default to 0
+  setMinimumRuntimeBeforeOperatingModeChange(0);
+
+  // Create a node for the Plenum or Mixer Air
+  Node node(model);
+  model.connect(*this,this->plenumorMixerAirPort(), node, node.inletPort());
 }
 
 IddObjectType AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::iddObjectType() {
@@ -820,6 +921,28 @@ bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setMaximumOutletAirTemperatu
 
 bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setDehumidificationControlType(std::string dehumidificationControlType) {
   return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->setDehumidificationControlType(dehumidificationControlType);
+}
+
+double AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::minimumRuntimeBeforeOperatingModeChange() const {
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->minimumRuntimeBeforeOperatingModeChange();
+}
+bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setMinimumRuntimeBeforeOperatingModeChange(double runtime) {
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->setMinimumRuntimeBeforeOperatingModeChange(runtime);
+}
+
+Node AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::plenumorMixerNode() const {
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->plenumorMixerNode();
+}
+boost::optional<Mixer> AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::plenumorMixer() const {
+}
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->plenumorMixer();
+
+bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setPlenumorMixer(const Mixer& returnPathComponent) {
+  return getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->setPlenumorMixer(returnPathComponent);
+}
+
+void AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::resetPlenumorMixer() {
+  getImpl<detail::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl>()->resetPlenumorMixer();
 }
 
 /// @cond

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp
@@ -127,6 +127,8 @@ class MODEL_API AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass : public StraightC
 
   double minimumRuntimeBeforeOperatingModeChange() const;
 
+  unsigned plenumorMixerAirPort() const;
+
   /** This Node always exists for connecting "Plenum or Mixer Inlet Node", it will be translated only if actually connected to an
    * AirLoopHVAC:ReturnPlenum or an AirLoopHVAC:ZoneMixer */
   Node plenumorMixerNode() const;

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp
@@ -38,6 +38,7 @@ namespace openstudio {
 namespace model {
 
 class Schedule;
+class Mixer;
 
 namespace detail {
 
@@ -124,6 +125,15 @@ class MODEL_API AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass : public StraightC
 
   std::string dehumidificationControlType() const;
 
+  double minimumRuntimeBeforeOperatingModeChange() const;
+
+  /** This Node always exists for connecting "Plenum or Mixer Inlet Node", it will be translated only if actually connected to an
+   * AirLoopHVAC:ReturnPlenum or an AirLoopHVAC:ZoneMixer */
+  Node plenumorMixerNode() const;
+
+  /** Convenience method to get the optional linked Mixer object (AirLoopHVAC:ReturnPlenum or AirLoopHVAC:ZoneMixer) */
+  boost::optional<Mixer> plenumorMixer() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -179,6 +189,14 @@ class MODEL_API AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass : public StraightC
   bool setMaximumOutletAirTemperatureDuringHeatingOperation(double maximumOutletAirTemperatureDuringHeatingOperation);
 
   bool setDehumidificationControlType(std::string dehumidificationControlType);
+
+  bool setMinimumRuntimeBeforeOperatingModeChange(double runtime);
+
+  /** Connect the bypass air duct to an AirLoopHVAC:ReturnPlenum or an AirLoopHVAC:ZoneMixer that must
+   * be on the same AirLoopHVAC as this Unitary System */
+  bool setPlenumorMixer(const Mixer& returnPathComponent);
+
+  void resetPlenumorMixer();
 
   boost::optional<double> autosizedSystemAirFlowRateDuringCoolingOperation() const ;
 

--- a/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl.hpp
@@ -37,6 +37,7 @@ namespace openstudio {
 namespace model {
 
 class Schedule;
+class Mixer;
 
 namespace detail {
 
@@ -120,6 +121,12 @@ namespace detail {
 
     std::string dehumidificationControlType() const;
 
+    double minimumRuntimeBeforeOperatingModeChange() const;
+
+    unsigned plenumorMixerAirPort() const;
+    Node plenumorMixerNode() const;
+    boost::optional<Mixer> plenumorMixer() const;
+
     boost::optional<double> autosizedSystemAirFlowRateDuringCoolingOperation() const ;
 
     boost::optional<double> autosizedSystemAirFlowRateDuringHeatingOperation() const ;
@@ -196,6 +203,12 @@ namespace detail {
 
     bool setDehumidificationControlType(std::string dehumidificationControlType);
 
+    bool setMinimumRuntimeBeforeOperatingModeChange(double runtime);
+
+    bool setPlenumorMixer(const Mixer& returnPathComponent);
+
+    void resetPlenumorMixer();
+
     //@}
     /** @name Other */
     //@{
@@ -204,11 +217,11 @@ namespace detail {
 
     virtual unsigned outletPort() const override;
 
-    ModelObject clone(Model model) const override;
+    virtual ModelObject clone(Model model) const override;
 
-    std::vector<IdfObject> remove() override;
+    virtual std::vector<IdfObject> remove() override;
 
-    std::vector<ModelObject> children() const override;
+    virtual std::vector<ModelObject> children() const override;
 
     //@}
    protected:

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -10,7 +10,7 @@
     <rule IddField="ThermalZone" Access="LOCKED"/>
     <rule IddField="Inlet Node" Access="HIDDEN"/>
     <rule IddField="Outlet Node" Access="HIDDEN"/>
-    <rule IddField="Induced Air Outlet Node" Access="HIDDEN"/>
+    <rule IddField="Induced Air Outlet Port List" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_CentralHeatPumpSystem">
     <rule IddField="Cooling Loop Inlet Node Name" Access="HIDDEN"/>
@@ -164,6 +164,7 @@
     <rule IddField="Supply Air Fan" Access="HIDDEN"/>
     <rule IddField="Cooling Coil" Access="HIDDEN"/>
     <rule IddField="Heating Coil" Access="HIDDEN"/>
+    <rule IddField="Plenum or Mixer Inlet Node Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_AirLoopHVAC_UnitaryHeatPump_AirToAir">
     <rule IddField="Air Inlet Node Name" Access="HIDDEN"/>


### PR DESCRIPTION
Fix #3639 - Add new Fields in AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass

The new choice is straightforward, so is the setter/getter for "Minimum Runtime Before Operating Mode Change".

Logic for the "Plenum or Mixer Inlet Node":
* `AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass` ctor will create an OS:Node and connect to it via an OS:ConnectionObject (similar to for eg the ThermalZone ctor that creates a Node for "Zone Air Node").
* `bool AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass::setPlenumorMixer(const Mixer& mixer)` will accept a `AirLoopHVACZoneMixer` or a `AirLoopHVACReturnPlenum` if it's on the *same* AirLoopHVAC as the unitary system is on, and connect to it. It will add a new `Inlet Node Name` extensible field to the mixer object.
* `void resetPlenumorMixer()` does the opposite. `boost::optional<Mixer> plenumorMixer() const` is the getter (you also have a getter to the Node itself just an FYI, `Node plenumorMixerNode() const`
* `ForwardTranslator::translateAirLoopHVACUnitaryHeatCoolVAVChangeoverBypass` will write "Plenum or Mixer Inlet Node" only  if it's actually connected to a plenum.
