### PR TITLE
Use conan swig_installer 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,40 +737,22 @@ endif()
 
 # SWIG
 
-# using forked version of SWIG at https://github.com/macumber/swig/tree/openstudio_swig_3_0_12
-if(UNIX)
-  # We patch it up with a version of pcre we provide to avoid having to have the requirement locally
-  ExternalProject_Add(SWIG
-    URL http://openstudio-resources.s3.amazonaws.com/dependencies/swig-3.0.12.tar.gz
-    URL_MD5 a7d384966974ed79455a455b517ad83d
-    PATCH_COMMAND cp ${PROJECT_SOURCE_DIR}/dependencies/pcre-8.31.tar.bz2 ${PROJECT_BINARY_DIR}/SWIG-prefix/src/SWIG && cd ${PROJECT_BINARY_DIR}/SWIG-prefix/src/SWIG && ./Tools/pcre-build.sh
-    CONFIGURE_COMMAND ./autogen.sh && ./configure --prefix=${PROJECT_BINARY_DIR}/SWIG-prefix/src/SWIG-install
-    BUILD_COMMAND ${MAKE}
-    INSTALL_COMMAND ${MAKE} install
-    BUILD_IN_SOURCE 1
-  )
-  set(SWIG_EXECUTABLE ${PROJECT_BINARY_DIR}/SWIG-prefix/src/SWIG-install/bin/swig)
-else()
-  # SWIG requires MinGW to compile on windows, so we just copy in the prebuilt binary
-  set(SWIG_ZIP "swigwin-3.0.12.zip")
-  set(SWIG_DIR "swigwin-3.0.12")
-  set(SWIG_EXPECTED_HASH "8ee412d1278ba3cac22e58f26a842918")
-  if(EXISTS "${PROJECT_BINARY_DIR}/${SWIG_ZIP}")
-    file(MD5 "${PROJECT_BINARY_DIR}/${SWIG_ZIP}" SWIG_HASH)
-  endif()
-  if(NOT EXISTS "${PROJECT_BINARY_DIR}/${SWIG_ZIP}" OR NOT EXISTS "${PROJECT_BINARY_DIR}/${SWIG_DIR}" OR NOT "${SWIG_HASH}" MATCHES "${SWIG_EXPECTED_HASH}")
-    message(STATUS "Downloading SWIG)")
-    file(DOWNLOAD "http://openstudio-resources.s3.amazonaws.com/dependencies/${SWIG_ZIP}" "${PROJECT_BINARY_DIR}/${SWIG_ZIP}" TIMEOUT 120 INACTIVITY_TIMEOUT 120 SHOW_PROGRESS EXPECTED_MD5 ${SWIG_EXPECTED_HASH})
-    execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/${SWIG_DIR}")
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz "${PROJECT_BINARY_DIR}/${SWIG_ZIP}" WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
-  endif()
-
-  set(SWIG_EXECUTABLE ${PROJECT_BINARY_DIR}/${SWIG_DIR}/swig.exe)
+# We use conan swig_installer 4.0 which enhances our PATH to include the CONAN_BIN_DIRS_SWIG_INSTALLER already
+# So I could just do:
+# set(SWIG_EXECUTABLE swig)
+# But better be safe
+find_program(SWIG_EXECUTABLE swig)
+if(NOT SWIG_EXECUTABLE)
+  message(FATAL_ERROR "Couldn't find swig, which shouldn't happen. CONAN_BIN_DIRS_SWIG_INSTALLER=${CONAN_BIN_DIRS_SWIG_INSTALLER}")
 endif()
+
+# The conan-provided binary has a built-in swiglib (`swig -swiglib`) that points to the build box on which it was built, which is problematic for us.
+set(SWIG_LIB "${CONAN_SWIG_INSTALLER_ROOT}/share/swig/4.0.0")
 
 # Export SWIG to parent scope
 if(hasParent)
   set(SWIG_EXECUTABLE "${SWIG_EXECUTABLE}" PARENT_SCOPE)
+  set(SWIG_LIB "${SWIG_LIB}" PARENT_SCOPE)
 endif()
 
 set(ALL_RUBY_BINDING_TARGETS "") # global list

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,7 +747,7 @@ if(NOT SWIG_EXECUTABLE)
 endif()
 
 # The conan-provided binary has a built-in swiglib (`swig -swiglib`) that points to the build box on which it was built, which is problematic for us.
-set(SWIG_LIB "${CONAN_SWIG_INSTALLER_ROOT}/share/swig/4.0.0")
+set(SWIG_LIB "${CONAN_SWIG_INSTALLER_ROOT}/share/swig/4.0.1")
 
 # Export SWIG to parent scope
 if(hasParent)

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -86,6 +86,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     cpprestsdk/2.10.13@bincrafters/stable
     websocketpp/0.8.1@bincrafters/stable
     geographiclib/1.49@bincrafters/stable
+    swig_installer/4.0.0@bincrafters/stable
     ${CONAN_GTEST}
     BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
     OPTIONS ${CONAN_OPTIONS}

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -32,8 +32,8 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   conan_add_remote(NAME nrel
     URL https://api.bintray.com/conan/commercialbuilding/nrel)
 
-  #conan_add_remote(NAME jmarrec
-  #  URL https://api.bintray.com/conan/jmarrec/testing)
+  conan_add_remote(NAME jmarrec
+    URL https://api.bintray.com/conan/jmarrec/testing)
 
   # Convenience variable to set a consistent version for individual boost packages
   set(BOOST_VERSION "1.69.0")
@@ -86,7 +86,8 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     cpprestsdk/2.10.13@bincrafters/stable
     websocketpp/0.8.1@bincrafters/stable
     geographiclib/1.49@bincrafters/stable
-    swig_installer/4.0.0@bincrafters/stable
+    # 4.0.1 should fix a C++17 issue with unexpectted_handler an set_unexpected but not available in bincrafters yet
+    swig_installer/4.0.1@jmarrec/testing
     ${CONAN_GTEST}
     BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
     OPTIONS ${CONAN_OPTIONS}

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -32,8 +32,8 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   conan_add_remote(NAME nrel
     URL https://api.bintray.com/conan/commercialbuilding/nrel)
 
-  conan_add_remote(NAME jmarrec
-    URL https://api.bintray.com/conan/jmarrec/testing)
+  # conan_add_remote(NAME jmarrec
+  #   URL https://api.bintray.com/conan/jmarrec/testing)
 
   # Convenience variable to set a consistent version for individual boost packages
   set(BOOST_VERSION "1.69.0")
@@ -86,8 +86,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     cpprestsdk/2.10.13@bincrafters/stable
     websocketpp/0.8.1@bincrafters/stable
     geographiclib/1.49@bincrafters/stable
-    # 4.0.1 should fix a C++17 issue with unexpectted_handler an set_unexpected but not available in bincrafters yet
-    swig_installer/4.0.1@jmarrec/testing
+    swig_installer/4.0.1@bincrafters/stable
     ${CONAN_GTEST}
     BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
     OPTIONS ${CONAN_OPTIONS}

--- a/ProjectMacros.cmake
+++ b/ProjectMacros.cmake
@@ -277,7 +277,8 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
 
   add_custom_command(
     OUTPUT "${SWIG_WRAPPER}"
-    COMMAND "${SWIG_EXECUTABLE}"
+    COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+            "${SWIG_EXECUTABLE}"
             "-ruby" "-c++" "-fvirtual" "-I${PROJECT_SOURCE_DIR}/src" "-I${PROJECT_BINARY_DIR}/src" "${extra_includes}" "${extra_includes2}" ${RUBY_AUTODOC}
             -module "${MODULE}" -initname "${LOWER_NAME}"
             "-I${PROJECT_SOURCE_DIR}/ruby"
@@ -492,7 +493,8 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
 
     add_custom_command(
       OUTPUT "${SWIG_WRAPPER_FULL_PATH}"
-      COMMAND "${SWIG_EXECUTABLE}"
+      COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+              "${SWIG_EXECUTABLE}"
               "-python" ${SWIG_PYTHON_3_FLAG} "-c++" ${PYTHON_AUTODOC}
               -outdir ${PYTHON_GENERATED_SRC_DIR} "-I${PROJECT_SOURCE_DIR}/src" "-I${PROJECT_BINARY_DIR}/src"
               -module "${MODULE}"
@@ -622,7 +624,8 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       OUTPUT ${SWIG_WRAPPER_FULL_PATH}
       COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CSHARP_GENERATED_SRC_DIR}"
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${CSHARP_GENERATED_SRC_DIR}"
-      COMMAND "${SWIG_EXECUTABLE}"
+      COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+              "${SWIG_EXECUTABLE}"
               "-csharp" "-c++" -namespace ${NAMESPACE} ${CSHARP_AUTODOC}
               -outdir "${CSHARP_GENERATED_SRC_DIR}"  "-I${PROJECT_SOURCE_DIR}/src" "-I${PROJECT_BINARY_DIR}/src"
               -module "${MODULE}"
@@ -715,7 +718,8 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       OUTPUT ${SWIG_WRAPPER}
       COMMAND "${CMAKE_COMMAND}" -E remove_directory "${JAVA_GENERATED_SRC_DIR}"
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${JAVA_GENERATED_SRC_DIR}"
-      COMMAND "${SWIG_EXECUTABLE}"
+      COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+              "${SWIG_EXECUTABLE}"
               "-java" "-c++"
               -package ${NAMESPACE}
               #-features autodoc=1
@@ -835,7 +839,8 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
 
     add_custom_command(
       OUTPUT ${SWIG_WRAPPER}
-      COMMAND "${SWIG_EXECUTABLE}"
+      COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+              "${SWIG_EXECUTABLE}"
               "-javascript" ${SWIG_ENGINE} "-c++"
               #-namespace ${NAMESPACE}
               #-features autodoc=1

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -192,16 +192,19 @@ set_source_files_properties(EmbeddedScripting.i
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR} )
 
+# Must call CMake itself in order to set the SWIG_LIB env var for add_custom_command
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
-  COMMAND "${SWIG_EXECUTABLE}"
+  COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+          "${SWIG_EXECUTABLE}"
           "-ruby"
           -external-runtime "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
 )
 
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/embedded_scripting_wrap.cxx"
-  COMMAND "${SWIG_EXECUTABLE}"
+  COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+          "${SWIG_EXECUTABLE}"
           "-ruby"
           "-c++"
           -o "${CMAKE_CURRENT_BINARY_DIR}/embedded_scripting_wrap.cxx"
@@ -294,7 +297,7 @@ target_link_libraries(openstudio
  openstudio_radiance
 )
 
-# Change to CONAN_PKG::OpenSSL vs OPENSSL_CRYPTO_LIBRARY if this is needed.  
+# Change to CONAN_PKG::OpenSSL vs OPENSSL_CRYPTO_LIBRARY if this is needed.
 # link CLI with ruby static library, ruby bindings (openstudio.so) are linked to dynamic ruby
 #if (APPLE)
 #  target_link_libraries(openstudio

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -225,18 +225,14 @@ source_group(units FILES ${units_src})
 source_group(documentation FILES ${documentation_src})
 source_group(embedded FILES ${EMBEDDED_OUTPUT})
 
-if(UNIX)
-  set(SWIG_DEPENDS "SWIG")
-else()
-  set(SWIG_DEPENDS "")
-endif()
-
+# Must call CMake itself in order to set the SWIG_LIB env var for add_custom_command
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
-  COMMAND "${SWIG_EXECUTABLE}"
+  COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+          "${SWIG_EXECUTABLE}"
+          "-v"
           "-ruby"
           -external-runtime "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
-  DEPENDS "${SWIG_DEPENDS}"
 )
 
 set(${target_name}_src


### PR DESCRIPTION
Fix #3607

Note that I had to adjust the add_custom_command to pass the SWIG_LIB env variable, since the exe given by conan has swiglib = the one on the build box (CI) used to build it

It worked fine on Ubuntu 18.04, and I was able to use the resulting bindings. I'll let CI produce binaries for other platforms and test.
