### PR TITLE
V2.9.0 rc1

### DIFF
--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -74,7 +74,7 @@ set(ENERGYPLUS_BUILD_SHA "d67e9e635f")
 
 # ENERGYPLUS_RELEASE_NAME is used to locate the E+ download
 # from the github releases
-set(ENERGYPLUS_RELEASE_NAME "v9.2.0")
+set(ENERGYPLUS_RELEASE_NAME "v9.2.0-Alpha2")
 
 # Radiance
 set(RADIANCE_VERSION "5.0.a.12")
@@ -382,7 +382,7 @@ endif()
 
 if(UNIX)
   if(APPLE)
-    set(ENERGYPLUS_EXPECTED_HASH d5cee5e3af2d71c8d3554bf4f427af09)
+    set(ENERGYPLUS_EXPECTED_HASH f9642bb57a5c4974b1f4a2818ea5776f)
     set(ENERGYPLUS_PLATFORM "Darwin-x86_64")
   elseif(EXISTS "/etc/redhat-release")
     # TODO: There aren't any redhat releases anymore, see PR #3145 too
@@ -622,7 +622,7 @@ endif()
 # build and release openstudio gems at https://github.com/NREL/OpenStudio-gems
 # upload the openstudio-gems-DATE.tar.gz to the dependencies location on s3, then update the MD5sum and url below
 set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20190916.tar.gz")
-set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "12fc96b208f74762172d6e93178e6b72")
+set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "14f08cf581b5e3951e91f7949ff5fafd")
 
 set(OPENSTUDIO_GEMS_ZIP_LOCAL_PATH "${CMAKE_BINARY_DIR}/${OPENSTUDIO_GEMS_ZIP_FILENAME}")
 if(EXISTS "${OPENSTUDIO_GEMS_ZIP_LOCAL_PATH}")

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -70,11 +70,11 @@ set(ENERGYPLUS_VERSION_MINOR 2)
 set(ENERGYPLUS_VERSION_PATCH 0)
 set(ENERGYPLUS_VERSION "${ENERGYPLUS_VERSION_MAJOR}.${ENERGYPLUS_VERSION_MINOR}.${ENERGYPLUS_VERSION_PATCH}")
 # Build SHA is not required to have a value, but if it does OpenStudio will require this build.
-set(ENERGYPLUS_BUILD_SHA "9da72147bb")
+set(ENERGYPLUS_BUILD_SHA "d67e9e635f")
 
 # ENERGYPLUS_RELEASE_NAME is used to locate the E+ download
 # from the github releases
-set(ENERGYPLUS_RELEASE_NAME "v9.2.0-IOFreeze")
+set(ENERGYPLUS_RELEASE_NAME "v9.2.0")
 
 # Radiance
 set(RADIANCE_VERSION "5.0.a.12")
@@ -382,14 +382,14 @@ endif()
 
 if(UNIX)
   if(APPLE)
-    set(ENERGYPLUS_EXPECTED_HASH 364799fcadafa6c0e554a18d9268cce3)
+    set(ENERGYPLUS_EXPECTED_HASH d5cee5e3af2d71c8d3554bf4f427af09)
     set(ENERGYPLUS_PLATFORM "Darwin-x86_64")
   elseif(EXISTS "/etc/redhat-release")
     # TODO: There aren't any redhat releases anymore, see PR #3145 too
     set(ENERGYPLUS_EXPECTED_HASH DOES_NOT_EXIST_02ed618aab65bf46c96bf1faf2e1905b)
     set(ENERGYPLUS_PLATFORM "Redhat-x86_64")
   else()
-    set(ENERGYPLUS_EXPECTED_HASH c1fe1f6739c03de706b4fab02023fdfa)
+    set(ENERGYPLUS_EXPECTED_HASH 2f39127e55c3726315d509df4cdc2059)
     set(ENERGYPLUS_PLATFORM "Linux-x86_64")
   endif()
   set(ENERGYPLUS_PATH "EnergyPlus-${ENERGYPLUS_VERSION}-${ENERGYPLUS_BUILD_SHA}-${ENERGYPLUS_PLATFORM}")
@@ -414,7 +414,7 @@ elseif(WIN32)
   if(CMAKE_CL_64)
     set(ENERGYPLUS_PATH "EnergyPlus-${ENERGYPLUS_VERSION}-${ENERGYPLUS_BUILD_SHA}-Windows-x86_64")
     set(ENERGYPLUS_ARCH 64)
-    set(ENERGYPLUS_EXPECTED_HASH 3fb18158edcaa403fe0ac7f64708e822)
+    set(ENERGYPLUS_EXPECTED_HASH 7c10b31d823920f99bfae1526f42dbce)
   else()
     set(ENERGYPLUS_PATH "EnergyPlus-${ENERGYPLUS_VERSION}-${ENERGYPLUS_BUILD_SHA}-Windows-i386")
     set(ENERGYPLUS_ARCH 32)
@@ -621,8 +621,8 @@ endif()
 
 # build and release openstudio gems at https://github.com/NREL/OpenStudio-gems
 # upload the openstudio-gems-DATE.tar.gz to the dependencies location on s3, then update the MD5sum and url below
-set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20190712.tar.gz")
-set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "1dc2b3d3585de6cf61b77c68d1373e88")
+set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20190916.tar.gz")
+set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "12fc96b208f74762172d6e93178e6b72")
 
 set(OPENSTUDIO_GEMS_ZIP_LOCAL_PATH "${CMAKE_BINARY_DIR}/${OPENSTUDIO_GEMS_ZIP_FILENAME}")
 if(EXISTS "${OPENSTUDIO_GEMS_ZIP_LOCAL_PATH}")

--- a/openstudiocore/CMakeLists.txt
+++ b/openstudiocore/CMakeLists.txt
@@ -621,8 +621,8 @@ endif()
 
 # build and release openstudio gems at https://github.com/NREL/OpenStudio-gems
 # upload the openstudio-gems-DATE.tar.gz to the dependencies location on s3, then update the MD5sum and url below
-set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20190916.tar.gz")
-set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "14f08cf581b5e3951e91f7949ff5fafd")
+set(OPENSTUDIO_GEMS_ZIP_FILENAME "openstudio-gems-20190918-rc1.tar.gz")
+set(OPENSTUDIO_GEMS_ZIP_EXPECTED_MD5 "77b29687d3981dacf67fe72826456a16")
 
 set(OPENSTUDIO_GEMS_ZIP_LOCAL_PATH "${CMAKE_BINARY_DIR}/${OPENSTUDIO_GEMS_ZIP_FILENAME}")
 if(EXISTS "${OPENSTUDIO_GEMS_ZIP_LOCAL_PATH}")

--- a/openstudiocore/pat/CMakeLists.txt
+++ b/openstudiocore/pat/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PAT_SHA 817b68beb9a5c8ea4337c913c1fcd7bc43292def)
+set(PAT_SHA 3c20e076f7813e7b9bc406a40314d50e0929157b)
 
 find_program(NPM_COMMAND npm)
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
@@ -118,7 +118,7 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
     // add the values
     for (const auto& xValue : xValues) {
       auto eg = tableIndependentVariable.pushExtensibleGroup();
-      eg.setDouble(Table_IndependentVariableExtensibleFields::Value, xvalue);
+      eg.setDouble(Table_IndependentVariableExtensibleFields::Value, xValue);
     }
 
     tableIndependentVariables.push_back(tableIndependentVariable);

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
@@ -72,7 +72,7 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
     // expect a full grid of values
     expectedNumberOfValues *= sizeX;
 
-    // create an independent variable for this x 
+    // create an independent variable for this x
     IdfObject tableIndependentVariable(IddObjectType::Table_IndependentVariable);
     if (s) {
       tableIndependentVariable.setName(*s + "_IndependentVariable_" + std::to_string(i));
@@ -90,7 +90,7 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
       tableIndependentVariable.setString(Table_IndependentVariableFields::InterpolationMethod, "Cubic");
       tableIndependentVariable.setString(Table_IndependentVariableFields::ExtrapolationMethod, "Constant");
     }
-    
+
     // these values should be unique and sorted in ascending order
     tableIndependentVariable.setDouble(Table_IndependentVariableFields::MinimumValue, xValues[0]);
     tableIndependentVariable.setDouble(Table_IndependentVariableFields::MaximumValue, xValues[sizeX - 1]);
@@ -117,7 +117,8 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
 
     // add the values
     for (const auto& xValue : xValues) {
-      tableIndependentVariable.pushExtensibleGroup(std::vector<std::string>(1, std::to_string(xValue)));
+      auto eg = tableIndependentVariable.pushExtensibleGroup();
+      eg.setDouble(Table_IndependentVariableExtensibleFields::Value, xvalue);
     }
 
     tableIndependentVariables.push_back(tableIndependentVariable);
@@ -174,13 +175,14 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
   // ExternalFileName
   // Not supported
 
-  // add the sorted values 
+  // add the sorted values
   for (const auto& point : points) {
-    tableLookup.pushExtensibleGroup(std::vector<std::string>(1, std::to_string(point.y())));
+    auto eg = tableLookup.pushExtensibleGroup();
+    eg.setDouble(Table_LookupExtensibleFields::OutputValue, point.y());
   }
 
   return tableLookup;
-  
+
 }
 
 } // energyplus

--- a/openstudiocore/src/model/CoilCoolingDXSingleSpeed.cpp
+++ b/openstudiocore/src/model/CoilCoolingDXSingleSpeed.cpp
@@ -1046,12 +1046,12 @@ namespace detail{
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXSingleSpeed_Impl::autosizedEvaporativeCondenserAirFlowRate() const {
-    return getAutosizedValue("Design Size Evaporative Condenser Effectiveness", "m3/s");
+    return getAutosizedValue("Design Size Evaporative Condenser Air Flow Rate", "m3/s");
   }
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXSingleSpeed_Impl::autosizedEvaporativeCondenserPumpRatedPowerConsumption()  const {
-    return getAutosizedValue("Design Size Evaporative Condenser Air Flow Rate", "W");
+    return getAutosizedValue("Design Size Evaporative Condenser Pump Rated Power Consumption", "W");
   }
 
   std::vector<EMSActuatorNames> CoilCoolingDXSingleSpeed_Impl::emsActuatorNames() const {

--- a/openstudiocore/src/model/CoilCoolingDXTwoSpeed.cpp
+++ b/openstudiocore/src/model/CoilCoolingDXTwoSpeed.cpp
@@ -861,22 +861,22 @@ namespace detail{
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXTwoSpeed_Impl::autosizedHighSpeedEvaporativeCondenserAirFlowRate() const {
-    return getAutosizedValue("Design Size High Speed Evaporative Condenser Effectiveness", "m3/s");
+    return getAutosizedValue("Design Size High Speed Evaporative Condenser Air Flow Rate", "m3/s");
   }
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXTwoSpeed_Impl::autosizedHighSpeedEvaporativeCondenserPumpRatedPowerConsumption() const {
-    return getAutosizedValue("Design Size High Speed Evaporative Condenser Air Flow Rate", "W");
+    return getAutosizedValue("Design Size High Speed Evaporative Condenser Pump Rated Power Consumption", "W");
   }
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXTwoSpeed_Impl::autosizedLowSpeedEvaporativeCondenserAirFlowRate() const {
-    return getAutosizedValue("Design Size Low Speed Evaporative Condenser Effectiveness", "m3/s");
+    return getAutosizedValue("Design Size Low Speed Evaporative Condenser Air Flow Rate", "m3/s");
   }
 
   // E+ output has a bug where this field label is incorrect
   boost::optional<double> CoilCoolingDXTwoSpeed_Impl::autosizedLowSpeedEvaporativeCondenserPumpRatedPowerConsumption() const {
-    return getAutosizedValue("Design Size Low Speed Evaporative Condenser Air Flow Rate", "W");
+    return getAutosizedValue("Design Size Low Speed Evaporative Condenser Pump Rated Power Consumption", "W");
   }
 
   void CoilCoolingDXTwoSpeed_Impl::autosize() {

--- a/openstudiocore/src/model/ExternalFile.cpp
+++ b/openstudiocore/src/model/ExternalFile.cpp
@@ -129,11 +129,20 @@ namespace detail {
 
   path ExternalFile_Impl::filePath() const {
     path result;
+    path fname = toPath(fileName());
     std::vector<path> absoluteFilePaths = this->model().workflowJSON().absoluteFilePaths();
     if (absoluteFilePaths.empty()) {
-      result = this->model().workflowJSON().absoluteRootDir() / toPath(fileName());
+      result = this->model().workflowJSON().absoluteRootDir() / fname;
     } else {
-      result = absoluteFilePaths[0] / toPath(fileName());
+      // Loop to find the file in all possible directories in order of preference
+      // (eg goes to hardcoded paths, then potentially generated_files, then files, etc.)
+      for (const openstudio::path& dirpath: absoluteFilePaths) {
+        path p = dirpath / fname;
+        if (openstudio::filesystem::exists(p) || openstudio::filesystem::is_regular_file(p)) {
+          result = p;
+          break;
+        }
+      }
     }
     return result;
   }

--- a/openstudiocore/src/utilities/sql/Test/SqlFileFixture.cpp
+++ b/openstudiocore/src/utilities/sql/Test/SqlFileFixture.cpp
@@ -28,6 +28,8 @@
 ***********************************************************************************************************************/
 
 #include "SqlFileFixture.hpp"
+#include <iomanip>
+#include <cmath>
 
 using openstudio::Logger;
 using openstudio::FileLogSink;
@@ -56,6 +58,18 @@ void SqlFileFixture::SetUpTestCase()
 
 void SqlFileFixture::TearDownTestCase() {
   logFile->disable();
+}
+
+::testing::AssertionResult SqlFileFixture::IsWithinRelativeTolerance(double expectedValue, double actualValue, double tolerance) {
+  double percentageDifference = (actualValue - expectedValue) / expectedValue;
+  if (std::fabs(percentageDifference) <= tolerance) {
+    return ::testing::AssertionSuccess();
+  } else {
+    // Google Test seems to be ingoring the fixed && precision iomanips
+    return ::testing::AssertionFailure() << "Value isn't within the required tolerance of "
+      << std::fixed << std::setprecision(2) << (tolerance * 100) << "%. "
+      << "Expected Value = " << expectedValue << ", Sql Value = " << actualValue << ", Difference = " << (100*percentageDifference) << "%.";
+  }
 }
 
 // define static storage

--- a/openstudiocore/src/utilities/sql/Test/SqlFileFixture.hpp
+++ b/openstudiocore/src/utilities/sql/Test/SqlFileFixture.hpp
@@ -39,7 +39,7 @@
 #include <resources.hxx>
 
 class SqlFileFixture : public ::testing::Test {
-protected:
+ protected:
 
   // initialize for each test
   virtual void SetUp() override;
@@ -53,10 +53,13 @@ protected:
   // tear down static members
   static void TearDownTestCase();
 
+  // Tolerance defaults to 0.001=0.1%
+  ::testing::AssertionResult IsWithinRelativeTolerance(double expectedValue, double actualValue, double tolerance=0.001);
+
   // set up logging
   REGISTER_LOGGER("SqlFileFixture");
 
-public:
+ public:
   // sql files
   static openstudio::SqlFile sqlFile;
   static openstudio::SqlFile sqlFile2;

--- a/openstudiocore/src/utilities/sql/Test/SqlFile_GTest.cpp
+++ b/openstudiocore/src/utilities/sql/Test/SqlFile_GTest.cpp
@@ -304,20 +304,57 @@ TEST_F(SqlFileFixture, CreateSqlFile)
 
 TEST_F(SqlFileFixture, AnnualTotalCosts) {
 
-  // Total annual costs for all fuel types
-  EXPECT_NEAR(195052539.91, *(sqlFile2.annualTotalUtilityCost()), 1000);
+  struct SqlResults {
+
+    // Total annual costs for all fuel types
+    double annualTotalUtilityCost;
+
+    // Costs by fuel type
+    double annualTotalCost_Electricity;
+    double annualTotalCost_Gas;
+    double annualTotalCost_DistrictCooling;
+    double annualTotalCost_DistrictHeating;
+    double annualTotalCost_Water;
+    double annualTotalCost_FuelOil_1;
+  };
+
+  // Actual values
+  SqlResults ep_910 = {195052539.91, 27600.69, 427.17, 324.04, 782.87, 3256405.15, 191767000.0};
+  SqlResults ep_920 = {194898706.43, 27595.94, 426.75, 324.25, 782.28, 3256577.21, 191613000.0};
+
+  // =========== Check that you are within relatively normal ranges compared to previous versions  =================
+
+  // Total annual costs for all fuel types. Here I'm explicitly passing a tolerance of 0.1% (which is the default really, so omitting it after)
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalUtilityCost, sqlFile2.annualTotalUtilityCost().get(), 0.001));
 
   // Costs by fuel type
-  EXPECT_NEAR(27600.69, *(sqlFile2.annualTotalCost(FuelType::Electricity)), 0.1);
-  EXPECT_NEAR(427.17, *(sqlFile2.annualTotalCost(FuelType::Gas)), 0.1);
-  EXPECT_NEAR(324.04, *(sqlFile2.annualTotalCost(FuelType::DistrictCooling)), 0.1);
-  EXPECT_NEAR(782.87, *(sqlFile2.annualTotalCost(FuelType::DistrictHeating)), 0.1);
-  EXPECT_NEAR(3256405.15, *(sqlFile2.annualTotalCost(FuelType::Water)), 0.1);
-  EXPECT_NEAR(191767000, *(sqlFile2.annualTotalCost(FuelType::FuelOil_1)), 1000);
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_Electricity,     sqlFile2.annualTotalCost(FuelType::Electricity).get()));
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_Gas,             sqlFile2.annualTotalCost(FuelType::Gas).get()));
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_DistrictCooling, sqlFile2.annualTotalCost(FuelType::DistrictCooling).get()));
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_DistrictHeating, sqlFile2.annualTotalCost(FuelType::DistrictHeating).get()));
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_Water,           sqlFile2.annualTotalCost(FuelType::Water).get()));
+  EXPECT_TRUE(IsWithinRelativeTolerance(ep_910.annualTotalCost_FuelOil_1,       sqlFile2.annualTotalCost(FuelType::FuelOil_1).get()));
 
+
+  // =========== Check that within our development based on the current E+ version we do not make the results vary (at all)  =================
+
+  // Total annual costs for all fuel types
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalUtilityCost, sqlFile2.annualTotalUtilityCost().get());
+
+  // Costs by fuel type
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_Electricity,     sqlFile2.annualTotalCost(FuelType::Electricity).get());
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_Gas,             sqlFile2.annualTotalCost(FuelType::Gas).get());
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_DistrictCooling, sqlFile2.annualTotalCost(FuelType::DistrictCooling).get());
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_DistrictHeating, sqlFile2.annualTotalCost(FuelType::DistrictHeating).get());
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_Water,           sqlFile2.annualTotalCost(FuelType::Water).get());
+  EXPECT_DOUBLE_EQ(ep_920.annualTotalCost_FuelOil_1,       sqlFile2.annualTotalCost(FuelType::FuelOil_1).get());
+
+
+  // These have a relatively high tolerance and shouldn't fail, and they depend on the above values divided by square footage which shouldn't vary
+  // So it's fine to keep it as is
   // Costs by total building area by fuel type
-  EXPECT_NEAR(11.50, *(sqlFile2.annualTotalCostPerBldgArea(FuelType::Electricity)), 0.1);
-  EXPECT_NEAR(0.18, *(sqlFile2.annualTotalCostPerBldgArea(FuelType::Gas)), 0.1);
+  EXPECT_NEAR(11.50, *(sqlFile2.annualTotalCostPerBldgArea(FuelType::Electricity)), 0.1); // (E+ 9.2.0 = 11.498308333333332)
+  EXPECT_NEAR(0.18, *(sqlFile2.annualTotalCostPerBldgArea(FuelType::Gas)), 0.1);          // (E+ 9.2.0 = 0.1778125)
 
   // Costs by conditioned building area by fuel type
   EXPECT_NEAR(11.50, *(sqlFile2.annualTotalCostPerNetConditionedBldgArea(FuelType::Electricity)), 0.1);


### PR DESCRIPTION
This PR updates EnergyPlus: 
* from : https://github.com/NREL/EnergyPlus/releases/tag/v9.2.0-IOFreeze 
* to: https://github.com/NREL/EnergyPlus/releases/tag/v9.2.0-Alpha2

It also updates openstudio-gems.tar.gz for the new openstudio-standards, openstudio-extension and openstudio-workflow gem versions. 

I ran a full build and there are a few issues: 

1 ) Windows CI server hit an exceeded path limit of 260 chars due to the new paths in the openstudio-standards gem.  It looks like I can fix this by setting the reg key 'LongPathsEnabled' to 1 which then allows 4x the path lengths. Rebuilding now to see if that resolves it. Here was the error

`
C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets(974,5): error MSB4023: Cannot evaluate the item metadata "%(Extension)". The item metadata "%(Extension)" cannot be applied to the path "C:\Users\jenkins\git\OpenStudio\build\src\cli\embedded_files\ruby\2.2.0\gems\openstudio-standards-0.2.10.rc1\lib\openstudio-standards\standards\ashrae_90_1\ashrae_90_1_2004\comstock_ashrae_90_1_2004\data\comstock_ashrae_90_1_2004_refrigeration_system_lineup_json.cxx". The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
`

2 )  One new unit test is failing. 
`169 - SqlFileFixture.AnnualTotalCosts (Failed)`

3 ) A few new regression test errors/failures. Assuming these are from the new e+ packages.  Here are the Linux results:

```
 **Failures** 
autosizedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Single Speed 1 of type CoilCoolingDXSingleSpeed
autosizedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Single Speed 1 of type CoilCoolingDXSingleSpeed
autosizedHighSpeedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedHighSpeedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedLowSpeedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedLowSpeedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed

*** Methods that aren't implemented in C++ (but should be) ***

*** Missing Objects ***
F...............

Finished tests in 910.949008s, 0.2569 tests/s, 0.3194 assertions/s.


Error:
ModelTests#test_foundation_kiva_rb:
RuntimeError: Cannot find file /home/ubuntu/OpenStudio-resources/testruns/foundation_kiva.rb/in.osm
    /home/ubuntu/OpenStudio-resources/model_tests.rb:400:in `sim_test'
    /home/ubuntu/OpenStudio-resources/model_tests.rb:1384:in `test_foundation_kiva_rb'

Failure:
ModelTests#test_schedule_fixed_interval_2_osm [/home/ubuntu/OpenStudio-resources/model_tests.rb:258]
Minitest::Assertion: Expected: "Success"
  Actual: "Fail"

Failure:
ModelTests#test_schedule_file_osm [/home/ubuntu/OpenStudio-resources/model_tests.rb:258]
Minitest::Assertion: Expected: "Success"
  Actual: "Fail"

Failure:
ModelTests#test_schedule_file_rb [/home/ubuntu/OpenStudio-resources/model_tests.rb:258]
Minitest::Assertion: Expected: "Success"
  Actual: "Fail"

Error:
ModelTests#test_intersect_356_osm:
RuntimeError: Exit code 1:
[openstudio.model.Surface] <1> Initial area of surface 'Surface 909' 161.303 does not equal post intersection area 161.303
[openstudio.model.Surface] <1> Initial area of other surface 'Surface 133' 248.051 does not equal post intersection area 248.051
[openstudio.model.Surface] <1> Initial area of surface 'Surface 922' 152.729 does not equal post intersection area 152.729
Initial area of surface 'Surface 909' 161.303 does not equal post intersection area 161.303
Initial area of other surface 'Surface 133' 248.051 does not equal post intersection area 248.051
Initial area of surface 'Surface 922' 152.729 does not equal post intersection area 152.729

Error: Incorrect messages detected
Backtrace:
        /home/ubuntu/OpenStudio-resources/testruns/intersections/356.osm/intersect.rb:45:in `<top (required)>'
        eval:107:in `require'
        eval:107:in `require'
        :/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        :/openstudio_cli.rb:1511:in `execute'
        :/openstudio_cli.rb:763:in `execute'
        :/openstudio_cli.rb:1746:in `<main>'
        eval:116:in `eval'
        eval:116:in `require_embedded_absolute'
        eval:101:in `block in require'
        eval:95:in `each'
        eval:95:in `require'
        eval:3:in `<main>'
Exception: Incorrect messages detected
<main>: unexpected return

    /home/ubuntu/OpenStudio-resources/model_tests.rb:164:in `block in run_command'
    :/ruby/2.2.0/open3.rb:199:in `popen_run'
    :/ruby/2.2.0/open3.rb:93:in `popen3'
    /home/ubuntu/OpenStudio-resources/model_tests.rb:148:in `run_command'
    /home/ubuntu/OpenStudio-resources/model_tests.rb:473:in `intersect_test'
    /home/ubuntu/OpenStudio-resources/model_tests.rb:2060:in `test_intersect_356_osm'

Failure:
ModelTests#test_schedule_fixed_interval_osm [/home/ubuntu/OpenStudio-resources/model_tests.rb:258]
Minitest::Assertion: Expected: "Success"
  Actual: "Fail"

Failure:
ModelTests#test_autosizing_rb [/home/ubuntu/OpenStudio-resources/model_tests.rb:781]
Minitest::Assertion: 6 autosizedFoo methods failed to return a value:
autosizedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Single Speed 1 of type CoilCoolingDXSingleSpeed
autosizedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Single Speed 1 of type CoilCoolingDXSingleSpeed
autosizedHighSpeedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedHighSpeedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedLowSpeedEvaporativeCondenserAirFlowRate failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed
autosizedLowSpeedEvaporativeCondenserPumpRatedPowerConsumption failed for Coil Cooling DX Two Speed 1 of type CoilCoolingDXTwoSpeed..
Expected: 0
  Actual: 6

234 tests, 291 assertions, 5 failures, 2 errors, 0 skips`
```




