### PR TITLE
Add support for supplemental heat to ZoneHVAC:TerminalUnit:VariableRefrigerantFlow

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -24142,13 +24142,13 @@ OS:ZoneHVAC:PackagedTerminalAirConditioner,
        \object-list ScheduleNames
 
 OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
-  A1, \field Handle
-       \type handle
-       \required-field
+  A1 ,  \field Handle
+        \type handle
+        \required-field
   A2 ,  \field Name
         \type alpha
         \reference ZoneTerminalUnitNames
-       \reference ConnectionObject
+        \reference ConnectionObject
   A3 ,  \field Terminal Unit Availability schedule
         \required-field
         \type object-list
@@ -24215,7 +24215,7 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \required-field
         \type object-list
         \object-list FansCVandOnOff
-  A9,  \field Outside Air Mixer
+  A9 ,  \field Outside Air Mixer
         \type object-list
         \object-list OutdoorAirMixers
         \note If this field is blank, and outside air mixer is not used.
@@ -24264,11 +24264,13 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \type real
         \units C
         \autosizable
+        \required-field
         \note Supply air temperature from the supplemental heater will not exceed this value.
   N12;  \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
         \type real
         \maximum 21.0
         \units C
+        \required-field
         \note Supplemental heater will not operate when outdoor temperature exceeds this value.
 
 

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -24239,11 +24239,40 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \type real
         \units W
         \minimum 0
-  N10; \field Rated Total Heating Capacity Sizing Ratio
+  N10,  \field Rated Total Heating Capacity Sizing Ratio
         \required-field
-       \type real
-       \units W/W
-       \minimum 1.0
+        \type real
+        \units W/W
+        \minimum 1.0
+        \note If this terminal unit's heating coil is autosized, the heating capacity is sized
+        \note to be equal to the cooling capacity multiplied by this sizing ratio.
+        \note This input applies to the terminal unit heating coil and overrides the sizing
+        \note ratio entered in the AirConditioner:VariableRefrigerantFlow object.
+  A12,  \field Availability Manager List Name
+        \note Enter the name of an AvailabilityManagerAssignmentList object.
+        \type object-list
+        \object-list SystemAvailabilityManagerLists
+  A13,  \field Design Specification ZoneHVAC Sizing Object Name
+        \note Enter the name of a DesignSpecificationZoneHVACSizing object.
+        \type object-list
+        \object-list DesignSpecificationZoneHVACSizingName
+  A14,  \field Supplemental Heating Coil Name
+        \type object-list
+        \object-list HeatingCoilName
+        \note Needs to match in the supplemental heating coil object.
+  N11,  \field Maximum Supply Air Temperature from Supplemental Heater
+        \type real
+        \units C
+        \autosizable
+        \default autosize
+        \note Supply air temperature from the supplemental heater will not exceed this value.
+  N12;  \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
+        \type real
+        \maximum 21.0
+        \default 21.0
+        \units C
+        \note Supplemental heater will not operate when outdoor temperature exceeds this value.
+
 
 OS:ZoneHVAC:WaterToAirHeatPump,
         \min-fields 25

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -24264,12 +24264,10 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \type real
         \units C
         \autosizable
-        \default autosize
         \note Supply air temperature from the supplemental heater will not exceed this value.
   N12;  \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
         \type real
         \maximum 21.0
-        \default 21.0
         \units C
         \note Supplemental heater will not operate when outdoor temperature exceeds this value.
 

--- a/openstudiocore/src/energyplus/CMakeLists.txt
+++ b/openstudiocore/src/energyplus/CMakeLists.txt
@@ -624,6 +624,7 @@ set(${target_name}_test_src
   Test/ZoneHVACLowTemperatureRadiantConstFlow_GTest.cpp
   Test/ZoneHVACLowTempRadiantElectric_GTest.cpp
   Test/ZoneHVACLowTempRadiantVarFlow_GTest.cpp
+  Test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
   Test/ZonePropertyUserViewFactorsBySurfaceName_GTest.cpp
 )
 

--- a/openstudiocore/src/energyplus/Test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -84,6 +84,10 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigera
 
     ForwardTranslator ft;
 
+    // VRF defaults to DrawThrough, so components are ordered like
+    // InletNode ----- (Mixer) ---- CoolingCoil ----- HeatingCoil ----- Fan ---- (Supplemental Heating Coil) -------- OutletNode
+
+
     // No Supplemental HC
     {
       // Translate
@@ -150,15 +154,15 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigera
       WorkspaceObject idf_supHC = idf_supHCs[0];
 
       // Check Node Connections
-      // --- CC --- HC --- supHC --- Fan
+      // --- CC --- HC --- Fan --- supHC
       EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
                 idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
 
       EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
-                idf_supHC.getString(Coil_Heating_ElectricFields::AirInletNodeName).get());
-
-      EXPECT_EQ(idf_supHC.getString(Coil_Heating_ElectricFields::AirOutletNodeName).get(),
                 idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_fan.getString(Fan_OnOffFields::AirOutletNodeName).get(),
+                idf_supHC.getString(Coil_Heating_ElectricFields::AirInletNodeName).get());
 
     }
 
@@ -192,15 +196,15 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigera
       WorkspaceObject idf_supHC = idf_supHCs[0];
 
       // Check Node Connections
-      // --- CC --- HC --- supHC --- Fan
+      // --- CC --- HC --- Fan --- supHC
       EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
                 idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
 
       EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
-                idf_supHC.getString(Coil_Heating_FuelFields::AirInletNodeName).get());
-
-      EXPECT_EQ(idf_supHC.getString(Coil_Heating_FuelFields::AirOutletNodeName).get(),
                 idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_fan.getString(Fan_OnOffFields::AirOutletNodeName).get(),
+                idf_supHC.getString(Coil_Heating_FuelFields::AirInletNodeName).get());
 
     }
 
@@ -234,15 +238,15 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigera
       WorkspaceObject idf_supHC = idf_supHCs[0];
 
       // Check Node Connections
-      // --- CC --- HC --- supHC --- Fan
+      // --- CC --- HC --- Fan --- supHC
       EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
                 idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
 
       EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
-                idf_supHC.getString(Coil_Heating_WaterFields::AirInletNodeName).get());
-
-      EXPECT_EQ(idf_supHC.getString(Coil_Heating_WaterFields::AirOutletNodeName).get(),
                 idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_fan.getString(Fan_OnOffFields::AirOutletNodeName).get(),
+                idf_supHC.getString(Coil_Heating_WaterFields::AirInletNodeName).get());
 
     }
 

--- a/openstudiocore/src/energyplus/Test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -1,0 +1,304 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+// #include "../ReverseTranslator.hpp"
+
+#include "../../model/Model.hpp"
+
+#include "../../model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp"
+#include "../../model/FanOnOff.hpp"
+#include "../../model/CoilCoolingDXVariableRefrigerantFlow.hpp"
+#include "../../model/CoilHeatingDXVariableRefrigerantFlow.hpp"
+
+#include "../../model/CoilHeatingElectric.hpp"
+#include "../../model/CoilHeatingGas.hpp"
+#include "../../model/CoilHeatingWater.hpp"
+
+#include "../../model/ThermalZone.hpp"
+
+#include "../../utilities/idf/WorkspaceObject.hpp"
+
+#include <utilities/idd/IddEnums.hxx>
+#include <utilities/idd/ZoneHVAC_TerminalUnit_VariableRefrigerantFlow_FieldEnums.hxx>
+#include <utilities/idd/Coil_Cooling_DX_VariableRefrigerantFlow_FieldEnums.hxx>
+#include <utilities/idd/Coil_Heating_DX_VariableRefrigerantFlow_FieldEnums.hxx>
+#include <utilities/idd/Fan_OnOff_FieldEnums.hxx>
+
+#include <utilities/idd/Coil_Heating_Electric_FieldEnums.hxx>
+#include <utilities/idd/Coil_Heating_Fuel_FieldEnums.hxx>
+#include <utilities/idd/Coil_Heating_Water_FieldEnums.hxx>
+// Not yet supported in OS
+// #include <utilities/idd/Coil_Heating_Steam_FieldEnums.hxx>
+
+#include <resources.hxx>
+
+#include <sstream>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigerantFlow_NodeConnections)
+{
+
+    Model m;
+
+    FanOnOff fan(m);
+    CoilCoolingDXVariableRefrigerantFlow cc(m);
+    CoilHeatingDXVariableRefrigerantFlow hc(m);
+
+    ZoneHVACTerminalUnitVariableRefrigerantFlow vrf(m, cc, hc, fan);
+
+    ThermalZone z(m);
+    EXPECT_TRUE(vrf.addToThermalZone(z));
+
+    ForwardTranslator ft;
+
+    // No Supplemental HC
+    {
+      // Translate
+      Workspace w = ft.translateModel(m);
+      // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_ccs = w.getObjectsByType(IddObjectType::Coil_Cooling_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_hcs = w.getObjectsByType(IddObjectType::Coil_Heating_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_fans = w.getObjectsByType(IddObjectType::Fan_OnOff);
+      std::vector<WorkspaceObject> idf_supHCs = w.getObjectsByType(IddObjectType::Coil_Heating_Electric);
+
+      EXPECT_EQ(1u, idf_vrfs.size());
+      EXPECT_EQ(1u, idf_ccs.size());
+      EXPECT_EQ(1u, idf_hcs.size());
+      EXPECT_EQ(1u, idf_fans.size());
+      EXPECT_EQ(0u, idf_supHCs.size());
+
+
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+      WorkspaceObject idf_cc = idf_ccs[0];
+      WorkspaceObject idf_hc = idf_hcs[0];
+      WorkspaceObject idf_fan = idf_fans[0];
+
+      // Check Node Connections
+      // --- CC --- HC --- Fan
+      EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
+
+      EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+    }
+
+
+    // Supplemental HC = CoilHeatingElectric
+    {
+      CoilHeatingElectric supHC(m);
+      EXPECT_TRUE(vrf.setSupplementalHeatingCoil(supHC));
+
+      // Translate
+      Workspace w = ft.translateModel(m);
+      // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_ccs = w.getObjectsByType(IddObjectType::Coil_Cooling_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_hcs = w.getObjectsByType(IddObjectType::Coil_Heating_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_fans = w.getObjectsByType(IddObjectType::Fan_OnOff);
+      std::vector<WorkspaceObject> idf_supHCs = w.getObjectsByType(IddObjectType::Coil_Heating_Electric);
+
+      EXPECT_EQ(1u, idf_vrfs.size());
+      EXPECT_EQ(1u, idf_ccs.size());
+      EXPECT_EQ(1u, idf_hcs.size());
+      EXPECT_EQ(1u, idf_fans.size());
+      EXPECT_EQ(1u, idf_supHCs.size());
+
+
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+      WorkspaceObject idf_cc = idf_ccs[0];
+      WorkspaceObject idf_hc = idf_hcs[0];
+      WorkspaceObject idf_fan = idf_fans[0];
+      WorkspaceObject idf_supHC = idf_supHCs[0];
+
+      // Check Node Connections
+      // --- CC --- HC --- supHC --- Fan
+      EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
+
+      EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_supHC.getString(Coil_Heating_ElectricFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_supHC.getString(Coil_Heating_ElectricFields::AirOutletNodeName).get(),
+                idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+    }
+
+    // Supplemental HC = CoilHeatingGas (translates to Coil_Heating_Fuel)
+    {
+      CoilHeatingGas supHC(m);
+      EXPECT_TRUE(vrf.setSupplementalHeatingCoil(supHC));
+
+      // Translate
+      Workspace w = ft.translateModel(m);
+      // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_ccs = w.getObjectsByType(IddObjectType::Coil_Cooling_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_hcs = w.getObjectsByType(IddObjectType::Coil_Heating_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_fans = w.getObjectsByType(IddObjectType::Fan_OnOff);
+      std::vector<WorkspaceObject> idf_supHCs = w.getObjectsByType(IddObjectType::Coil_Heating_Fuel);
+
+      EXPECT_EQ(1u, idf_vrfs.size());
+      EXPECT_EQ(1u, idf_ccs.size());
+      EXPECT_EQ(1u, idf_hcs.size());
+      EXPECT_EQ(1u, idf_fans.size());
+      EXPECT_EQ(1u, idf_supHCs.size());
+
+
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+      WorkspaceObject idf_cc = idf_ccs[0];
+      WorkspaceObject idf_hc = idf_hcs[0];
+      WorkspaceObject idf_fan = idf_fans[0];
+      WorkspaceObject idf_supHC = idf_supHCs[0];
+
+      // Check Node Connections
+      // --- CC --- HC --- supHC --- Fan
+      EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
+
+      EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_supHC.getString(Coil_Heating_FuelFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_supHC.getString(Coil_Heating_FuelFields::AirOutletNodeName).get(),
+                idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+    }
+
+    // Supplemental HC = CoilHeatingWater
+    {
+      CoilHeatingWater supHC(m);
+      EXPECT_TRUE(vrf.setSupplementalHeatingCoil(supHC));
+
+      // Translate
+      Workspace w = ft.translateModel(m);
+      // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_ccs = w.getObjectsByType(IddObjectType::Coil_Cooling_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_hcs = w.getObjectsByType(IddObjectType::Coil_Heating_DX_VariableRefrigerantFlow);
+      std::vector<WorkspaceObject> idf_fans = w.getObjectsByType(IddObjectType::Fan_OnOff);
+      std::vector<WorkspaceObject> idf_supHCs = w.getObjectsByType(IddObjectType::Coil_Heating_Water);
+
+      EXPECT_EQ(1u, idf_vrfs.size());
+      EXPECT_EQ(1u, idf_ccs.size());
+      EXPECT_EQ(1u, idf_hcs.size());
+      EXPECT_EQ(1u, idf_fans.size());
+      EXPECT_EQ(1u, idf_supHCs.size());
+
+
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+      WorkspaceObject idf_cc = idf_ccs[0];
+      WorkspaceObject idf_hc = idf_hcs[0];
+      WorkspaceObject idf_fan = idf_fans[0];
+      WorkspaceObject idf_supHC = idf_supHCs[0];
+
+      // Check Node Connections
+      // --- CC --- HC --- supHC --- Fan
+      EXPECT_EQ(idf_cc.getString(Coil_Cooling_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirInletNode).get());
+
+      EXPECT_EQ(idf_hc.getString(Coil_Heating_DX_VariableRefrigerantFlowFields::CoilAirOutletNode).get(),
+                idf_supHC.getString(Coil_Heating_WaterFields::AirInletNodeName).get());
+
+      EXPECT_EQ(idf_supHC.getString(Coil_Heating_WaterFields::AirOutletNodeName).get(),
+                idf_fan.getString(Fan_OnOffFields::AirInletNodeName).get());
+
+    }
+
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslatorZoneHVACTerminalUnitVariableRefrigerantFlow_SupplementalHeating)
+{
+
+    Model m;
+
+    FanOnOff fan(m);
+    CoilCoolingDXVariableRefrigerantFlow cc(m);
+    CoilHeatingDXVariableRefrigerantFlow hc(m);
+
+    ZoneHVACTerminalUnitVariableRefrigerantFlow vrf(m, cc, hc, fan);
+
+    ThermalZone z(m);
+    EXPECT_TRUE(vrf.addToThermalZone(z));
+
+    ForwardTranslator ft;
+
+    {
+      vrf.autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+      vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(19.5);
+
+      // Translate
+      Workspace w = ft.translateModel(m);
+        // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      EXPECT_EQ(1u, idf_vrfs.size());
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+
+      EXPECT_TRUE(openstudio::istringEqual("Autosize",
+            idf_vrf.getString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater).get()));
+      EXPECT_EQ(19.5, idf_vrf.getDouble(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation).get());
+
+    }
+
+    {
+      vrf.setMaximumSupplyAirTemperaturefromSupplementalHeater(35.2);
+      vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(15.5);
+
+      // Translate
+      Workspace w = ft.translateModel(m);
+        // No Errors
+      EXPECT_EQ(0u, ft.errors().size());
+
+      std::vector<WorkspaceObject> idf_vrfs = w.getObjectsByType(IddObjectType::ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
+      EXPECT_EQ(1u, idf_vrfs.size());
+      WorkspaceObject idf_vrf = idf_vrfs[0];
+
+      EXPECT_EQ(35.2, idf_vrf.getDouble(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater).get());
+      EXPECT_EQ(15.5, idf_vrf.getDouble(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation).get());
+
+    }
+
+}

--- a/openstudiocore/src/model/CMakeLists.txt
+++ b/openstudiocore/src/model/CMakeLists.txt
@@ -436,7 +436,7 @@ set(${target_name}_src
   Construction.cpp
   ConstructionAirBoundary.hpp
   ConstructionAirBoundary_Impl.hpp
-  ConstructionAirBoundary.cpp  
+  ConstructionAirBoundary.cpp
   ConstructionBase.hpp
   ConstructionBase_Impl.hpp
   ConstructionBase.cpp
@@ -2038,6 +2038,7 @@ set(${target_name}_test_src
   test/ZoneHVACLowTempRadiantVarFlow_GTest.cpp
   test/ZoneHVACPackagedTerminalHeatPump_GTest.cpp
   test/ZoneHVACPackagedTerminalAirConditioner_GTest.cpp
+  test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
   test/ZoneHVACUnitHeater_GTest.cpp
   test/ZoneHVACUnitVentilator_GTest.cpp
   test/ZoneHVACWaterToAirHeatPump_GTest.cpp

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -453,7 +453,7 @@ namespace detail {
   }
 
   void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::resetSupplementalHeatingCoil() {
-    bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplementalHeatingCoil, "");
+    bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplementalHeatingCoilName, "");
     OS_ASSERT(result);
   }
 

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -431,7 +431,10 @@ namespace detail {
 
 
   boost::optional<ModelObject> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplementalHeatingCoilAsModelObject() const {
-    OptionalModelObject result = supplementalHeatingCoil();
+    OptionalModelObject result;
+    if (boost::optional<HVACComponent> _coil = supplementalHeatingCoil()) {
+      result = _coil.get();
+    }
     return result;
   }
 

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -585,6 +585,9 @@ ZoneHVACTerminalUnitVariableRefrigerantFlow::ZoneHVACTerminalUnitVariableRefrige
 
   setRatedTotalHeatingCapacitySizingRatio(1.0);
 
+  autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+  setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
+
   CoilCoolingDXVariableRefrigerantFlow coolingCoil(model);
   coolingCoil.setName(name().get() + " Cooling Coil");
   getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setCoolingCoil(coolingCoil);

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -424,6 +424,77 @@ namespace detail {
     return setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::HeatingCoil,component.handle());
   }
 
+
+  boost::optional<HVACComponent> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplementalHeatingCoil() const {
+    return getObject<ModelObject>().getModelObjectTarget<HVACComponent>(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplementalHeatingCoilName);
+  }
+
+
+  boost::optional<ModelObject> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplementalHeatingCoilAsModelObject() const {
+    OptionalModelObject result = supplementalHeatingCoil();
+    return result;
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setSupplementalHeatingCoil(const HVACComponent& coil) {
+    bool result = setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplementalHeatingCoilName, coil.handle());
+    return result;
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setSupplementalHeatingCoilAsModelObject(const boost::optional<ModelObject>& modelObject) {
+    if (modelObject) {
+      OptionalHVACComponent intermediate = modelObject->optionalCast<HVACComponent>();
+      if (intermediate) {
+        HVACComponent heatingCoilName(*intermediate);
+        setSupplementalHeatingCoil(heatingCoilName);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::resetSupplementalHeatingCoil() {
+    bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplementalHeatingCoil, "");
+    OS_ASSERT(result);
+  }
+
+  boost::optional<double> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::maximumSupplyAirTemperaturefromSupplementalHeater() const {
+    boost::optional<double> value = getDouble(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater, false);
+    return value;
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater) {
+    bool result = setDouble(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater, maximumSupplyAirTemperaturefromSupplementalHeater);
+    // OS_ASSERT(result);
+    return result;
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
+  }
+
+  void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::autosizeMaximumSupplyAirTemperaturefromSupplementalHeater() {
+    bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumSupplyAirTemperaturefromSupplementalHeater, "Autosize");
+    OS_ASSERT(result);
+  }
+
+  double ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const {
+    boost::optional<double> value = getDouble(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation, true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation) {
+    bool result = setDouble(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation, maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+    // OS_ASSERT(result);
+    return result;
+  }
+
+
   ModelObject ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::clone(Model model) const
   {
     ModelObject terminalClone = ZoneHVACComponent_Impl::clone(model);
@@ -438,6 +509,11 @@ namespace detail {
     if( auto coil = heatingCoil() ) {
       auto coilClone = coil->clone(model).cast<CoilHeatingDXVariableRefrigerantFlow>();
       terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setHeatingCoil(coilClone);
+    }
+
+    if (auto coil = supplementalHeatingCoil()) {
+      auto coilClone = coil->clone(model).cast<HVACComponent>();
+      terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplementalHeatingCoil(coilClone);
     }
 
     terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFan(fanClone);
@@ -460,6 +536,10 @@ namespace detail {
     }
 
     if( auto coil = heatingCoil() ) {
+      result.push_back(coil.get());
+    }
+
+    if (auto coil = supplementalHeatingCoil()) {
       result.push_back(coil.get());
     }
 
@@ -633,6 +713,9 @@ ZoneHVACTerminalUnitVariableRefrigerantFlow::ZoneHVACTerminalUnitVariableRefrige
   setZoneTerminalUnitOffParasiticElectricEnergyUse(20);
 
   setRatedTotalHeatingCapacitySizingRatio(1.0);
+
+  autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+  setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
 
   getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setCoolingCoil(coolingCoil);
 
@@ -820,6 +903,42 @@ bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setCoolingCoil(const CoilCooli
 
 bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setHeatingCoil(const CoilHeatingDXVariableRefrigerantFlow & coil) {
   return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setHeatingCoil(coil);
+}
+
+boost::optional<HVACComponent> ZoneHVACTerminalUnitVariableRefrigerantFlow::supplementalHeatingCoil() const {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->supplementalHeatingCoil();
+}
+
+bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setSupplementalHeatingCoil(const HVACComponent& coil) {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplementalHeatingCoil(coil);
+}
+
+void ZoneHVACTerminalUnitVariableRefrigerantFlow::resetSupplementalHeatingCoil() {
+  getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->resetSupplementalHeatingCoil();
+}
+
+boost::optional<double> ZoneHVACTerminalUnitVariableRefrigerantFlow::maximumSupplyAirTemperaturefromSupplementalHeater() const {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->maximumSupplyAirTemperaturefromSupplementalHeater();
+}
+
+bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater) {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setMaximumSupplyAirTemperaturefromSupplementalHeater(maximumSupplyAirTemperaturefromSupplementalHeater);
+}
+
+bool ZoneHVACTerminalUnitVariableRefrigerantFlow::isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized();
+}
+
+void ZoneHVACTerminalUnitVariableRefrigerantFlow::autosizeMaximumSupplyAirTemperaturefromSupplementalHeater() {
+  getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+}
+
+bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation) {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+}
+
+double ZoneHVACTerminalUnitVariableRefrigerantFlow::maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const {
+  return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation();
 }
 
 /// @cond

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -175,15 +175,11 @@ class MODEL_API ZoneHVACTerminalUnitVariableRefrigerantFlow : public ZoneHVACCom
   bool isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const;
 
   bool setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater);
-  void resetMaximumSupplyAirTemperaturefromSupplementalHeater(); // <=== ?
   void autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
 
   // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
   double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
-  bool isMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperationDefaulted() const; // <=== ?
   bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
-  void resetMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(); // <=== ?
-
 
   boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
 

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -159,6 +159,32 @@ class MODEL_API ZoneHVACTerminalUnitVariableRefrigerantFlow : public ZoneHVACCom
 
   bool setRatedTotalHeatingCapacitySizingRatio(double ratedTotalHeatingCapacitySizingRatio);
 
+
+
+  // \field Availability Manager List Name
+  // \field Design Specification ZoneHVAC Sizing Object Name
+
+
+  // Supplemental Heating Coil Name
+  boost::optional<HVACComponent> supplementalHeatingCoil() const;
+  bool setSupplementalHeatingCoil(const HVACComponent& coil);
+  void resetSupplementalHeatingCoil();
+
+  // Maximum Supply Air Temperature from Supplemental Heater (autosized)
+  boost::optional<double> maximumSupplyAirTemperaturefromSupplementalHeater() const;
+  bool isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const;
+
+  bool setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater);
+  void resetMaximumSupplyAirTemperaturefromSupplementalHeater(); // <=== ?
+  void autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+
+  // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
+  double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
+  bool isMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperationDefaulted() const; // <=== ?
+  bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+  void resetMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(); // <=== ?
+
+
   boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
 
   boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const ;

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -173,7 +173,6 @@ class MODEL_API ZoneHVACTerminalUnitVariableRefrigerantFlow : public ZoneHVACCom
   // Maximum Supply Air Temperature from Supplemental Heater (autosized)
   boost::optional<double> maximumSupplyAirTemperaturefromSupplementalHeater() const;
   bool isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const;
-
   bool setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater);
   void autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
 
@@ -181,19 +180,19 @@ class MODEL_API ZoneHVACTerminalUnitVariableRefrigerantFlow : public ZoneHVACCom
   double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
   bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateWhenNoHeatingisNeeded() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateWhenNoHeatingisNeeded() const;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const ;
+  boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const ;
+  boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const;
 
-  boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
+  boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const;
 
 
 

--- a/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/openstudiocore/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -75,6 +75,22 @@ namespace detail {
 
     virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
+    virtual void autosize() override;
+
+    virtual void applySizingValues() override;
+
+    virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;
+
+    virtual std::vector<std::string> emsInternalVariableNames() const override;
+
+    virtual unsigned inletPort() const override;
+
+    virtual unsigned outletPort() const override;
+
+    virtual ModelObject clone(Model model) const override;
+
+    virtual std::vector<ModelObject> children() const override;
+
     //@}
     /** @name Getters */
     //@{
@@ -123,27 +139,34 @@ namespace detail {
 
     double ratedTotalHeatingCapacitySizingRatio() const;
 
-    boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
+    // Supplemental Heating Coil Name
+    boost::optional<HVACComponent> supplementalHeatingCoil() const;
+    bool setSupplementalHeatingCoil(const HVACComponent& coil);
+    void resetSupplementalHeatingCoil();
 
-    boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const ;
+    // Maximum Supply Air Temperature from Supplemental Heater (autosized)
+    boost::optional<double> maximumSupplyAirTemperaturefromSupplementalHeater() const;
+    bool isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized() const;
+    bool setMaximumSupplyAirTemperaturefromSupplementalHeater(double maximumSupplyAirTemperaturefromSupplementalHeater);
+    void autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
 
-    boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const ;
+    // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
+    double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
+    bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
 
-    boost::optional<double> autosizedSupplyAirFlowRateWhenNoHeatingisNeeded() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 
-    boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const;
 
-    boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const;
 
-    boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const ;
+    boost::optional<double> autosizedSupplyAirFlowRateWhenNoHeatingisNeeded() const;
 
-    virtual void autosize() override;
+    boost::optional<double> autosizedOutdoorAirFlowRateDuringCoolingOperation() const;
 
-    virtual void applySizingValues() override;
+    boost::optional<double> autosizedOutdoorAirFlowRateDuringHeatingOperation() const;
 
-    virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;
-
-    virtual std::vector<std::string> emsInternalVariableNames() const override;
+    boost::optional<double> autosizedOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded() const;
 
     //@}
     /** @name Setters */
@@ -191,19 +214,12 @@ namespace detail {
     /** @name Other */
     //@{
 
-    unsigned inletPort() const override;
-
-    unsigned outletPort() const override;
-
     bool setSupplyAirFan(const HVACComponent & component);
 
     bool setCoolingCoil(const CoilCoolingDXVariableRefrigerantFlow & component);
 
     bool setHeatingCoil(const CoilHeatingDXVariableRefrigerantFlow & component);
 
-    ModelObject clone(Model model) const override;
-
-    std::vector<ModelObject> children() const override;
 
     //@}
    protected:
@@ -214,6 +230,10 @@ namespace detail {
     boost::optional<Schedule> optionalTerminalUnitAvailabilityschedule() const;
     boost::optional<Schedule> optionalSupplyAirFanOperatingModeSchedule() const;
     boost::optional<HVACComponent> optionalSupplyAirFan() const;
+
+    boost::optional<ModelObject> supplementalHeatingCoilAsModelObject() const;
+    bool setSupplementalHeatingCoilAsModelObject(const boost::optional<ModelObject>& modelObject);
+
   };
 
 } // detail

--- a/openstudiocore/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -1,0 +1,134 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "ModelFixture.hpp"
+#include "../Model.hpp"
+
+#include "../Node.hpp"
+
+#include "../FanOnOff.hpp"
+#include "../HVACComponent.hpp"
+#include "../HVACComponent_Impl.hpp"
+
+#include "../ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp"
+#include "../CoilCoolingDXVariableRefrigerantFlow.hpp"
+#include "../CoilHeatingDXVariableRefrigerantFlow.hpp"
+
+#include "../CoilHeatingElectric.hpp"
+
+#include "../ScheduleConstant.hpp"
+#include "../Schedule.hpp"
+#include "../ThermalZone.hpp"
+
+#include "../../utilities/core/Compare.hpp"
+
+using namespace openstudio;
+using namespace openstudio::model;
+
+TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_Default_Ctor)
+{
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  ASSERT_EXIT (
+  {
+    Model model;
+
+    ZoneHVACTerminalUnitVariableRefrigerantFlow vrfTerminal(model);
+
+    exit(0);
+  } ,
+    ::testing::ExitedWithCode(0), "" );
+}
+
+TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_Explicit_Ctor)
+{
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  ASSERT_EXIT (
+  {
+    Model model;
+
+    FanOnOff fan(model);
+    CoilCoolingDXVariableRefrigerantFlow cc(model);
+    CoilHeatingDXVariableRefrigerantFlow hc(model);
+
+    ZoneHVACTerminalUnitVariableRefrigerantFlow vrfTerminal(model, cc, hc, fan);
+
+    exit(0);
+  } ,
+    ::testing::ExitedWithCode(0), "" );
+}
+
+TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_SupplementalHeating) {
+
+  Model m;
+  ZoneHVACTerminalUnitVariableRefrigerantFlow vrf(m);
+
+  // test defaults
+  EXPECT_FALSE(vrf.supplementalHeatingCoil());
+  EXPECT_TRUE(vrf.isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized());
+  EXPECT_FALSE(vrf.maximumSupplyAirTemperaturefromSupplementalHeater());
+  EXPECT_EQ(21.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
+
+  // Supplemental Coil
+  CoilHeatingElectric supplemental_hc(m);
+  EXPECT_TRUE(vrf.setSupplementalHeatingCoil(supplemental_hc));
+  ASSERT_TRUE(vrf.supplementalHeatingCoil());
+  EXPECT_EQ(supplemental_hc, vrf.supplementalHeatingCoil().get());
+
+  CoilHeatingDXVariableRefrigerantFlow hc_wrong_type(m);
+  EXPECT_FALSE(vrf.setSupplementalHeatingCoil(hc_wrong_type));
+  ASSERT_TRUE(vrf.supplementalHeatingCoil());
+  EXPECT_EQ(supplemental_hc, vrf.supplementalHeatingCoil().get());
+
+  vrf.resetSupplementalHeatingCoil();
+  EXPECT_FALSE(vrf.supplementalHeatingCoil());
+
+
+  // Max SAT
+  vrf.setMaximumSupplyAirTemperaturefromSupplementalHeater(35.0);
+  EXPECT_FALSE(vrf.isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized());
+  ASSERT_TRUE(vrf.maximumSupplyAirTemperaturefromSupplementalHeater());
+  EXPECT_EQ(35.0, vrf.maximumSupplyAirTemperaturefromSupplementalHeater().get());
+
+  vrf.autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
+  EXPECT_TRUE(vrf.isMaximumSupplyAirTemperaturefromSupplementalHeaterAutosized());
+  EXPECT_FALSE(vrf.maximumSupplyAirTemperaturefromSupplementalHeater());
+
+
+  // Max OATdb for supplemental heater
+  EXPECT_TRUE(vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(19.0));
+  EXPECT_EQ(19.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
+  EXPECT_FALSE(vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(45.0)); // > max
+  EXPECT_EQ(45.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
+
+}
+

--- a/openstudiocore/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -128,7 +128,7 @@ TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_SupplementalHea
   EXPECT_TRUE(vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(19.0));
   EXPECT_EQ(19.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
   EXPECT_FALSE(vrf.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(45.0)); // > max
-  EXPECT_EQ(45.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
+  EXPECT_EQ(19.0, vrf.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
 
 }
 

--- a/openstudiocore/src/openstudio_lib/IconLibrary.cpp
+++ b/openstudiocore/src/openstudio_lib/IconLibrary.cpp
@@ -69,6 +69,7 @@ namespace openstudio {
 
 IconLibrary::IconLibrary()
 {
+  m_icons[openstudio::IddObjectType(openstudio::IddObjectType::OS_AirConditioner_VariableRefrigerantFlow).value()] = new QPixmap(":images/vrf_outdoor.png");
   m_icons[openstudio::IddObjectType(openstudio::IddObjectType::OS_AirLoopHVAC_OutdoorAirSystem).value()] = new QPixmap(":images/OAMixer.png");
   m_icons[openstudio::IddObjectType(openstudio::IddObjectType::OS_AirLoopHVAC_UnitaryCoolOnly).value()] = new QPixmap(":images/DXCoolingCoil.png");
   m_icons[openstudio::IddObjectType(openstudio::IddObjectType::OS_AirLoopHVAC_UnitaryHeatPump_AirToAir).value()] = new QPixmap(":images/heat_pump3.png");
@@ -218,7 +219,7 @@ IconLibrary::IconLibrary()
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Building).value()] = new QPixmap(":images/mini_icons/building.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_BuildingStory).value()] = new QPixmap(":images/mini_icons/building_story.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction).value()] = new QPixmap(":images/mini_icons/construction.png");
-  m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_AirBoundary).value()] = new QPixmap(":images/mini_icons/construction_air_boundary.png");  
+  m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_AirBoundary).value()] = new QPixmap(":images/mini_icons/construction_air_boundary.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_CfactorUndergroundWall).value()] = new QPixmap(":images/mini_icons/construction_undergnd.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_FfactorGroundFloor).value()] = new QPixmap(":images/mini_icons/construction_gnd.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_InternalSource).value()] = new QPixmap(":images/mini_icons/construct_inter_source.png");

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -135,6 +135,7 @@
     <rule IddField="Supplemental Heating Coil Name" Access="HIDDEN"/>
     <rule IddField="Outdoor Dry-Bulb Temperature Sensor Node Name" Access="HIDDEN"/>
     <rule IddField="Availability Manager List Name" Access="HIDDEN"/>
+    <rule IddField="Design Specification ZoneHVAC Sizing Object Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlow">
     <rule IddField="Low Temp Radiant Constant Flow Heating Coil Name" Access="HIDDEN"/>
@@ -1043,6 +1044,9 @@
     <rule IddField="Outside Air Mixer" Access="HIDDEN"/>
     <rule IddField="Cooling Coil" Access="HIDDEN"/>
     <rule IddField="Heating Coil" Access="HIDDEN"/>
+    <rule IddField="Availability Manager List Name" Access="HIDDEN"/>
+    <rule IddField="Design Specification ZoneHVAC Sizing Object Name" Access="HIDDEN"/>
+    <rule IddField="Supplemental Heating Coil Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_Coil_Heating_DX_VariableRefrigerantFlow">
     <rule IddField="Coil Air Inlet Node" Access="HIDDEN"/>

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -4710,6 +4710,30 @@ std::string VersionTranslator::update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, c
       m_refactored.push_back(RefactoredObjectData(object, newObject));
       ss << newObject;
 
+
+    } else if (iddname == "OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow") {
+      auto iddObject = idd_2_9_0.getObject("OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow");
+      IdfObject newObject(iddObject.get());
+
+      // Added fields at end, so copy everything existing in place
+      for (size_t i = 0; i < object.numFields(); ++i) {
+        if ((value = object.getString(i))) {
+          newObject.setString(i, value.get());
+        }
+      }
+
+      // 21 = AVM List
+      // 22 = Design Spec ZoneHVAC Sizing
+      // 23 = Supplemental Heating Coil (optional)
+      // Maximum SAT for Supplemental Heater
+      newObject.setString(24, "Autosize");
+      // Maximum OATdb for Supplemental Heater
+      newObject.setDouble(25, 21.0);
+
+      // Register refactored
+      m_refactored.push_back(RefactoredObjectData(object, newObject));
+      ss << newObject;
+
     // No-op
     } else {
       ss << object;


### PR DESCRIPTION
Fix #3645 - Add support for supplemental heat to `ZoneHVAC:TerminalUnit:VariableRefrigerantFlow`
