### PR TITLE
HeatPumpWaterToWaterEquationFit required fields not initialized in hvac_library

### DIFF
--- a/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
@@ -10797,7 +10797,10 @@ OS:HeatPump:WaterToWater:EquationFit:Cooling,
   0.96265085,                             !- Cooling Compressor Power Coefficient 2
   8.69489229,                             !- Cooling Compressor Power Coefficient 3
   0.02501669,                             !- Cooling Compressor Power Coefficient 4
-  -0.20132665;                            !- Cooling Compressor Power Coefficient 5
+  -0.20132665,                            !- Cooling Compressor Power Coefficient 5
+  8.0,                                    !- Reference Coefficient of Performance
+  1.0,                                    !- Sizing Factor
+  ;                                       !- Companion Heating Heat Pump Name
 
 OS:HeatPump:WaterToWater:EquationFit:Heating,
   {80f71496-82ae-4ad8-b677-1ca17b0ca84a}, !- Handle
@@ -10820,8 +10823,9 @@ OS:HeatPump:WaterToWater:EquationFit:Heating,
   1.29660976,                             !- Heating Compressor Power Coefficient 3
   -0.21629222,                            !- Heating Compressor Power Coefficient 4
   0.033862378,                            !- Heating Compressor Power Coefficient 5
-  ,                                       !- Reference Coefficient of Performance
-  ;                                       !- Sizing Factor
+  7.5,                                    !- Reference Coefficient of Performance
+  1.0,                                    !- Sizing Factor
+  ;                                       !- Companion Cooling Heat Pump Name
 
 OS:Generator:MicroTurbine,
   {5f037e71-1ba0-4b22-9d0d-0ab372356d49}, !- Handle


### PR DESCRIPTION
Fix #3680 HeatPumpWaterToWaterEquationFit frequired fields not initialized in Hvac_library



Something must have gone wrong since I see VT rules were added, cf https://github.com/jmarrec/OpenStudio/commit/19037a79c66fb2ffb849095ee37c7874e2846963#diff-f40f617c05070be7f31161a497d2d1ae. I suppose hvac_library.osm was updated BEFORE the VT rules were written, or the version was bumped manually.

----

After fix: 

**HeatPump:WaterToWater:EquationFit:Cooling**

![image](https://user-images.githubusercontent.com/5479063/65604981-9f341080-dfa8-11e9-9858-c2087ad7d942.png)

**HeatPump:WaterToWater:EquationFit:Heating**

![image](https://user-images.githubusercontent.com/5479063/65605220-05b92e80-dfa9-11e9-8961-bcb8538381f2.png)




