### PR TITLE
Add missing methods for HeaderedPumpsConstantSpeed and HeaderedPumpsVariableSpeed

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeaderedPumpsConstantSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeaderedPumpsConstantSpeed.cpp
@@ -139,6 +139,23 @@ boost::optional<IdfObject> ForwardTranslator::translateHeaderedPumpsConstantSpee
     idfObject.setDouble(HeaderedPumps_ConstantSpeedFields::SkinLossRadiativeFraction,value);
   }
 
+  {
+    auto s = modelObject.designPowerSizingMethod();
+    idfObject.setString(HeaderedPumps_ConstantSpeedFields::DesignPowerSizingMethod, s);
+  }
+
+
+  {
+    auto value = modelObject.designElectricPowerPerUnitFlowRate();
+    idfObject.setDouble(HeaderedPumps_ConstantSpeedFields::DesignElectricPowerperUnitFlowRate, value);
+  }
+
+
+  {
+    auto value = modelObject.designShaftPowerPerUnitFlowRatePerUnitHead();
+    idfObject.setDouble(HeaderedPumps_ConstantSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead, value);
+  }
+
   // End Use Subcategory
   idfObject.setString(HeaderedPumps_ConstantSpeedFields::EndUseSubcategory, modelObject.endUseSubcategory());
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeaderedPumpsVariableSpeed.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateHeaderedPumpsVariableSpeed.cpp
@@ -169,6 +169,23 @@ boost::optional<IdfObject> ForwardTranslator::translateHeaderedPumpsVariableSpee
     idfObject.setDouble(HeaderedPumps_VariableSpeedFields::SkinLossRadiativeFraction,value);
   }
 
+  {
+    auto s = modelObject.designPowerSizingMethod();
+    idfObject.setString(HeaderedPumps_VariableSpeedFields::DesignPowerSizingMethod, s);
+  }
+
+
+  {
+    auto value = modelObject.designElectricPowerPerUnitFlowRate();
+    idfObject.setDouble(HeaderedPumps_VariableSpeedFields::DesignElectricPowerperUnitFlowRate, value);
+  }
+
+
+  {
+    auto value = modelObject.designShaftPowerPerUnitFlowRatePerUnitHead();
+    idfObject.setDouble(HeaderedPumps_VariableSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead, value);
+  }
+
   // End Use Subcategory
   idfObject.setString(HeaderedPumps_VariableSpeedFields::EndUseSubcategory, modelObject.endUseSubcategory());
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
@@ -206,7 +206,7 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsConstantSpeed_Impl::setFlowSequencingControlScheme(std::string flowSequencingControlScheme) {
+  bool HeaderedPumpsConstantSpeed_Impl::setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme) {
     bool result = setString(OS_HeaderedPumps_ConstantSpeedFields::FlowSequencingControlScheme, flowSequencingControlScheme);
     return result;
   }
@@ -241,12 +241,12 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsConstantSpeed_Impl::setPumpControlType(std::string pumpControlType) {
+  bool HeaderedPumpsConstantSpeed_Impl::setPumpControlType(const std::string& pumpControlType) {
     bool result = setString(OS_HeaderedPumps_ConstantSpeedFields::PumpControlType, pumpControlType);
     return result;
   }
 
-  bool HeaderedPumpsConstantSpeed_Impl::setPumpFlowRateSchedule(Schedule& schedule) {
+  bool HeaderedPumpsConstantSpeed_Impl::setPumpFlowRateSchedule(const Schedule& schedule) {
     bool result = setSchedule(OS_HeaderedPumps_ConstantSpeedFields::PumpFlowRateSchedule,
                               "HeaderedPumpsConstantSpeed",
                               "Pump Flow Rate Schedule",
@@ -444,7 +444,7 @@ bool HeaderedPumpsConstantSpeed::setNumberofPumpsinBank(int numberofPumpsinBank)
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setNumberofPumpsinBank(numberofPumpsinBank);
 }
 
-bool HeaderedPumpsConstantSpeed::setFlowSequencingControlScheme(std::string flowSequencingControlScheme) {
+bool HeaderedPumpsConstantSpeed::setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme) {
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setFlowSequencingControlScheme(flowSequencingControlScheme);
 }
 
@@ -468,11 +468,11 @@ bool HeaderedPumpsConstantSpeed::setFractionofMotorInefficienciestoFluidStream(d
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setFractionofMotorInefficienciestoFluidStream(fractionofMotorInefficienciestoFluidStream);
 }
 
-bool HeaderedPumpsConstantSpeed::setPumpControlType(std::string pumpControlType) {
+bool HeaderedPumpsConstantSpeed::setPumpControlType(const std::string& pumpControlType) {
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setPumpControlType(pumpControlType);
 }
 
-bool HeaderedPumpsConstantSpeed::setPumpFlowRateSchedule(Schedule& schedule) {
+bool HeaderedPumpsConstantSpeed::setPumpFlowRateSchedule(const Schedule& schedule) {
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setPumpFlowRateSchedule(schedule);
 }
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
@@ -336,6 +336,36 @@ namespace detail {
     return types;
   }
 
+  std::string HeaderedPumpsConstantSpeed_Impl::designPowerSizingMethod() const {
+    auto value = getString(OS_HeaderedPumps_ConstantSpeedFields::DesignPowerSizingMethod,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsConstantSpeed_Impl::setDesignPowerSizingMethod(const std::string & designPowerSizingMethod) {
+    return setString(OS_HeaderedPumps_ConstantSpeedFields::DesignPowerSizingMethod,designPowerSizingMethod);
+  }
+
+  double HeaderedPumpsConstantSpeed_Impl::designElectricPowerPerUnitFlowRate() const {
+    auto value = getDouble(OS_HeaderedPumps_ConstantSpeedFields::DesignElectricPowerperUnitFlowRate,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsConstantSpeed_Impl::setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate) {
+    return setDouble(OS_HeaderedPumps_ConstantSpeedFields::DesignElectricPowerperUnitFlowRate,designElectricPowerPerUnitFlowRate);
+  }
+
+  double HeaderedPumpsConstantSpeed_Impl::designShaftPowerPerUnitFlowRatePerUnitHead() const {
+    auto value = getDouble(OS_HeaderedPumps_ConstantSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsConstantSpeed_Impl::setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead) {
+    return setDouble(OS_HeaderedPumps_ConstantSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead,designShaftPowerPerUnitFlowRatePerUnitHead);
+  }
+
   std::string HeaderedPumpsConstantSpeed_Impl::endUseSubcategory() const {
     auto value = getString(OS_HeaderedPumps_ConstantSpeedFields::EndUseSubcategory, true);
     OS_ASSERT(value);
@@ -363,6 +393,10 @@ HeaderedPumpsConstantSpeed::HeaderedPumpsConstantSpeed(const Model& model)
   setPumpControlType("Continuous");
   setSkinLossRadiativeFraction(0.1);
 
+  setDesignPowerSizingMethod("PowerPerFlowPerPressure");
+  setDesignElectricPowerPerUnitFlowRate(348701.1);
+  setDesignShaftPowerPerUnitFlowRatePerUnitHead(1.282051282);
+
   setEndUseSubcategory("General");
 }
 
@@ -378,6 +412,11 @@ std::vector<std::string> HeaderedPumpsConstantSpeed::flowSequencingControlScheme
 std::vector<std::string> HeaderedPumpsConstantSpeed::pumpControlTypeValues() {
   return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
                         OS_HeaderedPumps_ConstantSpeedFields::PumpControlType);
+}
+
+std::vector<std::string> HeaderedPumpsConstantSpeed::designPowerSizingMethodValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_HeaderedPumps_ConstantSpeedFields::DesignPowerSizingMethod);
 }
 
 boost::optional<double> HeaderedPumpsConstantSpeed::totalRatedFlowRate() const {
@@ -492,6 +531,29 @@ bool HeaderedPumpsConstantSpeed::setSkinLossRadiativeFraction(double skinLossRad
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setSkinLossRadiativeFraction(skinLossRadiativeFraction);
 }
 
+std::string HeaderedPumpsConstantSpeed::designPowerSizingMethod() const {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->designPowerSizingMethod();
+}
+
+bool HeaderedPumpsConstantSpeed::setDesignPowerSizingMethod(const std::string & designPowerSizingMethod) {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setDesignPowerSizingMethod(designPowerSizingMethod);
+}
+
+double HeaderedPumpsConstantSpeed::designElectricPowerPerUnitFlowRate() const {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->designElectricPowerPerUnitFlowRate();
+}
+
+bool HeaderedPumpsConstantSpeed::setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate) {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setDesignElectricPowerPerUnitFlowRate(designElectricPowerPerUnitFlowRate);
+}
+
+double HeaderedPumpsConstantSpeed::designShaftPowerPerUnitFlowRatePerUnitHead() const {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->designShaftPowerPerUnitFlowRatePerUnitHead();
+}
+
+bool HeaderedPumpsConstantSpeed::setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead) {
+  return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setDesignShaftPowerPerUnitFlowRatePerUnitHead(designShaftPowerPerUnitFlowRatePerUnitHead);
+}
 
 std::string HeaderedPumpsConstantSpeed::endUseSubcategory() const {
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->endUseSubcategory();

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.cpp
@@ -246,7 +246,7 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsConstantSpeed_Impl::setPumpFlowRateSchedule(const Schedule& schedule) {
+  bool HeaderedPumpsConstantSpeed_Impl::setPumpFlowRateSchedule(Schedule& schedule) {
     bool result = setSchedule(OS_HeaderedPumps_ConstantSpeedFields::PumpFlowRateSchedule,
                               "HeaderedPumpsConstantSpeed",
                               "Pump Flow Rate Schedule",
@@ -511,7 +511,7 @@ bool HeaderedPumpsConstantSpeed::setPumpControlType(const std::string& pumpContr
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setPumpControlType(pumpControlType);
 }
 
-bool HeaderedPumpsConstantSpeed::setPumpFlowRateSchedule(const Schedule& schedule) {
+bool HeaderedPumpsConstantSpeed::setPumpFlowRateSchedule(Schedule& schedule) {
   return getImpl<detail::HeaderedPumpsConstantSpeed_Impl>()->setPumpFlowRateSchedule(schedule);
 }
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
@@ -130,7 +130,7 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   bool setPumpControlType(const std::string& pumpControlType);
 
-  bool setPumpFlowRateSchedule(const Schedule& schedule);
+  bool setPumpFlowRateSchedule(Schedule& schedule);
 
   void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
@@ -96,6 +96,12 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   double skinLossRadiativeFraction() const;
 
+  std::string designPowerSizingMethod() const;
+
+  double designElectricPowerPerUnitFlowRate() const;
+
+  double designShaftPowerPerUnitFlowRatePerUnitHead() const;
+
   std::string endUseSubcategory() const;
 
   //@}
@@ -132,7 +138,13 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   bool setSkinLossRadiativeFraction(double skinLossRadiativeFraction);
 
-  bool setEndUseSubcategory(const std::string & endUseSubcategory);
+  bool setDesignPowerSizingMethod(const std::string& designPowerSizingMethod);
+
+  bool setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate);
+
+  bool setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead);
+
+  bool setEndUseSubcategory(const std::string& endUseSubcategory);
 
   //@}
   /** @name Other */

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
@@ -64,6 +64,8 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   static std::vector<std::string> pumpControlTypeValues();
 
+  static std::vector<std::string> designPowerSizingMethodValues();
+
   /** @name Getters */
   //@{
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed.hpp
@@ -114,7 +114,7 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   bool setNumberofPumpsinBank(int numberofPumpsinBank);
 
-  bool setFlowSequencingControlScheme(std::string flowSequencingControlScheme);
+  bool setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme);
 
   bool setRatedPumpHead(double ratedPumpHead);
 
@@ -126,9 +126,9 @@ class MODEL_API HeaderedPumpsConstantSpeed : public StraightComponent {
 
   bool setFractionofMotorInefficienciestoFluidStream(double fractionofMotorInefficienciestoFluidStream);
 
-  bool setPumpControlType(std::string pumpControlType);
+  bool setPumpControlType(const std::string& pumpControlType);
 
-  bool setPumpFlowRateSchedule(Schedule& schedule);
+  bool setPumpFlowRateSchedule(const Schedule& schedule);
 
   void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
@@ -109,11 +109,17 @@ namespace detail {
 
     double skinLossRadiativeFraction() const;
 
+    std::string designPowerSizingMethod() const;
+
+    double designElectricPowerPerUnitFlowRate() const;
+
+    double designShaftPowerPerUnitFlowRatePerUnitHead() const;
+
+    std::string endUseSubcategory() const;
+
     boost::optional<double> autosizedTotalRatedFlowRate() const ;
 
     boost::optional<double> autosizedRatedPowerConsumption() const ;
-
-    std::string endUseSubcategory() const;
 
     //@}
     /** @name Setters */
@@ -149,7 +155,13 @@ namespace detail {
 
     bool setSkinLossRadiativeFraction(double skinLossRadiativeFraction);
 
-    bool setEndUseSubcategory(const std::string & endUseSubcategory);
+    bool setDesignPowerSizingMethod(const std::string& designPowerSizingMethod);
+
+    bool setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate);
+
+    bool setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead);
+
+    bool setEndUseSubcategory(const std::string& endUseSubcategory);
 
     //@}
     /** @name Other */

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
@@ -145,7 +145,7 @@ namespace detail {
 
     bool setPumpControlType(const std::string& pumpControlType);
 
-    bool setPumpFlowRateSchedule(const Schedule& schedule);
+    bool setPumpFlowRateSchedule(Schedule& schedule);
 
     void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsConstantSpeed_Impl.hpp
@@ -131,7 +131,7 @@ namespace detail {
 
     bool setNumberofPumpsinBank(int numberofPumpsinBank);
 
-    bool setFlowSequencingControlScheme(std::string flowSequencingControlScheme);
+    bool setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme);
 
     bool setRatedPumpHead(double ratedPumpHead);
 
@@ -143,9 +143,9 @@ namespace detail {
 
     bool setFractionofMotorInefficienciestoFluidStream(double fractionofMotorInefficienciestoFluidStream);
 
-    bool setPumpControlType(std::string pumpControlType);
+    bool setPumpControlType(const std::string& pumpControlType);
 
-    bool setPumpFlowRateSchedule(Schedule& schedule);
+    bool setPumpFlowRateSchedule(const Schedule& schedule);
 
     void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
@@ -306,7 +306,7 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsVariableSpeed_Impl::setPumpFlowRateSchedule(const Schedule& schedule) {
+  bool HeaderedPumpsVariableSpeed_Impl::setPumpFlowRateSchedule(Schedule& schedule) {
     bool result = setSchedule(OS_HeaderedPumps_VariableSpeedFields::PumpFlowRateSchedule,
                               "HeaderedPumpsVariableSpeed",
                               "Pump Flow Rate Schedule",
@@ -616,7 +616,7 @@ bool HeaderedPumpsVariableSpeed::setPumpControlType(const std::string& pumpContr
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setPumpControlType(pumpControlType);
 }
 
-bool HeaderedPumpsVariableSpeed::setPumpFlowRateSchedule(const Schedule& schedule) {
+bool HeaderedPumpsVariableSpeed::setPumpFlowRateSchedule(Schedule& schedule) {
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setPumpFlowRateSchedule(schedule);
 }
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
@@ -396,6 +396,36 @@ namespace detail {
     return types;
   }
 
+  std::string HeaderedPumpsVariableSpeed_Impl::designPowerSizingMethod() const {
+    auto value = getString(OS_HeaderedPumps_VariableSpeedFields::DesignPowerSizingMethod,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsVariableSpeed_Impl::setDesignPowerSizingMethod(const std::string & designPowerSizingMethod) {
+    return setString(OS_HeaderedPumps_VariableSpeedFields::DesignPowerSizingMethod,designPowerSizingMethod);
+  }
+
+  double HeaderedPumpsVariableSpeed_Impl::designElectricPowerPerUnitFlowRate() const {
+    auto value = getDouble(OS_HeaderedPumps_VariableSpeedFields::DesignElectricPowerperUnitFlowRate,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsVariableSpeed_Impl::setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate) {
+    return setDouble(OS_HeaderedPumps_VariableSpeedFields::DesignElectricPowerperUnitFlowRate,designElectricPowerPerUnitFlowRate);
+  }
+
+  double HeaderedPumpsVariableSpeed_Impl::designShaftPowerPerUnitFlowRatePerUnitHead() const {
+    auto value = getDouble(OS_HeaderedPumps_VariableSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool HeaderedPumpsVariableSpeed_Impl::setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead) {
+    return setDouble(OS_HeaderedPumps_VariableSpeedFields::DesignShaftPowerperUnitFlowRateperUnitHead,designShaftPowerPerUnitFlowRatePerUnitHead);
+  }
+
   std::string HeaderedPumpsVariableSpeed_Impl::endUseSubcategory() const {
     auto value = getString(OS_HeaderedPumps_VariableSpeedFields::EndUseSubcategory, true);
     OS_ASSERT(value);
@@ -428,6 +458,10 @@ HeaderedPumpsVariableSpeed::HeaderedPumpsVariableSpeed(const Model& model)
   setPumpControlType("Continuous");
   setSkinLossRadiativeFraction(0.1);
 
+  setDesignPowerSizingMethod("PowerPerFlowPerPressure");
+  setDesignElectricPowerPerUnitFlowRate(348701.1);
+  setDesignShaftPowerPerUnitFlowRatePerUnitHead(1.282051282);
+
   setEndUseSubcategory("General");
 }
 
@@ -443,6 +477,11 @@ std::vector<std::string> HeaderedPumpsVariableSpeed::flowSequencingControlScheme
 std::vector<std::string> HeaderedPumpsVariableSpeed::pumpControlTypeValues() {
   return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
                         OS_HeaderedPumps_VariableSpeedFields::PumpControlType);
+}
+
+std::vector<std::string> HeaderedPumpsVariableSpeed::designPowerSizingMethodValues() {
+  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
+                        OS_HeaderedPumps_VariableSpeedFields::DesignPowerSizingMethod);
 }
 
 boost::optional<double> HeaderedPumpsVariableSpeed::totalRatedFlowRate() const {
@@ -595,6 +634,30 @@ void HeaderedPumpsVariableSpeed::resetThermalZone() {
 
 bool HeaderedPumpsVariableSpeed::setSkinLossRadiativeFraction(double skinLossRadiativeFraction) {
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setSkinLossRadiativeFraction(skinLossRadiativeFraction);
+}
+
+std::string HeaderedPumpsVariableSpeed::designPowerSizingMethod() const {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->designPowerSizingMethod();
+}
+
+bool HeaderedPumpsVariableSpeed::setDesignPowerSizingMethod(const std::string & designPowerSizingMethod) {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setDesignPowerSizingMethod(designPowerSizingMethod);
+}
+
+double HeaderedPumpsVariableSpeed::designElectricPowerPerUnitFlowRate() const {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->designElectricPowerPerUnitFlowRate();
+}
+
+bool HeaderedPumpsVariableSpeed::setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate) {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setDesignElectricPowerPerUnitFlowRate(designElectricPowerPerUnitFlowRate);
+}
+
+double HeaderedPumpsVariableSpeed::designShaftPowerPerUnitFlowRatePerUnitHead() const {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->designShaftPowerPerUnitFlowRatePerUnitHead();
+}
+
+bool HeaderedPumpsVariableSpeed::setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead) {
+  return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setDesignShaftPowerPerUnitFlowRatePerUnitHead(designShaftPowerPerUnitFlowRatePerUnitHead);
 }
 
 std::string HeaderedPumpsVariableSpeed::endUseSubcategory() const {

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.cpp
@@ -237,7 +237,7 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsVariableSpeed_Impl::setFlowSequencingControlScheme(std::string flowSequencingControlScheme) {
+  bool HeaderedPumpsVariableSpeed_Impl::setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme) {
     bool result = setString(OS_HeaderedPumps_VariableSpeedFields::FlowSequencingControlScheme, flowSequencingControlScheme);
     return result;
   }
@@ -301,12 +301,12 @@ namespace detail {
     return result;
   }
 
-  bool HeaderedPumpsVariableSpeed_Impl::setPumpControlType(std::string pumpControlType) {
+  bool HeaderedPumpsVariableSpeed_Impl::setPumpControlType(const std::string& pumpControlType) {
     bool result = setString(OS_HeaderedPumps_VariableSpeedFields::PumpControlType, pumpControlType);
     return result;
   }
 
-  bool HeaderedPumpsVariableSpeed_Impl::setPumpFlowRateSchedule(Schedule& schedule) {
+  bool HeaderedPumpsVariableSpeed_Impl::setPumpFlowRateSchedule(const Schedule& schedule) {
     bool result = setSchedule(OS_HeaderedPumps_VariableSpeedFields::PumpFlowRateSchedule,
                               "HeaderedPumpsVariableSpeed",
                               "Pump Flow Rate Schedule",
@@ -529,7 +529,7 @@ bool HeaderedPumpsVariableSpeed::setNumberofPumpsinBank(int numberofPumpsinBank)
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setNumberofPumpsinBank(numberofPumpsinBank);
 }
 
-bool HeaderedPumpsVariableSpeed::setFlowSequencingControlScheme(std::string flowSequencingControlScheme) {
+bool HeaderedPumpsVariableSpeed::setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme) {
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setFlowSequencingControlScheme(flowSequencingControlScheme);
 }
 
@@ -573,11 +573,11 @@ bool HeaderedPumpsVariableSpeed::setMinimumFlowRateFraction(double minimumFlowRa
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setMinimumFlowRateFraction(minimumFlowRateFraction);
 }
 
-bool HeaderedPumpsVariableSpeed::setPumpControlType(std::string pumpControlType) {
+bool HeaderedPumpsVariableSpeed::setPumpControlType(const std::string& pumpControlType) {
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setPumpControlType(pumpControlType);
 }
 
-bool HeaderedPumpsVariableSpeed::setPumpFlowRateSchedule(Schedule& schedule) {
+bool HeaderedPumpsVariableSpeed::setPumpFlowRateSchedule(const Schedule& schedule) {
   return getImpl<detail::HeaderedPumpsVariableSpeed_Impl>()->setPumpFlowRateSchedule(schedule);
 }
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
@@ -150,7 +150,7 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   bool setPumpControlType(const std::string& pumpControlType);
 
-  bool setPumpFlowRateSchedule(const Schedule& schedule);
+  bool setPumpFlowRateSchedule(Schedule& schedule);
 
   void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
@@ -64,6 +64,8 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   static std::vector<std::string> pumpControlTypeValues();
 
+  static std::vector<std::string> designPowerSizingMethodValues();
+
   /** @name Getters */
   //@{
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
@@ -124,7 +124,7 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   bool setNumberofPumpsinBank(int numberofPumpsinBank);
 
-  bool setFlowSequencingControlScheme(std::string flowSequencingControlScheme);
+  bool setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme);
 
   bool setRatedPumpHead(double ratedPumpHead);
 
@@ -146,9 +146,9 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   bool setMinimumFlowRateFraction(double minimumFlowRateFraction);
 
-  bool setPumpControlType(std::string pumpControlType);
+  bool setPumpControlType(const std::string& pumpControlType);
 
-  bool setPumpFlowRateSchedule(Schedule& schedule);
+  bool setPumpFlowRateSchedule(const Schedule& schedule);
 
   void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed.hpp
@@ -106,6 +106,12 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   double skinLossRadiativeFraction() const;
 
+  std::string designPowerSizingMethod() const;
+
+  double designElectricPowerPerUnitFlowRate() const;
+
+  double designShaftPowerPerUnitFlowRatePerUnitHead() const;
+
   std::string endUseSubcategory() const;
 
   //@}
@@ -152,7 +158,13 @@ class MODEL_API HeaderedPumpsVariableSpeed : public StraightComponent {
 
   bool setSkinLossRadiativeFraction(double skinLossRadiativeFraction);
 
-  bool setEndUseSubcategory(const std::string & endUseSubcategory);
+  bool setDesignPowerSizingMethod(const std::string& designPowerSizingMethod);
+
+  bool setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate);
+
+  bool setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead);
+
+  bool setEndUseSubcategory(const std::string& endUseSubcategory);
 
   //@}
   /** @name Other */

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
@@ -119,6 +119,12 @@ namespace detail {
 
     double skinLossRadiativeFraction() const;
 
+    std::string designPowerSizingMethod() const;
+
+    double designElectricPowerPerUnitFlowRate() const;
+
+    double designShaftPowerPerUnitFlowRatePerUnitHead() const;
+
     boost::optional<double> autosizedTotalRatedFlowRate() const ;
 
     boost::optional<double> autosizedRatedPowerConsumption() const ;
@@ -169,7 +175,13 @@ namespace detail {
 
     bool setSkinLossRadiativeFraction(double skinLossRadiativeFraction);
 
-    bool setEndUseSubcategory(const std::string & endUseSubcategory);
+    bool setDesignPowerSizingMethod(const std::string& designPowerSizingMethod);
+
+    bool setDesignElectricPowerPerUnitFlowRate(double designElectricPowerPerUnitFlowRate);
+
+    bool setDesignShaftPowerPerUnitFlowRatePerUnitHead(double designShaftPowerPerUnitFlowRatePerUnitHead);
+
+    bool setEndUseSubcategory(const std::string& endUseSubcategory);
 
     //@}
     /** @name Other */

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
@@ -165,7 +165,7 @@ namespace detail {
 
     bool setPumpControlType(const std::string& pumpControlType);
 
-    bool setPumpFlowRateSchedule(const Schedule& schedule);
+    bool setPumpFlowRateSchedule(Schedule& schedule);
 
     void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
+++ b/openstudiocore/src/model/HeaderedPumpsVariableSpeed_Impl.hpp
@@ -141,7 +141,7 @@ namespace detail {
 
     bool setNumberofPumpsinBank(int numberofPumpsinBank);
 
-    bool setFlowSequencingControlScheme(std::string flowSequencingControlScheme);
+    bool setFlowSequencingControlScheme(const std::string& flowSequencingControlScheme);
 
     bool setRatedPumpHead(double ratedPumpHead);
 
@@ -163,9 +163,9 @@ namespace detail {
 
     bool setMinimumFlowRateFraction(double minimumFlowRateFraction);
 
-    bool setPumpControlType(std::string pumpControlType);
+    bool setPumpControlType(const std::string& pumpControlType);
 
-    bool setPumpFlowRateSchedule(Schedule& schedule);
+    bool setPumpFlowRateSchedule(const Schedule& schedule);
 
     void resetPumpFlowRateSchedule();
 

--- a/openstudiocore/src/model/test/HeaderedPumpsConstantSpeed_GTest.cpp
+++ b/openstudiocore/src/model/test/HeaderedPumpsConstantSpeed_GTest.cpp
@@ -51,3 +51,30 @@ TEST_F(ModelFixture,HeaderedPumpsConstantSpeed)
   } ,
     ::testing::ExitedWithCode(0), "" );
 }
+
+TEST_F(ModelFixture,HeaderedPumpsConstantSpeed_DesignFields) {
+
+  Model m;
+  HeaderedPumpsConstantSpeed p(m);
+
+  // Check defaults
+  EXPECT_EQ("PowerPerFlowPerPressure", p.designPowerSizingMethod());
+  EXPECT_EQ(348701.1, p.designElectricPowerPerUnitFlowRate());
+  EXPECT_EQ(1.282051282, p.designShaftPowerPerUnitFlowRatePerUnitHead());
+  EXPECT_EQ("General", p.endUseSubcategory());
+
+  EXPECT_TRUE(p.setDesignPowerSizingMethod("PowerPerFlow"));
+  EXPECT_EQ("PowerPerFlow", p.designPowerSizingMethod());
+  EXPECT_FALSE(p.setDesignPowerSizingMethod("ABADVALUE"));
+  EXPECT_EQ("PowerPerFlow", p.designPowerSizingMethod());
+
+  EXPECT_TRUE(p.setDesignElectricPowerPerUnitFlowRate(350000.0));
+  EXPECT_EQ(350000.0, p.designElectricPowerPerUnitFlowRate());
+
+  EXPECT_TRUE(p.setDesignShaftPowerPerUnitFlowRatePerUnitHead(1.1));
+  EXPECT_EQ(1.1, p.designShaftPowerPerUnitFlowRatePerUnitHead());
+
+  EXPECT_TRUE(p.setEndUseSubcategory("Pumps"));
+  EXPECT_EQ("Pumps", p.endUseSubcategory());
+
+}

--- a/openstudiocore/src/model/test/HeaderedPumpsVariableSpeed_GTest.cpp
+++ b/openstudiocore/src/model/test/HeaderedPumpsVariableSpeed_GTest.cpp
@@ -51,3 +51,30 @@ TEST_F(ModelFixture,HeaderedPumpsVariableSpeed)
   } ,
     ::testing::ExitedWithCode(0), "" );
 }
+
+TEST_F(ModelFixture,HeaderedPumpsVariableSpeed_DesignFields) {
+
+  Model m;
+  HeaderedPumpsVariableSpeed p(m);
+
+  // Check defaults
+  EXPECT_EQ("PowerPerFlowPerPressure", p.designPowerSizingMethod());
+  EXPECT_EQ(348701.1, p.designElectricPowerPerUnitFlowRate());
+  EXPECT_EQ(1.282051282, p.designShaftPowerPerUnitFlowRatePerUnitHead());
+  EXPECT_EQ("General", p.endUseSubcategory());
+
+  EXPECT_TRUE(p.setDesignPowerSizingMethod("PowerPerFlow"));
+  EXPECT_EQ("PowerPerFlow", p.designPowerSizingMethod());
+  EXPECT_FALSE(p.setDesignPowerSizingMethod("ABADVALUE"));
+  EXPECT_EQ("PowerPerFlow", p.designPowerSizingMethod());
+
+  EXPECT_TRUE(p.setDesignElectricPowerPerUnitFlowRate(350000.0));
+  EXPECT_EQ(350000.0, p.designElectricPowerPerUnitFlowRate());
+
+  EXPECT_TRUE(p.setDesignShaftPowerPerUnitFlowRatePerUnitHead(1.1));
+  EXPECT_EQ(1.1, p.designShaftPowerPerUnitFlowRatePerUnitHead());
+
+  EXPECT_TRUE(p.setEndUseSubcategory("Pumps"));
+  EXPECT_EQ("Pumps", p.endUseSubcategory());
+
+}

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -4731,11 +4731,15 @@ std::string VersionTranslator::update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, c
       newObject.setDouble(i++, 1.282051282);
 
       // EndUseSubcategory
-      if (value = object.getString(i)) {
+      if ((value = object.getString(i))) {
         newObject.setString(i, value.get());
       } else {
         newObject.setString(i,"General");
       }
+
+      // Register refactored
+      m_refactored.push_back(RefactoredObjectData(object, newObject));
+      ss << newObject;
 
     // No-op
     } else {

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -4716,25 +4716,31 @@ std::string VersionTranslator::update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, c
       auto iddObject = idd_2_9_0.getObject(iddname);
       IdfObject newObject(iddObject.get());
 
-      for (size_t i = 0; i < object.numFields() - 4; ++i) {
+      for (size_t i = 0; i < object.numFields(); ++i) {
         if ((value = object.getString(i))) {
           newObject.setString(i, value.get());
         }
       }
 
-       unsigned i = object.numFields() - 4;
+      unsigned currentIndex;
+      if (iddname == "OS:HeaderedPumps:ConstantSpeed") {
+        currentIndex = 15;
+      } else {
+        currentIndex = 20;
+      }
+
       // DesignPowerSizingMethod
-      newObject.setString(i++, "PowerPerFlowPerPressure");
+      newObject.setString(currentIndex++, "PowerPerFlowPerPressure");
       // DesignElectricPowerPerUnitFlowRate
-      newObject.setDouble(i++, 348701.1);
+      newObject.setDouble(currentIndex++, 348701.1);
       // DesignElectricPowerPerUnitFlowRate
-      newObject.setDouble(i++, 1.282051282);
+      newObject.setDouble(currentIndex++, 1.282051282);
 
       // EndUseSubcategory
-      if ((value = object.getString(i))) {
-        newObject.setString(i, value.get());
+      if ((value = object.getString(currentIndex))) {
+        newObject.setString(currentIndex, value.get());
       } else {
-        newObject.setString(i,"General");
+        newObject.setString(currentIndex,"General");
       }
 
       // Register refactored

--- a/openstudiocore/src/osversion/VersionTranslator.cpp
+++ b/openstudiocore/src/osversion/VersionTranslator.cpp
@@ -4710,6 +4710,33 @@ std::string VersionTranslator::update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, c
       m_refactored.push_back(RefactoredObjectData(object, newObject));
       ss << newObject;
 
+
+    // Four fields were added but only the last (End Use Subcat) was implemented, but withotu transition rules either
+    } else if ((iddname == "OS:HeaderedPumps:ConstantSpeed") || (iddname == "OS:HeaderedPumps:VariableSpeed")) {
+      auto iddObject = idd_2_9_0.getObject(iddname);
+      IdfObject newObject(iddObject.get());
+
+      for (size_t i = 0; i < object.numFields() - 4; ++i) {
+        if ((value = object.getString(i))) {
+          newObject.setString(i, value.get());
+        }
+      }
+
+       unsigned i = object.numFields() - 4;
+      // DesignPowerSizingMethod
+      newObject.setString(i++, "PowerPerFlowPerPressure");
+      // DesignElectricPowerPerUnitFlowRate
+      newObject.setDouble(i++, 348701.1);
+      // DesignElectricPowerPerUnitFlowRate
+      newObject.setDouble(i++, 1.282051282);
+
+      // EndUseSubcategory
+      if (value = object.getString(i)) {
+        newObject.setString(i, value.get());
+      } else {
+        newObject.setString(i,"General");
+      }
+
     // No-op
     } else {
       ss << object;


### PR DESCRIPTION
Fix #3553
* Added methods to model API
* Added methods to FT
* Added Version Translation (and tested it, in particular on hvac_library.osm)
* Extended model test for new fields
* Tested that OpenStudio-resources test headered_pumps (both rb and osm) still run and have zero difference with previous run