### PR TITLE
Add autosizable capability for LowTempRadiantConstFlow Hydronic Tubing Length and for Rated Flow Rate

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -1176,6 +1176,9 @@ OS:Site:WaterMainsTemperature,
        \required-field
        \key Schedule
        \key Correlation
+       \key CorrelationFromWeatherFile
+       \note If calculation method is CorrelationFromWeatherFile, the two numeric input
+       \note fields are ignored. Instead, EnergyPlus calculates them from weather file.
   A3, \field Temperature Schedule Name
        \type object-list
        \object-list ScheduleNames

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -23829,6 +23829,7 @@ OS:ZoneHVAC:LowTemperatureRadiant:ConstantFlow,
         \note Total length of pipe embedded in surface
         \units m
         \minimum> 0
+        \autosizable
         \required-field
    A5 , \field Temperature Control Type
         \note Temperature used to control system
@@ -23849,6 +23850,8 @@ OS:ZoneHVAC:LowTemperatureRadiant:ConstantFlow,
         \object-list CoilCoolingLowTempRadiantConstantFlow
    N3 , \field Rated Flow Rate
         \units m3/s
+        \ip-units gal/min
+        \autosizable
    A8 , \field Pump Flow Rate Schedule Name
         \note Modifies the Rated Flow Rate of the pump on a time basis
         \note the default is that the pump is ON and runs according to its other

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACLowTempRadiantConstFlow.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACLowTempRadiantConstFlow.cpp
@@ -147,7 +147,11 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACLowTempRadiantCon
   }
 
   //field Hydronic Tubing Length
- if( (value = modelObject.hydronicTubingLength()) )
+  if (modelObject.isHydronicTubingLengthAutosized())
+  {
+    idfObject.setString(ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength, "Autosize");
+  }
+  else if( (value = modelObject.hydronicTubingLength()) )
   {
     idfObject.setDouble(ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength,value.get());
   }
@@ -159,7 +163,11 @@ boost::optional<IdfObject> ForwardTranslator::translateZoneHVACLowTempRadiantCon
   }
 
   //field Rated Flow Rate
-  if( (value = modelObject.ratedFlowRate()) )
+  if (modelObject.isRatedFlowRateAutosized())
+  {
+    idfObject.setString(ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate, "Autosize");
+  }
+  else if( (value = modelObject.ratedFlowRate()) )
   {
     idfObject.setDouble(ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate,value.get());
   }

--- a/openstudiocore/src/model/SiteWaterMainsTemperature.cpp
+++ b/openstudiocore/src/model/SiteWaterMainsTemperature.cpp
@@ -279,6 +279,7 @@ SiteWaterMainsTemperature::SiteWaterMainsTemperature(const Model& model)
   : ModelObject(SiteWaterMainsTemperature::iddObjectType(),model)
 {
   OS_ASSERT(getImpl<detail::SiteWaterMainsTemperature_Impl>());
+  // TODO: switch this to CorrelationFromWeatherFile to match E+. Can be done at OS 3.0
   bool ok = setCalculationMethod("Schedule");
   OS_ASSERT(ok);
 }

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
@@ -278,12 +278,6 @@ namespace detail {
     return isEmpty(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingInsideDiameter);
   }
 
-  double ZoneHVACLowTempRadiantConstFlow_Impl::hydronicTubingLength() const {
-    boost::optional<double> value = getDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength,true);
-    OS_ASSERT(value);
-    return value.get();
-  }
-
   std::string ZoneHVACLowTempRadiantConstFlow_Impl::temperatureControlType() const {
     boost::optional<std::string> value = getString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::TemperatureControlType,true);
     OS_ASSERT(value);
@@ -304,10 +298,6 @@ namespace detail {
     boost::optional<HVACComponent> coil = optionalCoolingCoil();
     OS_ASSERT(coil);
     return coil.get();
-  }
-
-  boost::optional<double> ZoneHVACLowTempRadiantConstFlow_Impl::ratedFlowRate() const {
-    return getDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate,true);
   }
 
   boost::optional<Schedule> ZoneHVACLowTempRadiantConstFlow_Impl::pumpFlowRateSchedule() const {
@@ -395,20 +385,33 @@ namespace detail {
     OS_ASSERT(result);
   }
 
+  boost::optional<double> ZoneHVACLowTempRadiantConstFlow_Impl::hydronicTubingLength() const {
+    return getDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength,true);
+  }
+
   bool ZoneHVACLowTempRadiantConstFlow_Impl::setHydronicTubingLength(boost::optional<double> hydronicTubingLength) {
     bool result(false);
     if (hydronicTubingLength) {
       result = setDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength, hydronicTubingLength.get());
     }
     else {
-      resetHydronicTubingLength();
+      autosizeHydronicTubingLength();
       result = true;
     }
     return result;
   }
 
-  void ZoneHVACLowTempRadiantConstFlow_Impl::resetHydronicTubingLength() {
-    bool result = setString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength, "");
+  bool ZoneHVACLowTempRadiantConstFlow_Impl::isHydronicTubingLengthAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
+  }
+
+  void ZoneHVACLowTempRadiantConstFlow_Impl::autosizeHydronicTubingLength() {
+    bool result = setString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::HydronicTubingLength, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -432,21 +435,34 @@ namespace detail {
     return result;
   }
 
+  boost::optional<double> ZoneHVACLowTempRadiantConstFlow_Impl::ratedFlowRate() const {
+    return getDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate,true);
+  }
+
   bool ZoneHVACLowTempRadiantConstFlow_Impl::setRatedFlowRate(boost::optional<double> ratedFlowRate) {
     bool result(false);
     if (ratedFlowRate) {
       result = setDouble(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate, ratedFlowRate.get());
     }
     else {
-      resetRatedFlowRate();
+      autosizeRatedFlowRate();
       result = true;
     }
     OS_ASSERT(result);
     return result;
   }
 
-  void ZoneHVACLowTempRadiantConstFlow_Impl::resetRatedFlowRate() {
-    bool result = setString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate, "");
+  bool ZoneHVACLowTempRadiantConstFlow_Impl::isRatedFlowRateAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
+  }
+
+  void ZoneHVACLowTempRadiantConstFlow_Impl::autosizeRatedFlowRate() {
+    bool result = setString(OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlowFields::RatedFlowRate, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -599,7 +615,58 @@ namespace detail {
     return types;
   }
 
+  boost::optional<double> ZoneHVACLowTempRadiantConstFlow_Impl::autosizedHydronicTubingLength() const {
+    return getAutosizedValue("Design Size Hydronic Tubing Length", "m");
+  }
+
+  boost::optional<double> ZoneHVACLowTempRadiantConstFlow_Impl::autosizedRatedFlowRate() const {
+    return getAutosizedValue("Design Size Maximum Water Flow", "m3/s");
+  }
+
+ void ZoneHVACWaterToAirHeatPump_Impl::autosize() {
+    autosizeHydronicTubingLength();
+    autosizeRatedFlowRate();
+  }
+
+  void ZoneHVACWaterToAirHeatPump_Impl::applySizingValues() {
+    boost::optional<double> val;
+    val = autosizedHydronicTubingLength();
+    if (val) {
+      setHydronicTubingLength(val.get());
+    }
+
+    val = autosizedRatedFlowRate();
+    if (val) {
+      setRatedFlowRate(val.get());
+    }
+  }
+
+
 } // detail
+
+ZoneHVACLowTempRadiantConstFlow::ZoneHVACLowTempRadiantConstFlow(const Model& model,
+                                                                 Schedule& availabilitySchedule,
+                                                                 HVACComponent& heatingCoil,
+                                                                 HVACComponent& coolingCoil)
+  : ZoneHVACComponent(ZoneHVACLowTempRadiantConstFlow::iddObjectType(),model)
+{
+  OS_ASSERT(getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>());
+
+  bool ok = setAvailabilitySchedule(availabilitySchedule);
+  if (!ok) {
+    remove();
+    LOG_AND_THROW("Unable to set " << briefDescription() << "'s availability schedule to "
+                  << availabilitySchedule.briefDescription() << ".");
+  }
+  ok = setHeatingCoil(heatingCoil);
+  OS_ASSERT(ok);
+
+  ok = setCoolingCoil(coolingCoil);
+  OS_ASSERT(ok);
+
+  autosizeHydronicTubingLength();
+  autosizeRatedFlowRate();
+}
 
 ZoneHVACLowTempRadiantConstFlow::ZoneHVACLowTempRadiantConstFlow(const Model& model,
                                                                  Schedule& availabilitySchedule,
@@ -625,6 +692,7 @@ ZoneHVACLowTempRadiantConstFlow::ZoneHVACLowTempRadiantConstFlow(const Model& mo
   ok = setHydronicTubingLength(hydronicTubingLength);
   OS_ASSERT(ok);
 
+  autosizeRatedFlowRate();
 }
 
 IddObjectType ZoneHVACLowTempRadiantConstFlow::iddObjectType() {
@@ -661,8 +729,12 @@ bool ZoneHVACLowTempRadiantConstFlow::isHydronicTubingInsideDiameterDefaulted() 
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->isHydronicTubingInsideDiameterDefaulted();
 }
 
-double ZoneHVACLowTempRadiantConstFlow::hydronicTubingLength() const {
+boost::optional<double> ZoneHVACLowTempRadiantConstFlow::hydronicTubingLength() const {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->hydronicTubingLength();
+}
+
+bool ZoneHVACLowTempRadiantConstFlow::isHydronicTubingLengthAutosized() const {
+  return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->isHydronicTubingLengthAutosized();
 }
 
 std::string ZoneHVACLowTempRadiantConstFlow::temperatureControlType() const {
@@ -683,6 +755,10 @@ HVACComponent ZoneHVACLowTempRadiantConstFlow::coolingCoil() const {
 
 boost::optional<double> ZoneHVACLowTempRadiantConstFlow::ratedFlowRate() const {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->ratedFlowRate();
+}
+
+bool ZoneHVACLowTempRadiantConstFlow::isRatedFlowRateAutosized() const {
+  return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->isRatedFlowRateAutosized();
 }
 
 boost::optional<Schedule> ZoneHVACLowTempRadiantConstFlow::pumpFlowRateSchedule() const {
@@ -749,8 +825,8 @@ bool ZoneHVACLowTempRadiantConstFlow::setHydronicTubingLength(double hydronicTub
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->setHydronicTubingLength(hydronicTubingLength);
 }
 
-void ZoneHVACLowTempRadiantConstFlow::resetHydronicTubingLength() {
-  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->resetHydronicTubingLength();
+void ZoneHVACLowTempRadiantConstFlow::autosizeHydronicTubingLength() {
+  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizeHydronicTubingLength();
 }
 
 bool ZoneHVACLowTempRadiantConstFlow::setTemperatureControlType(std::string temperatureControlType) {
@@ -773,8 +849,8 @@ bool ZoneHVACLowTempRadiantConstFlow::setRatedFlowRate(double ratedFlowRate) {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->setRatedFlowRate(ratedFlowRate);
 }
 
-void ZoneHVACLowTempRadiantConstFlow::resetRatedFlowRate() {
-  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->resetRatedFlowRate();
+void ZoneHVACLowTempRadiantConstFlow::autosizeRatedFlowRate() {
+  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizeRatedFlowRate();
 }
 
 bool ZoneHVACLowTempRadiantConstFlow::setPumpFlowRateSchedule(Schedule& schedule) {
@@ -839,11 +915,30 @@ void ZoneHVACLowTempRadiantConstFlow::removeFromThermalZone()
 {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->removeFromThermalZone();
 }
+
+boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedHydronicTubingLength() {
+  return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizedHydronicTubingLength();
+}
+
+boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedRatedFlowRate() {
+  return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizedRatedFlowRate();
+}
+
 /// @cond
 ZoneHVACLowTempRadiantConstFlow::ZoneHVACLowTempRadiantConstFlow(std::shared_ptr<detail::ZoneHVACLowTempRadiantConstFlow_Impl> impl)
   : ZoneHVACComponent(std::move(impl))
 {}
 /// @endcond
+
+// TODO: deprecated
+void ZoneHVACLowTempRadiantConstFlow::resetHydronicTubingLength() {
+  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizeHydronicTubingLength();
+}
+
+void ZoneHVACLowTempRadiantConstFlow::resetRatedFlowRate() {
+  getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizeRatedFlowRate();
+}
+
 
 } // model
 } // openstudio

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
@@ -623,12 +623,12 @@ namespace detail {
     return getAutosizedValue("Design Size Maximum Water Flow", "m3/s");
   }
 
- void ZoneHVACWaterToAirHeatPump_Impl::autosize() {
+ void ZoneHVACLowTempRadiantConstFlow_Impl::autosize() {
     autosizeHydronicTubingLength();
     autosizeRatedFlowRate();
   }
 
-  void ZoneHVACWaterToAirHeatPump_Impl::applySizingValues() {
+  void ZoneHVACLowTempRadiantConstFlow_Impl::applySizingValues() {
     boost::optional<double> val;
     val = autosizedHydronicTubingLength();
     if (val) {

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.cpp
@@ -916,11 +916,11 @@ void ZoneHVACLowTempRadiantConstFlow::removeFromThermalZone()
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->removeFromThermalZone();
 }
 
-boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedHydronicTubingLength() {
+boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedHydronicTubingLength() const {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizedHydronicTubingLength();
 }
 
-boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedRatedFlowRate() {
+boost::optional<double> ZoneHVACLowTempRadiantConstFlow::autosizedRatedFlowRate() const {
   return getImpl<detail::ZoneHVACLowTempRadiantConstFlow_Impl>()->autosizedRatedFlowRate();
 }
 

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.hpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow.hpp
@@ -34,6 +34,7 @@
 #include "Surface.hpp"
 #include "Surface_Impl.hpp"
 #include "ZoneHVACComponent.hpp"
+#include "../utilities/core/Deprecated.hpp"
 
 namespace openstudio {
 
@@ -60,6 +61,12 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
                                   HVACComponent& coolingCoil,
                                   double hydronicTubingLength);
 
+  // Ctor with hydronicTubingLength autosized
+  ZoneHVACLowTempRadiantConstFlow(const Model& model,
+                                  Schedule& availabilitySchedule,
+                                  HVACComponent& heatingCoil,
+                                  HVACComponent& coolingCoil);
+
   virtual ~ZoneHVACLowTempRadiantConstFlow() {}
 
   //@}
@@ -83,7 +90,9 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
 
   bool isHydronicTubingInsideDiameterDefaulted() const;
 
-  double hydronicTubingLength() const;
+  boost::optional<double> hydronicTubingLength() const;
+
+  bool isHydronicTubingLengthAutosized() const;
 
   std::string temperatureControlType() const;
 
@@ -94,6 +103,8 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
   HVACComponent coolingCoil() const;
 
   boost::optional<double> ratedFlowRate() const;
+
+  bool isRatedFlowRateAutosized() const;
 
   boost::optional<Schedule> pumpFlowRateSchedule() const;
 
@@ -131,7 +142,10 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
 
   bool setHydronicTubingLength(double hydronicTubingLength);
 
-  void resetHydronicTubingLength();
+  // Will forward to autosizeHydronicTubingLength()
+  OS_DEPRECATED void resetHydronicTubingLength(); // Shouldn't have existed to begin with.
+
+  void autosizeHydronicTubingLength();
 
   bool setTemperatureControlType(std::string temperatureControlType);
 
@@ -143,7 +157,10 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
 
   bool setRatedFlowRate(double ratedFlowRate);
 
-  void resetRatedFlowRate();
+  // Will forward to autosizeRatedFlowRate()
+  OS_DEPRECATED void resetRatedFlowRate();
+
+  void autosizeRatedFlowRate();
 
   bool setPumpFlowRateSchedule(Schedule& schedule);
 
@@ -178,6 +195,10 @@ class MODEL_API ZoneHVACLowTempRadiantConstFlow : public ZoneHVACComponent {
   //@}
   /** @name Other */
   //@{
+
+  boost::optional<double> autosizedHydronicTubingLength() const;
+
+  boost::optional<double> autosizedRatedFlowRate() const;
 
   //@}
  protected:

--- a/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow_Impl.hpp
+++ b/openstudiocore/src/model/ZoneHVACLowTempRadiantConstFlow_Impl.hpp
@@ -83,6 +83,14 @@ namespace detail {
 
     virtual unsigned outletPort() const override;
 
+    virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;
+
+    virtual std::vector<std::string> emsInternalVariableNames() const override;
+
+    virtual void autosize() override;
+
+    virtual void applySizingValues() override;
+
 
     //@}
     /** @name Getters */
@@ -98,7 +106,9 @@ namespace detail {
 
     bool isHydronicTubingInsideDiameterDefaulted() const;
 
-    double hydronicTubingLength() const;
+    boost::optional<double> hydronicTubingLength() const;
+
+    bool isHydronicTubingLengthAutosized() const;
 
     std::string temperatureControlType() const;
 
@@ -109,6 +119,8 @@ namespace detail {
     HVACComponent coolingCoil() const;
 
     boost::optional<double> ratedFlowRate() const;
+
+    bool isRatedFlowRateAutosized() const;
 
     boost::optional<Schedule> pumpFlowRateSchedule() const;
 
@@ -146,7 +158,7 @@ namespace detail {
 
     bool setHydronicTubingLength(boost::optional<double> hydronicTubingLength);
 
-    void resetHydronicTubingLength();
+    void autosizeHydronicTubingLength();
 
     bool setTemperatureControlType(std::string temperatureControlType);
 
@@ -158,7 +170,7 @@ namespace detail {
 
     bool setRatedFlowRate(boost::optional<double> ratedFlowRate);
 
-    void resetRatedFlowRate();
+    void autosizeRatedFlowRate();
 
     bool setPumpFlowRateSchedule(Schedule& schedule);
 
@@ -194,9 +206,9 @@ namespace detail {
     /** @name Other */
     //@{
 
-    virtual std::vector<EMSActuatorNames> emsActuatorNames() const override;
+    boost::optional<double> autosizedHydronicTubingLength() const;
 
-    virtual std::vector<std::string> emsInternalVariableNames() const override;
+    boost::optional<double> autosizedRatedFlowRate() const;
 
     //@}
    protected:

--- a/openstudiocore/src/model/test/ZoneHVACLowTempRadiantConstFlow_GTest.cpp
+++ b/openstudiocore/src/model/test/ZoneHVACLowTempRadiantConstFlow_GTest.cpp
@@ -166,5 +166,27 @@ TEST_F(ModelFixture,ZoneHVACLowTempRadiantConstFlow_SetGetFields) {
   EXPECT_TRUE(testCC1.containingZoneHVACComponent());
 
 
+  EXPECT_TRUE(testRad.isRatedFlowRateAutosized());
+  EXPECT_FALSE(testRad.ratedFlowRate());
+  EXPECT_TRUE(testRad.setRatedFlowRate(0.75));
+  EXPECT_FALSE(testRad.isRatedFlowRateAutosized());
+  ASSERT_TRUE(testRad.ratedFlowRate());
+  EXPECT_EQ(0.75, testRad.ratedFlowRate().get());
+  testRad.autosizeRatedFlowRate();
+  EXPECT_TRUE(testRad.isRatedFlowRateAutosized());
+  EXPECT_FALSE(testRad.ratedFlowRate());
+
+
+  testRad.autosizeHydronicTubingLength();
+  EXPECT_TRUE(testRad.isHydronicTubingLengthAutosized());
+  EXPECT_FALSE(testRad.hydronicTubingLength());
+  EXPECT_TRUE(testRad.setHydronicTubingLength(150.0));
+  EXPECT_FALSE(testRad.isHydronicTubingLengthAutosized());
+  ASSERT_TRUE(testRad.hydronicTubingLength());
+  EXPECT_EQ(150.0, testRad.hydronicTubingLength().get());
+  testRad.autosizeHydronicTubingLength();
+  EXPECT_TRUE(testRad.isHydronicTubingLengthAutosized());
+  EXPECT_FALSE(testRad.hydronicTubingLength());
+
 }
 


### PR DESCRIPTION
Fix #3442 : Add CorrelationFromWeatherFile to SiteMainsWaterTemperature

Fix #3411 - Add autosizable capability for LowTempRadiantConstFlow `Hydronic Tubing Length` and for `Rated Flow Rate`.

**API Breaking change:**

* hydronicTubingLength now returns an OptionalDouble and not a double