### PR TITLE
Add `getDefaultSchedule(defaultScheduleType)` for `Building` and `BuildingStory`

### DIFF
--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -44,6 +44,8 @@
 #include "DefaultConstructionSet_Impl.hpp"
 #include "DefaultScheduleSet.hpp"
 #include "DefaultScheduleSet_Impl.hpp"
+#include "Schedule.hpp"
+#include "Schedule_Impl.hpp"
 #include "ThermalZone.hpp"
 #include "ThermalZone_Impl.hpp"
 #include "ShadingSurface.hpp"

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -591,6 +591,36 @@ namespace detail {
     return getObject<ModelObject>().getModelObjectTarget<DefaultScheduleSet>(OS_BuildingFields::DefaultScheduleSetName);
   }
 
+  boost::optional<Schedule> Building_Impl::getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const
+  {
+    boost::optional<Schedule> result;
+    boost::optional<DefaultScheduleSet> defaultScheduleSet;
+    boost::optional<SpaceType> spaceType;
+
+    // first check this object (building)
+    defaultScheduleSet = this->defaultScheduleSet();
+    if (defaultScheduleSet){
+      result = defaultScheduleSet->getDefaultSchedule(defaultScheduleType);
+      if (result){
+        return result;
+      }
+    }
+
+
+    // then check building's space type
+    if (boost::optional<SpaceType> spaceType = this->spaceType()) {
+      defaultScheduleSet = spaceType->defaultScheduleSet();
+      if (defaultScheduleSet){
+        result = defaultScheduleSet->getDefaultSchedule(defaultScheduleType);
+        if (result){
+          return result;
+        }
+      }
+    }
+
+    return boost::none;
+  }
+
   bool Building_Impl::setDefaultScheduleSet(const DefaultScheduleSet& defaultScheduleSet)
   {
     return setPointer(OS_BuildingFields::DefaultScheduleSetName, defaultScheduleSet.handle());

--- a/openstudiocore/src/model/Building.cpp
+++ b/openstudiocore/src/model/Building.cpp
@@ -1329,6 +1329,10 @@ boost::optional<DefaultScheduleSet> Building::defaultScheduleSet() const
   return getImpl<detail::Building_Impl>()->defaultScheduleSet();
 }
 
+boost::optional<Schedule> Building::getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const {
+  return getImpl<detail::Building_Impl>()->getDefaultSchedule(defaultScheduleType);
+}
+
 bool Building::setDefaultScheduleSet(const DefaultScheduleSet& defaultScheduleSet)
 {
   return getImpl<detail::Building_Impl>()->setDefaultScheduleSet(defaultScheduleSet);

--- a/openstudiocore/src/model/Building.hpp
+++ b/openstudiocore/src/model/Building.hpp
@@ -49,6 +49,7 @@ class Space;
 class SpaceType;
 class DefaultConstructionSet;
 class DefaultScheduleSet;
+class DefaultScheduleType;
 class ThermalZone;
 
 namespace detail {
@@ -118,6 +119,11 @@ class MODEL_API Building : public ParentObject {
 
   bool relocatable() const;
   bool isRelocatableDefaulted() const;
+
+  /// Returns the default schedule set for the specified type if available by searching (in order):
+  /// The building's default schedule set
+  /// The building's space type's default schedule set
+  boost::optional<Schedule> getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const;
 
   //@}
   /** @name Setters */

--- a/openstudiocore/src/model/BuildingStory.cpp
+++ b/openstudiocore/src/model/BuildingStory.cpp
@@ -40,6 +40,8 @@
 #include "DefaultConstructionSet_Impl.hpp"
 #include "DefaultScheduleSet.hpp"
 #include "DefaultScheduleSet_Impl.hpp"
+#include "Schedule.hpp"
+#include "Schedule_Impl.hpp"
 #include "RenderingColor.hpp"
 #include "RenderingColor_Impl.hpp"
 
@@ -146,6 +148,49 @@ namespace detail {
   boost::optional<DefaultScheduleSet> BuildingStory_Impl::defaultScheduleSet() const
   {
     return getObject<ModelObject>().getModelObjectTarget<DefaultScheduleSet>(OS_BuildingStoryFields::DefaultScheduleSetName);
+  }
+
+  boost::optional<Schedule> BuildingStory_Impl::getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const
+  {
+    boost::optional<Schedule> result;
+    boost::optional<DefaultScheduleSet> defaultScheduleSet;
+    boost::optional<Building> building;
+    boost::optional<SpaceType> spaceType;
+
+    // first check this object
+    defaultScheduleSet = this->defaultScheduleSet();
+    if (defaultScheduleSet){
+      result = defaultScheduleSet->getDefaultSchedule(defaultScheduleType);
+      if (result){
+        return result;
+      }
+    }
+
+    // then check building
+    building = this->model().building();
+    if (building){
+      defaultScheduleSet = building->defaultScheduleSet();
+      if (defaultScheduleSet){
+        result = defaultScheduleSet->getDefaultSchedule(defaultScheduleType);
+        if (result){
+          return result;
+        }
+      }
+
+      // then check building's space type
+      spaceType = building->spaceType();
+      if (spaceType){
+        defaultScheduleSet = spaceType->defaultScheduleSet();
+        if (defaultScheduleSet){
+          result = defaultScheduleSet->getDefaultSchedule(defaultScheduleType);
+          if (result){
+            return result;
+          }
+        }
+      }
+    }
+
+    return boost::none;
   }
 
   bool BuildingStory_Impl::setDefaultScheduleSet(const DefaultScheduleSet& defaultScheduleSet)

--- a/openstudiocore/src/model/BuildingStory.cpp
+++ b/openstudiocore/src/model/BuildingStory.cpp
@@ -367,6 +367,10 @@ boost::optional<DefaultScheduleSet> BuildingStory::defaultScheduleSet() const
   return getImpl<detail::BuildingStory_Impl>()->defaultScheduleSet();
 }
 
+boost::optional<Schedule> BuildingStory::getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const {
+  return getImpl<detail::BuildingStory_Impl>()->getDefaultSchedule(defaultScheduleType);
+}
+
 bool BuildingStory::setDefaultScheduleSet(const DefaultScheduleSet& defaultScheduleSet)
 {
   return getImpl<detail::BuildingStory_Impl>()->setDefaultScheduleSet(defaultScheduleSet);

--- a/openstudiocore/src/model/BuildingStory.hpp
+++ b/openstudiocore/src/model/BuildingStory.hpp
@@ -40,6 +40,7 @@ namespace model {
 class SpaceType;
 class DefaultConstructionSet;
 class DefaultScheduleSet;
+class DefaultScheduleType;
 class Space;
 class RenderingColor;
 
@@ -107,6 +108,12 @@ class MODEL_API BuildingStory : public ModelObject {
 
   /// Resets the default schedule set for this space.
   void resetDefaultScheduleSet();
+
+  /// Returns the default schedule set for the specified type if available by searching (in order):
+  /// This object
+  /// The building's default schedule set
+  /// The building's space type's default schedule set
+  boost::optional<Schedule> getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const;
 
   /// Returns the rendering color.
   boost::optional<RenderingColor> renderingColor() const;

--- a/openstudiocore/src/model/BuildingStory_Impl.hpp
+++ b/openstudiocore/src/model/BuildingStory_Impl.hpp
@@ -38,6 +38,7 @@ namespace model {
 class SpaceType;
 class DefaultConstructionSet;
 class DefaultScheduleSet;
+class DefaultScheduleType;
 class Space;
 class RenderingColor;
 class BuildingStory;
@@ -117,6 +118,8 @@ namespace detail {
 
     /// Resets the default schedule set for this space.
     void resetDefaultScheduleSet();
+
+    boost::optional<Schedule> getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const;
 
     /// Returns the rendering color.
     boost::optional<RenderingColor> renderingColor() const;

--- a/openstudiocore/src/model/Building_Impl.hpp
+++ b/openstudiocore/src/model/Building_Impl.hpp
@@ -50,6 +50,7 @@ class Space;
 class SpaceType;
 class DefaultConstructionSet;
 class DefaultScheduleSet;
+class DefaultScheduleType;
 class ThermalZone;
 class Building;
 
@@ -116,6 +117,8 @@ namespace detail {
 
     bool relocatable() const;
     bool isRelocatableDefaulted() const;
+
+    boost::optional<Schedule> getDefaultSchedule(const DefaultScheduleType& defaultScheduleType) const;
 
     //@}
     /** @name Setters */

--- a/openstudiocore/src/model/test/BuildingStory_GTest.cpp
+++ b/openstudiocore/src/model/test/BuildingStory_GTest.cpp
@@ -34,6 +34,11 @@
 #include "../BuildingStory.hpp"
 #include "../BuildingStory_Impl.hpp"
 
+#include "../Building.hpp"
+#include "../SpaceType.cpp"
+#include "../DefaultScheduleSet.hpp"
+#include "../ScheduleConstant.hpp"
+
 #include "../../utilities/units/Quantity.hpp"
 #include "../../utilities/units/Unit.hpp"
 
@@ -66,3 +71,47 @@ TEST_F(ModelFixture,BuildingStory_NominalFloortoFloorHeight) {
   EXPECT_NEAR(value, *result, 1.0E-8);
 }
 
+
+TEST_F(ModelFixture, BuildingStory_getDefaultSchedule)
+{
+  Model model;
+
+  BuildingStory buildingStory(model);
+  DefaultScheduleSet bldgStoryDefaultScheduleSet(model);
+  ScheduleConstant sch_bs_lighting(model);
+  EXPECT_TRUE(bldgStoryDefaultScheduleSet.setLightingSchedule(sch_bs_lighting));
+  EXPECT_TRUE(buildingStory.setDefaultScheduleSet(bldgStoryDefaultScheduleSet));
+
+  Building building = model.getUniqueModelObject<Building>();
+  DefaultScheduleSet bldgDefaultScheduleSet(model);
+  ScheduleConstant sch_bldg_lighting(model);
+  EXPECT_TRUE(bldgDefaultScheduleSet.setLightingSchedule(sch_bldg_lighting));
+  ScheduleConstant sch_bldg_people(model);
+  EXPECT_TRUE(bldgDefaultScheduleSet.setNumberofPeopleSchedule(sch_bldg_people));
+  EXPECT_TRUE(building.setDefaultScheduleSet(bldgDefaultScheduleSet));
+
+
+  SpaceType spaceType(model);
+  EXPECT_TRUE(building.setSpaceType(spaceType));
+
+  DefaultScheduleSet spDefaultScheduleSet(model);
+  ScheduleConstant sch_sp_lighting(model);
+  EXPECT_TRUE(spDefaultScheduleSet.setLightingSchedule(sch_sp_lighting));
+  ScheduleConstant sch_sp_people(model);
+  EXPECT_TRUE(spDefaultScheduleSet.setNumberofPeopleSchedule(sch_sp_people));
+  ScheduleConstant sch_sp_hours(model);
+  EXPECT_TRUE(spDefaultScheduleSet.setHoursofOperationSchedule(sch_sp_hours));
+  EXPECT_TRUE(spaceType.setDefaultScheduleSet(spDefaultScheduleSet));
+
+  // BuildingStory, Building and its SpaceType both have a lighting schedule. It should return the BuildingStory's one in priority
+  ASSERT_TRUE(buildingStory.getDefaultSchedule(DefaultScheduleType::LightingSchedule));
+  EXPECT_EQ(sch_bldg_people.handle(), buildingStory.getDefaultSchedule(DefaultScheduleType::LightingSchedule)->handle());
+
+  // BuldingStory doesn't have one, but Building and its SpaceType both have a people schedule. It should return the building's one in priority
+  ASSERT_TRUE(buildingStory.getDefaultSchedule(DefaultScheduleType::NumberofPeopleSchedule));
+  EXPECT_EQ(sch_bldg_people.handle(), buildingStory.getDefaultSchedule(DefaultScheduleType::NumberofPeopleSchedule)->handle());
+
+  // BuldingStory and Building don't have an hours of operation schedule, but its SpaceType does so it should return the SpaceType's one
+  ASSERT_TRUE(buildingStory.getDefaultSchedule(DefaultScheduleType::HoursofOperationSchedule));
+  EXPECT_EQ(sch_sp_hours.handle(), buildingStory.getDefaultSchedule(DefaultScheduleType::HoursofOperationSchedule)->handle());
+}

--- a/openstudiocore/src/model/test/BuildingStory_GTest.cpp
+++ b/openstudiocore/src/model/test/BuildingStory_GTest.cpp
@@ -105,7 +105,7 @@ TEST_F(ModelFixture, BuildingStory_getDefaultSchedule)
 
   // BuildingStory, Building and its SpaceType both have a lighting schedule. It should return the BuildingStory's one in priority
   ASSERT_TRUE(buildingStory.getDefaultSchedule(DefaultScheduleType::LightingSchedule));
-  EXPECT_EQ(sch_bldg_people.handle(), buildingStory.getDefaultSchedule(DefaultScheduleType::LightingSchedule)->handle());
+  EXPECT_EQ(sch_bs_lighting.handle(), buildingStory.getDefaultSchedule(DefaultScheduleType::LightingSchedule)->handle());
 
   // BuldingStory doesn't have one, but Building and its SpaceType both have a people schedule. It should return the building's one in priority
   ASSERT_TRUE(buildingStory.getDefaultSchedule(DefaultScheduleType::NumberofPeopleSchedule));


### PR DESCRIPTION
Fix #3413 - Add `getDefaultSchedule(defaultScheduleType)` for:
* [x] `Building` and,
* [x] `BuildingStory`
