### PR TITLE
 AirLoopHVAC:UnitarySystem add missing control type SingleZoneVAV and make Minimum Supply Air Temperatre autosizable

### DIFF
--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10393,9 +10393,13 @@ OS:AirLoopHVAC:UnitarySystem,
        \type choice
        \key Load
        \key SetPoint
+       \key SingleZoneVAV
        \default Load
        \note Load control requires a Controlling Zone name.
        \note SetPoint control requires set points at coil outlet node.
+       \note SingleZoneVAV also requires a Controlling Zone name and allows
+       \note load control at low speed fan until the load exceeds capacity
+       \note or outlet air temperature limits. The fan speed is then increased.
   A4,  \field Controlling Zone or Thermostat Location
        \note Used only for Load based control
        \type object-list
@@ -10407,14 +10411,14 @@ OS:AirLoopHVAC:UnitarySystem,
        \key Multimode
        \key CoolReheat
        \default None
-       \note None = meet sensible load only
+       \note None = meet sensible load only. Required when Control Type = SingleZoneVAV.
        \note Multimode = activate enhanced dehumidification mode
        \note as needed and meet sensible load.  Valid only with
-       \note cooling coil type CoilSystem:Cooling:DX:HeatExchangerAssisted.
-       \note This control mode allows the heat exchanger to be turned
+       \note cooling coil type Coil:Cooling:DX:TwoStageWithHumidityControlMode or CoilSystem:Cooling:DX:HeatExchangerAssisted.
+       \note This control mode either switches the coil mode or allows the heat exchanger to be turned
        \note on and off based on the zone dehumidification requirements.
        \note A ZoneControl:Humidistat object is also required.
-       \note CoolReheat = cool beyond the dry bulb setpoint.
+       \note CoolReheat = cool beyond the dry-bulb setpoint.
        \note as required to meet the humidity setpoint.  Valid with all
        \note cooling coil types. When a heat exchanger assisted cooling
        \note coil is used, the heat exchanger is locked on at all times.
@@ -10457,7 +10461,8 @@ OS:AirLoopHVAC:UnitarySystem,
        \note Leaving this schedule name blank will default to constant fan mode for the
        \note entire simulation period.
        \note This field is not used when set point based control is used where a set point
-       \note controls the coil (i.e., model assumes constant fan mode operation).
+       \note controls the coil.
+       \note SingleZoneVAV control type is only active when constant fan operating mode is active.
   A12, \field Heating Coil Name
        \type object-list
        \object-list HeatingCoilsDX
@@ -10475,7 +10480,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \default 1.0
        \minimum> 0
        \note Used to adjust heat pump heating capacity with respect to DX cooling capacity
-       \note used only for heat pump configurations (i.e., a cooling and DX heating coil is used).
+       \note used only for heat pump configurations (i.e., a DX cooling and DX heating coil is used).
   A13, \field Cooling Coil Name
        \type object-list
        \object-list CoolingCoilsDX
@@ -10497,19 +10502,22 @@ OS:AirLoopHVAC:UnitarySystem,
        \type real
        \units C
        \minimum 0.0
-       \maximum 7.2
+       \maximum 20.0
        \default 2.0
-       \note DX cooling coil leaving minimum air temperature defines the minimum DOAS DX cooling coil
-       \note leaving air temperature that should be maintained to avoid frost formation. This input
-       \note field is optional and only used along with the input field above.
+       \autosizable
+       \note When Use DOAS DX Cooling Coil is specified as Yes, Minimum Supply Air Temperature
+       \note defines the minimum DOAS DX cooling coil leaving air temperature that should
+       \note be maintained to avoid frost formation. This field is not autosizable when
+       \note the input for Use DOAS DX Cooling Coil = Yes.
+       \note When Control Type = SingleZoneVAV, enter the minimum air temperature limit for reduced fan speed.
   A15, \field Latent Load Control
        \type choice
        \key SensibleOnlyLoadControl
        \key LatentOnlyLoadControl
        \key LatentWithSensibleLoadControl
        \key LatentOrSensibleLoadControl
-       \Default SensibleOnlyLoadControl
-       \note SensibleOnlyLoadControl is selected when thermostat control is used.
+       \default SensibleOnlyLoadControl
+       \note SensibleOnlyLoadControl is selected when thermostat or SingleZoneVAV control is used.
        \note LatentOnlyLoadControl is selected when humidistat control is used.
        \note LatentWithSensibleLoadControl is selected when thermostat control is used and
        \note dehumidification is required only when a sensible load exists.
@@ -10519,6 +10527,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \type object-list
        \object-list HeatingCoilName
        \object-list HeatingCoilsDesuperheater
+       \object-list UserDefinedCoil
        \note Enter the name of the supplemental heating coil if included in the unitary system.
        \note Only required if dehumidification control type is "CoolReheat".
   A17, \field Supply Air Flow Rate Method During Cooling Operation
@@ -10619,7 +10628,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \key FlowPerCoolingCapacity
        \key FlowPerHeatingCapacity
        \note Enter the method used to determine the supply air volume flow rate when no cooling or heating is required.
-       \note None is used when a heating coil is not included in the unitary system or this field may be blank.
+       \note None is used when a cooling and heating coil is not included in the unitary system or this field may be blank.
        \note SupplyAirFlowRate is selected when the magnitude of the supply air volume is used.
        \note FlowPerFloorArea is selected when the supply air volume flow rate is based on total floor area
        \note served by the unitary system.
@@ -10672,6 +10681,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \autosizable
        \default 80.0
        \note Enter the maximum supply air temperature leaving the heating coil.
+       \note When Control Type = SingleZoneVAV, enter the maximum air temperature limit for reduced fan speed.
   N18, \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
        \type real
        \units C
@@ -10756,7 +10766,6 @@ OS:AirLoopHVAC:UnitarySystem,
        \type object-list
        \object-list UnitarySystemPerformaceNames
        \note Enter the name of the performance specification object used to describe the multispeed coil.
-
 OS:UnitarySystemPerformance:Multispeed,
        \memo The UnitarySystemPerformance object is used to specify the air flow ratio at each
        \memo operating speed. This object is primarily used for multispeed DX and water coils to allow

--- a/openstudiocore/resources/model/OpenStudio.idd
+++ b/openstudiocore/resources/model/OpenStudio.idd
@@ -10766,6 +10766,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \type object-list
        \object-list UnitarySystemPerformaceNames
        \note Enter the name of the performance specification object used to describe the multispeed coil.
+
 OS:UnitarySystemPerformance:Multispeed,
        \memo The UnitarySystemPerformance object is used to specify the air flow ratio at each
        \memo operating speed. This object is primarily used for multispeed DX and water coils to allow

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
@@ -255,9 +255,10 @@ boost::optional<IdfObject> ForwardTranslator::translateAirLoopHVACUnitarySystem(
   }
 
   // DOAS DX Cooling Coil Leaving Minimum Air Temperature
-  d = modelObject.dOASDXCoolingCoilLeavingMinimumAirTemperature();
-  if (d) {
-    unitarySystem.setDouble(AirLoopHVAC_UnitarySystemFields::MinimumSupplyAirTemperature,d.get());
+  if( modelObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized() ) {
+    unitarySystem.setString(AirLoopHVAC_UnitarySystemFields::MinimumSupplyAirTemperature, "Autosize");
+  } else if ((d = modelObject.dOASDXCoolingCoilLeavingMinimumAirTemperature())) {
+    unitarySystem.setDouble(AirLoopHVAC_UnitarySystemFields::MinimumSupplyAirTemperature, d.get());
   }
 
   // Latent Load Control

--- a/openstudiocore/src/model/AirLoopHVACUnitarySystem.cpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitarySystem.cpp
@@ -396,6 +396,15 @@ namespace detail {
     return isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature);
   }
 
+  bool AirLoopHVACUnitarySystem_Impl::isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized() const {
+    bool result = false;
+    boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, true);
+    if (value) {
+      result = openstudio::istringEqual(value.get(), "Autosize");
+    }
+    return result;
+  }
+
   std::string AirLoopHVACUnitarySystem_Impl::latentLoadControl() const {
     boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl,true);
     OS_ASSERT(value);
@@ -422,7 +431,7 @@ namespace detail {
     bool result = false;
     boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation, true);
     if (value) {
-      result = openstudio::istringEqual(value.get(), "autosize");
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
     return result;
   }
@@ -451,7 +460,7 @@ namespace detail {
     bool result = false;
     boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation, true);
     if (value) {
-      result = openstudio::istringEqual(value.get(), "autosize");
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
     return result;
   }
@@ -480,7 +489,7 @@ namespace detail {
     bool result = false;
     boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, true);
     if (value) {
-      result = openstudio::istringEqual(value.get(), "autosize");
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
     return result;
   }
@@ -517,7 +526,7 @@ namespace detail {
     bool result = false;
     boost::optional<std::string> value = getString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, true);
     if (value) {
-      result = openstudio::istringEqual(value.get(), "autosize");
+      result = openstudio::istringEqual(value.get(), "Autosize");
     }
     return result;
   }
@@ -780,6 +789,11 @@ namespace detail {
     OS_ASSERT(result);
   }
 
+  void AirLoopHVACUnitarySystem_Impl::autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature() {
+    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, "Autosize");
+    OS_ASSERT(result);
+  }
+
   bool AirLoopHVACUnitarySystem_Impl::setLatentLoadControl(std::string latentLoadControl) {
     bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl, latentLoadControl);
     return result;
@@ -842,7 +856,7 @@ namespace detail {
   }
 
   void AirLoopHVACUnitarySystem_Impl::autosizeSupplyAirFlowRateDuringCoolingOperation() {
-    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation, "autosize");
+    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -932,7 +946,7 @@ namespace detail {
   }
 
   void AirLoopHVACUnitarySystem_Impl::autosizeSupplyAirFlowRateDuringHeatingOperation() {
-    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation, "autosize");
+    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -1022,7 +1036,7 @@ namespace detail {
   }
 
   void AirLoopHVACUnitarySystem_Impl::autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "autosize");
+    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -1130,7 +1144,7 @@ namespace detail {
   }
 
   void AirLoopHVACUnitarySystem_Impl::autosizeMaximumSupplyAirTemperature() {
-    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "autosize");
+    bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "Autosize");
     OS_ASSERT(result);
   }
 
@@ -1274,6 +1288,10 @@ namespace detail {
 
   boost::optional<double> AirLoopHVACUnitarySystem_Impl::autosizedMaximumSupplyAirTemperature() const {
     return getAutosizedValue("Design Size Maximum Supply Air Temperature", "C");
+  }
+
+  boost::optional<double> AirLoopHVACUnitarySystem_Impl::autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature() const {
+    return getAutosizedValue("Design Size Minimum Supply Air Temperature", "C");
   }
 
   void AirLoopHVACUnitarySystem_Impl::autosize() {
@@ -1469,6 +1487,10 @@ double AirLoopHVACUnitarySystem::dOASDXCoolingCoilLeavingMinimumAirTemperature()
 
 bool AirLoopHVACUnitarySystem::isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted() const {
   return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted();
+}
+
+bool AirLoopHVACUnitarySystem::isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized() const {
+  return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized();
 }
 
 std::string AirLoopHVACUnitarySystem::latentLoadControl() const {
@@ -1750,6 +1772,10 @@ bool AirLoopHVACUnitarySystem::setDOASDXCoolingCoilLeavingMinimumAirTemperature(
 
 void AirLoopHVACUnitarySystem::resetDOASDXCoolingCoilLeavingMinimumAirTemperature() {
   getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetDOASDXCoolingCoilLeavingMinimumAirTemperature();
+}
+
+void AirLoopHVACUnitarySystem::autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature() {
+  getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature();
 }
 
 bool AirLoopHVACUnitarySystem::setLatentLoadControl(std::string latentLoadControl) {
@@ -2037,6 +2063,10 @@ AirLoopHVACUnitarySystem::AirLoopHVACUnitarySystem(std::shared_ptr<detail::AirLo
 
   boost::optional<double> AirLoopHVACUnitarySystem::autosizedMaximumSupplyAirTemperature() const {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->autosizedMaximumSupplyAirTemperature();
+  }
+
+  boost::optional<double> AirLoopHVACUnitarySystem::autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature() const {
+    return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature();
   }
 
 } // model

--- a/openstudiocore/src/model/AirLoopHVACUnitarySystem.hpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitarySystem.hpp
@@ -112,7 +112,10 @@ class MODEL_API AirLoopHVACUnitarySystem : public ZoneHVACComponent {
   /** As of EnergyPlus version 8.7.0 this field maps to MinimumSupplyAirTemperature **/
   double dOASDXCoolingCoilLeavingMinimumAirTemperature() const;
 
+  // Note JM 2019-09-27: I would probably make this field \required instead and remove this.
   bool isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted() const;
+
+  bool isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized() const;
 
   std::string latentLoadControl() const;
 
@@ -276,6 +279,9 @@ class MODEL_API AirLoopHVACUnitarySystem : public ZoneHVACComponent {
   /** As of EnergyPlus version 8.7.0 this field maps to MinimumSupplyAirTemperature **/
   bool setDOASDXCoolingCoilLeavingMinimumAirTemperature(double dOASDXCoolingCoilLeavingMinimumAirTemperature);
 
+  void autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature();
+
+  // Would remove
   void resetDOASDXCoolingCoilLeavingMinimumAirTemperature();
 
   bool setLatentLoadControl(std::string latentLoadControl);
@@ -414,15 +420,15 @@ class MODEL_API AirLoopHVACUnitarySystem : public ZoneHVACComponent {
   /** @name Other */
   //@{
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateDuringHeatingOperation() const;
 
-  boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() const ;
+  boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() const;
 
-  boost::optional<double> autosizedMaximumSupplyAirTemperature() const ;
+  boost::optional<double> autosizedMaximumSupplyAirTemperature() const;
 
-
+  boost::optional<double> autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature() const;
 
   //@}
  protected:

--- a/openstudiocore/src/model/AirLoopHVACUnitarySystem_Impl.hpp
+++ b/openstudiocore/src/model/AirLoopHVACUnitarySystem_Impl.hpp
@@ -124,6 +124,8 @@ namespace detail {
 
     bool isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted() const;
 
+    bool isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized() const;
+
     std::string latentLoadControl() const;
 
     bool isLatentLoadControlDefaulted() const;
@@ -224,6 +226,8 @@ namespace detail {
 
     boost::optional<double> autosizedMaximumSupplyAirTemperature() const ;
 
+    boost::optional<double> autosizedDOASDXCoolingCoilLeavingMinimumAirTemperature() const;
+
     virtual void autosize() override;
 
     virtual void applySizingValues() override;
@@ -283,6 +287,8 @@ namespace detail {
     bool setDOASDXCoolingCoilLeavingMinimumAirTemperature(double dOASDXCoolingCoilLeavingMinimumAirTemperature);
 
     void resetDOASDXCoolingCoilLeavingMinimumAirTemperature();
+
+    void autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature();
 
     bool setLatentLoadControl(std::string latentLoadControl);
 

--- a/openstudiocore/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
+++ b/openstudiocore/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
@@ -200,7 +200,17 @@ TEST_F(ModelFixture, AirLoopHVACUnitarySystem_CloneOneModelWithCustomData)
   testObject.setFanPlacement("BlowThrough");
   testObject.setDXHeatingCoilSizingRatio(999.0);
   testObject.setUseDOASDXCoolingCoil(true);
+
+  testObject.resetDOASDXCoolingCoilLeavingMinimumAirTemperature();
+  EXPECT_TRUE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted());
+  EXPECT_FALSE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized());
+  testObject.autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature();
+  EXPECT_FALSE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted());
+  EXPECT_TRUE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized());
   testObject.setDOASDXCoolingCoilLeavingMinimumAirTemperature(7.0);
+  EXPECT_FALSE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureDefaulted());
+  EXPECT_FALSE(testObject.isDOASDXCoolingCoilLeavingMinimumAirTemperatureAutosized());
+
   testObject.setLatentLoadControl("LatentWithSensibleLoadControl");
   testObject.autosizeSupplyAirFlowRateDuringCoolingOperation();
   testObject.autosizeSupplyAirFlowRateDuringHeatingOperation();


### PR DESCRIPTION
Fix #3280  AirLoopHVAC:UnitarySystem add missing control type SingleZoneVAV

Also N2, \field `DOAS DX Cooling Coil Leaving Minimum Air Temperature` in OS (called `Minimum Supply Air Temperature` in E+ now) becomes `autosizable`. And the maximum is raised to 20 too.


----

Note: IDD is falling out of sync with E+, lots of field renames, typos, etc:
* A bunch other fields are renamed too, like Supply Air Flow Rate Method During Cooling Operation which is Cooling Supply Air Flow Rate Method
* Some other fields have a typo in OS and not in E+, eg
OS:Ancilliary On-Cycle Electric Power
E+:Ancillary On-Cycle Electric Power