### PR TITLE
ScheduleTypeRegistry adjustment in looking for a compatible ScheduleTypeLimits

### DIFF
--- a/openstudiocore/src/model/ScheduleTypeRegistry.cpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.cpp
@@ -109,7 +109,7 @@ ScheduleTypeLimits ScheduleTypeRegistrySingleton::getOrCreateScheduleTypeLimits(
   //if (scheduleType.lowerLimitValue && scheduleType.upperLimitValue) {
   ScheduleTypeLimitsVector candidates = model.getConcreteModelObjectsByName<ScheduleTypeLimits>(defaultName);
     for (const ScheduleTypeLimits& candidate : candidates) {
-      if (isCompatible(scheduleType,candidate)) {
+      if (isCompatible(scheduleType,candidate, true)) {
         return candidate;
       }
     }
@@ -493,14 +493,16 @@ std::string ScheduleTypeRegistrySingleton::getDefaultName(const ScheduleType& sc
 
 bool isCompatible(const std::string& className,
                   const std::string& scheduleDisplayName,
-                  const ScheduleTypeLimits& candidate)
+                  const ScheduleTypeLimits& candidate,
+                  bool isStringent)
 {
   ScheduleType scheduleType = ScheduleTypeRegistry::instance().getScheduleType(className,scheduleDisplayName);
-  return isCompatible(scheduleType,candidate);
+  return isCompatible(scheduleType,candidate, isStringent);
 }
 
 bool isCompatible(const ScheduleType& scheduleType,
-                  const ScheduleTypeLimits& candidate)
+                  const ScheduleTypeLimits& candidate,
+                  bool isStringent)
 {
   // do not check continuous/discrete
 
@@ -518,7 +520,7 @@ bool isCompatible(const ScheduleType& scheduleType,
       return false;
     }
   } else {
-    if (candidate.lowerLimitValue()) {
+    if (isStringent && candidate.lowerLimitValue()) {
       return false;
     }
   }
@@ -531,7 +533,7 @@ bool isCompatible(const ScheduleType& scheduleType,
       return false;
     }
   } else {
-    if (candidate.upperLimitValue()) {
+    if (isStringent && candidate.upperLimitValue()) {
       return false;
     }
   }
@@ -549,7 +551,7 @@ bool checkOrAssignScheduleTypeLimits(const std::string& className,
       scheduleDisplayName);
   bool result(true);
   if (OptionalScheduleTypeLimits scheduleTypeLimits = schedule.scheduleTypeLimits()) {
-    if (!isCompatible(scheduleType,*scheduleTypeLimits)) {
+    if (!isCompatible(scheduleType,*scheduleTypeLimits, false)) {
       result = false;
     }
   }
@@ -574,7 +576,7 @@ std::vector<ScheduleTypeLimits> getCompatibleScheduleTypeLimits(const Model& mod
   ScheduleTypeLimitsVector candidates = model.getConcreteModelObjects<ScheduleTypeLimits>();
   ScheduleType scheduleType = ScheduleTypeRegistry::instance().getScheduleType(className,scheduleDisplayName);
   for (const ScheduleTypeLimits& candidate : candidates) {
-    if (isCompatible(scheduleType,candidate)) {
+    if (isCompatible(scheduleType,candidate, true)) {
       result.push_back(candidate);
     }
   }

--- a/openstudiocore/src/model/ScheduleTypeRegistry.cpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.cpp
@@ -109,6 +109,7 @@ ScheduleTypeLimits ScheduleTypeRegistrySingleton::getOrCreateScheduleTypeLimits(
   //if (scheduleType.lowerLimitValue && scheduleType.upperLimitValue) {
   ScheduleTypeLimitsVector candidates = model.getConcreteModelObjectsByName<ScheduleTypeLimits>(defaultName);
     for (const ScheduleTypeLimits& candidate : candidates) {
+      // Pass isStringent = true, so we don't return for eg a Dimensionless schedule with limits [0.5, 0.7] when our object accepts any number
       if (isCompatible(scheduleType,candidate, true)) {
         return candidate;
       }
@@ -493,11 +494,11 @@ std::string ScheduleTypeRegistrySingleton::getDefaultName(const ScheduleType& sc
 
 bool isCompatible(const std::string& className,
                   const std::string& scheduleDisplayName,
-                  const ScheduleTypeLimits& candidate,
-                  bool isStringent)
+                  const ScheduleTypeLimits& candidate)
 {
   ScheduleType scheduleType = ScheduleTypeRegistry::instance().getScheduleType(className,scheduleDisplayName);
-  return isCompatible(scheduleType,candidate, isStringent);
+  // Always call with isString=false
+  return isCompatible(scheduleType, candidate, false);
 }
 
 bool isCompatible(const ScheduleType& scheduleType,
@@ -551,7 +552,9 @@ bool checkOrAssignScheduleTypeLimits(const std::string& className,
       scheduleDisplayName);
   bool result(true);
   if (OptionalScheduleTypeLimits scheduleTypeLimits = schedule.scheduleTypeLimits()) {
-    if (!isCompatible(scheduleType,*scheduleTypeLimits, false)) {
+    // isStringent = false, we do not enforce NOT having lower / upper limits if our object accepts any.
+    // This is user-specified, so user is free to do this
+    if (!isCompatible(scheduleType, *scheduleTypeLimits, false)) {
       result = false;
     }
   }
@@ -576,7 +579,8 @@ std::vector<ScheduleTypeLimits> getCompatibleScheduleTypeLimits(const Model& mod
   ScheduleTypeLimitsVector candidates = model.getConcreteModelObjects<ScheduleTypeLimits>();
   ScheduleType scheduleType = ScheduleTypeRegistry::instance().getScheduleType(className,scheduleDisplayName);
   for (const ScheduleTypeLimits& candidate : candidates) {
-    if (isCompatible(scheduleType,candidate, true)) {
+    // Pass isStringent = true, so we don't return for eg a Dimensionless schedule with limits [0.5, 0.7] when our object accepts any number
+    if (isCompatible(scheduleType, candidate, true)) {
       result.push_back(candidate);
     }
   }

--- a/openstudiocore/src/model/ScheduleTypeRegistry.cpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.cpp
@@ -517,6 +517,10 @@ bool isCompatible(const ScheduleType& scheduleType,
     {
       return false;
     }
+  } else {
+    if (candidate.lowerLimitValue()) {
+      return false;
+    }
   }
 
   // check upper limit
@@ -524,6 +528,10 @@ bool isCompatible(const ScheduleType& scheduleType,
     if (!candidate.upperLimitValue() ||
         (candidate.upperLimitValue().get() > scheduleType.upperLimitValue.get()))
     {
+      return false;
+    }
+  } else {
+    if (candidate.upperLimitValue()) {
       return false;
     }
   }

--- a/openstudiocore/src/model/ScheduleTypeRegistry.hpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.hpp
@@ -83,7 +83,8 @@ typedef std::vector<ScheduleType> ScheduleTypeVector;
 
 /** Returns true if candidate is consistent with scheduleType. \relates ScheduleType */
 MODEL_API bool isCompatible(const ScheduleType& scheduleType,
-                            const ScheduleTypeLimits& candidate);
+                            const ScheduleTypeLimits& candidate,
+                            bool isStringent = false);
 
 
 /** Singleton class that contains a registry of all types of schedules that can exist in a Model.
@@ -133,7 +134,8 @@ typedef openstudio::Singleton<ScheduleTypeRegistrySingleton> ScheduleTypeRegistr
  *  \relates ScheduleTypeRegistrySingleton */
 MODEL_API bool isCompatible(const std::string& className,
                             const std::string& scheduleDisplayName,
-                            const ScheduleTypeLimits& candidate);
+                            const ScheduleTypeLimits& candidate,
+                            bool isStringent = false);
 
 /** If schedule.scheduleTypeLimtis(), returns true if that ScheduleTypeLimits isCompatible and
  *  otherwise returns false. Otherwise, uses

--- a/openstudiocore/src/model/ScheduleTypeRegistry.hpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.hpp
@@ -81,7 +81,9 @@ struct MODEL_API ScheduleType {
 /** \relates ScheduleType */
 typedef std::vector<ScheduleType> ScheduleTypeVector;
 
-/** Returns true if candidate is consistent with scheduleType. \relates ScheduleType */
+/** Returns true if candidate is consistent with scheduleType.
+ * When isStringent is true, we also check that if scheduleType does not have a lower/upper bound, then candidate must not have them either.
+ * \relates ScheduleType */
 MODEL_API bool isCompatible(const ScheduleType& scheduleType,
                             const ScheduleTypeLimits& candidate,
                             bool isStringent = false);
@@ -134,8 +136,7 @@ typedef openstudio::Singleton<ScheduleTypeRegistrySingleton> ScheduleTypeRegistr
  *  \relates ScheduleTypeRegistrySingleton */
 MODEL_API bool isCompatible(const std::string& className,
                             const std::string& scheduleDisplayName,
-                            const ScheduleTypeLimits& candidate,
-                            bool isStringent = false);
+                            const ScheduleTypeLimits& candidate);
 
 /** If schedule.scheduleTypeLimtis(), returns true if that ScheduleTypeLimits isCompatible and
  *  otherwise returns false. Otherwise, uses


### PR DESCRIPTION
Fix #2991 - ScheduleTypeRegistry isCompatible shouldn't return a schedule that does have a lower/upper limit when the ScheduleType we're looking for doesn't.