### PR TITLE
Fix #3669: make order deterministic for SurfacePropertyConvectionCoeficients and SurfacePropertyExposedPerimeter

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.cpp
@@ -3482,7 +3482,6 @@ std::vector<IddObjectType> ForwardTranslator::iddObjectsToTranslateInitializer()
   result.push_back(IddObjectType::OS_ShadingSurfaceGroup);
   result.push_back(IddObjectType::OS_ShadingSurface);
 
-  result.push_back(IddObjectType::OS_SurfaceProperty_ConvectionCoefficients);
   result.push_back(IddObjectType::OS_ZoneProperty_UserViewFactors_BySurfaceName);
 
   result.push_back(IddObjectType::OS_Daylighting_Control);
@@ -3680,10 +3679,11 @@ void ForwardTranslator::translateConstructions(const model::Model & model)
   iddObjectTypes.push_back(IddObjectType::OS_DefaultConstructionSet);
   iddObjectTypes.push_back(IddObjectType::OS_DefaultScheduleSet);
 
-  iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideCoefficients);
-  iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideConditionsModel);
-  iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ExposedFoundationPerimeter);
-  iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ConvectionCoefficients);
+  // Translated by the surface (or subsurface, except ExposedFoundation which doesn't concern it) directly
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideCoefficients);
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideConditionsModel);
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ExposedFoundationPerimeter);
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ConvectionCoefficients);
 
   for (const IddObjectType& iddObjectType : iddObjectTypes){
 

--- a/openstudiocore/src/energyplus/ForwardTranslator.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator.cpp
@@ -3679,11 +3679,11 @@ void ForwardTranslator::translateConstructions(const model::Model & model)
   iddObjectTypes.push_back(IddObjectType::OS_DefaultConstructionSet);
   iddObjectTypes.push_back(IddObjectType::OS_DefaultScheduleSet);
 
-  // Translated by the surface (or subsurface, except ExposedFoundation which doesn't concern it) directly
-  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideCoefficients);
-  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideConditionsModel);
-  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ExposedFoundationPerimeter);
-  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ConvectionCoefficients);
+  // Translated by the object it references directly
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideCoefficients);      // Surface, SubSurface,
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_OtherSideConditionsModel);   // Surface, SubSurface,
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ExposedFoundationPerimeter); // Surface Only
+  //iddObjectTypes.push_back(IddObjectType::OS_SurfaceProperty_ConvectionCoefficients);     // Surface, SubSurface, or InternalMass
 
   for (const IddObjectType& iddObjectType : iddObjectTypes){
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateInternalMass.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateInternalMass.cpp
@@ -74,6 +74,13 @@ boost::optional<IdfObject> ForwardTranslator::translateInternalMass( model::Inte
     spaces = spaceType->spaces();
   }
 
+  // Call the translation of the SurfacePropertyConvectionCoefficients, which has two advantages:
+  // * will not translate them if they are orphaned (=not referencing a surface or subsurface), and,
+  // * makes the order of these objects in the IDF deterministic
+  if (boost::optional<SurfacePropertyConvectionCoefficients> _sCoefs = modelObject.surfacePropertyConvectionCoefficients()) {
+    translateAndMapModelObject(_sCoefs.get());
+  }
+
   boost::optional<IdfObject> result;
   if (spaces.empty()){
 

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateInternalMass.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateInternalMass.cpp
@@ -42,6 +42,7 @@
 #include "../../model/ThermalZone_Impl.hpp"
 #include "../../model/ConstructionBase.hpp"
 #include "../../model/ConstructionBase_Impl.hpp"
+#include "../../model/SurfacePropertyConvectionCoefficients.hpp"
 
 #include <utilities/idd/InternalMass_FieldEnums.hxx>
 #include "../../utilities/idd/IddEnums.hpp"

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSubSurface.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateSubSurface.cpp
@@ -124,6 +124,13 @@ boost::optional<IdfObject> ForwardTranslator::translateSubSurface( model::SubSur
     }
   }
 
+  // Call the translation of the SurfacePropertyConvectionCoefficients, which has two advantages:
+  // * will not translate them if they are orphaned (=not referencing a surface or subsurface), and,
+  // * makes the order of these objects in the IDF deterministic
+  if (boost::optional<SurfacePropertyConvectionCoefficients> _sCoefs = modelObject.surfacePropertyConvectionCoefficients()) {
+    translateAndMapModelObject(_sCoefs.get());
+  }
+
   boost::optional<double> viewFactortoGround = modelObject.viewFactortoGround();
   if (viewFactortoGround){
     idfObject.setDouble(FenestrationSurface_DetailedFields::ViewFactortoGround, *viewFactortoGround);


### PR DESCRIPTION
Fix #3669: make order deterministic for SurfacePropertyConvectionCoeficients and SurfacePropertyExposedPerimeter

Basically Surface and SubSurface FTs are responsible to call the translation of these objects.