### PR TITLE
Add methods to AvailablityManagerNightCycle (applicabilitySchedule) and hide attributes in OS App

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAvailabilityManagerNightCycle.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateAvailabilityManagerNightCycle.cpp
@@ -66,17 +66,22 @@ boost::optional<IdfObject> ForwardTranslator::translateAvailabilityManagerNightC
   }
 
   {
-    auto schedule = modelObject.model().alwaysOnDiscreteSchedule();
+    auto schedule = modelObject.applicabilitySchedule();
     idfObject.setString(AvailabilityManager_NightCycleFields::ApplicabilityScheduleName,schedule.name().get());
   }
 
-  if( airLoopHVAC ) {
-    // Fan schedules are set to match the availabilitySchedule in the translator
-    idfObject.setString(AvailabilityManager_NightCycleFields::FanScheduleName,airLoopHVAC->availabilitySchedule().name().get());
-  }
 
-  // TODO: @kbenne, we don't even translate the AVM:NightCycle if it's not on an airloop anyways
+  // Note: always true, we don't even translate the AVM:NightCycle if it's not on an airloop anyways
   // Translation is triggered from the AirLoopHVAC itself
+  // if( airLoopHVAC ) {
+  //   // Fan schedules are set to match the availabilitySchedule in the translator
+  //   idfObject.setString(AvailabilityManager_NightCycleFields::FanScheduleName,airLoopHVAC->availabilitySchedule().name().get());
+  // }
+
+  // The above was moved to the model API directly, so use that instead. It will fetch the airLoopHVAC availability schedule (which we know exists)
+  if(boost::optional<Schedule> _fanSchedule = modelObject.fanSchedule()) {
+    idfObject.setString(AvailabilityManager_NightCycleFields::FanScheduleName, _fanSchedule->name().get());
+  }
 
   if( auto s = modelObject.name() ) {
     idfObject.setName(*s);

--- a/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
@@ -152,7 +152,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AvailabilityManagerNightCycle) {
   // Schedules
 
   // default
-  EXPECT_EQ(avm.fanSchedule().name().get(),           idf_avm2.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
+  EXPECT_EQ(avm.fanSchedule()->name().get(),          idf_avm2.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
   EXPECT_EQ(a.availabilitySchedule().name().get(),    idf_avm2.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
   EXPECT_EQ("Always On Discrete",                     idf_avm2.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
 
@@ -178,7 +178,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AvailabilityManagerNightCycle) {
   EXPECT_EQ(1u, idfObjs3.size());
   WorkspaceObject idf_avm3(idfObjs3[0]);
 
-  EXPECT_EQ(avm.fanSchedule().name().get(),           idf_avm3.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
+  EXPECT_EQ(avm.fanSchedule()->name().get(),          idf_avm3.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
   EXPECT_EQ(a.availabilitySchedule().name().get(),    idf_avm3.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
   EXPECT_EQ("HVAC Operation",                         idf_avm3.getString(AvailabilityManager_NightCycleFields::FanScheduleName).get());
 

--- a/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
@@ -37,6 +37,8 @@
 #include "../../model/AvailabilityManagerNightCycle.hpp"
 #include "../../model/ThermalZone.hpp"
 #include "../../model/AirLoopHVAC.hpp"
+#include "../../model/Schedule.hpp"
+#include "../../model/ScheduleConstant.hpp"
 
 #include <utilities/idd/AvailabilityManager_NightCycle_FieldEnums.hxx>
 #include <utilities/idd/ZoneList_FieldEnums.hxx>
@@ -183,7 +185,4 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AvailabilityManagerNightCycle) {
   EXPECT_EQ(avm.applicabilitySchedule().name().get(), idf_avm3.getString(AvailabilityManager_NightCycleFields::ApplicabilityScheduleName).get());
   EXPECT_EQ("AVM NightCycle Applicability Schedule",  idf_avm3.getString(AvailabilityManager_NightCycleFields::ApplicabilityScheduleName).get());
 
-
 }
-
-

--- a/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/AvailabilityManagerNightCycle_GTest.cpp
@@ -168,7 +168,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AvailabilityManagerNightCycle) {
 
   ScheduleConstant sch_applicability(m);
   sch_applicability.setName("AVM NightCycle Applicability Schedule");
-  sch.setValue(1.0);
+  sch_applicability.setValue(1.0);
   EXPECT_TRUE(avm.setApplicabilitySchedule(sch_applicability));
 
   // Re translate

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
@@ -38,6 +38,10 @@
 #include "ModelObject.hpp"
 #include "ModelObjectList.hpp"
 #include "ModelObjectList_Impl.hpp"
+#include "Loop.hpp"
+#include "AirLoopHVAC.hpp"
+#include "AirLoopHVAC_Impl.hpp"
+
 #include <utilities/idd/IddFactory.hxx>
 
 #include <utilities/idd/OS_AvailabilityManager_NightCycle_FieldEnums.hxx>
@@ -87,6 +91,48 @@ namespace detail {
   std::vector<ScheduleTypeKey> AvailabilityManagerNightCycle_Impl::getScheduleTypeKeys(const Schedule& schedule) const
   {
     std::vector<ScheduleTypeKey> result;
+    UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
+    UnsignedVector::const_iterator b(fieldIndices.begin()), e(fieldIndices.end());
+    if (std::find(b,e,OS_AvailabilityManager_NightCycleFields::ApplicabilitySchedule) != e)
+    {
+      result.push_back(ScheduleTypeKey("AvailabilityManagerNightCycle","Applicability Schedule"));
+    }
+    return result;
+  }
+
+  boost::optional<Schedule> AvailabilityManagerNightCycle_Impl::optionalApplicabilitySchedule() const {
+    return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_AvailabilityManager_NightCycleFields::ApplicabilitySchedule);
+  }
+
+  Schedule AvailabilityManagerNightCycle_Impl::applicabilitySchedule() const {
+    boost::optional<Schedule> value = optionalApplicabilitySchedule();
+    if (!value) {
+      LOG_AND_THROW(briefDescription() << " does not have an Applicability Schedule attached.");
+    }
+    return value.get();
+  }
+
+  bool AvailabilityManagerNightCycle_Impl::setAvailabilitySchedule(Schedule& schedule) {
+    bool result = setSchedule(OS_AvailabilityManager_NightCycleFields::ApplicabilitySchedule,
+                              "AvailabilityManagerNightCycle",
+                              "Applicability Schedule",
+                              schedule);
+    return result;
+  }
+
+
+  boost::optional<AirLoopHVAC> AvailabilityManagerNightCycle_Impl::airLoopHVAC() const {
+    if (boost::optional<Loop> _loop = loop()) {
+      return _loop->optionalCast<AirLoopHVAC>();
+    }
+    return boost::none;
+  }
+
+  boost::optional<Schedule> AvailabilityManagerNightCycle_Impl::fanSchedule() const {
+    boost::optional<Schedule> result;
+    if (boost::optional<AirLoopHVAC> _airLoop = airLoopHVAC()) {
+      result = _airLoop->availabilitySchedule();
+    }
     return result;
   }
 
@@ -476,6 +522,12 @@ AvailabilityManagerNightCycle::AvailabilityManagerNightCycle(const Model& model)
   : AvailabilityManager(AvailabilityManagerNightCycle::iddObjectType(),model)
 {
   OS_ASSERT(getImpl<detail::AvailabilityManagerNightCycle_Impl>());
+
+  {
+    auto schedule = model.alwaysOnDiscreteSchedule();
+    setApplicabilitySchedule(schedule);
+  }
+
   setThermostatTolerance(1.0);
   setCyclingRunTime(3600);
 
@@ -679,7 +731,21 @@ void AvailabilityManagerNightCycle::resetCyclingRunTimeControlType() {
   getImpl<detail::AvailabilityManagerNightCycle_Impl>()->resetCyclingRunTimeControlType();
 }
 
+boost::optional<AirLoopHVAC> AvailabilityManagerNightCycle::airLoopHVAC() const {
+  return getImpl<detail::AvailabilityManagerNightCycle_Impl>()->airLoopHVAC();
+}
 
+Schedule AvailabilityManagerNightCycle::applicabilitySchedule() const {
+  return getImpl<detail::AvailabilityManagerNightCycle_Impl>()->applicabilitySchedule();
+}
+
+bool AvailabilityManagerNightCycle::setApplicabilitySchedule(Schedule& schedule) {
+  return getImpl<detail::AvailabilityManagerNightCycle_Impl>()->setApplicabilitySchedule(schedule);
+}
+
+boost::optional<Schedule> AvailabilityManagerNightCycle::fanSchedule() const {
+  return getImpl<detail::AvailabilityManagerNightCycle_Impl>()->fanSchedule();
+}
 
 /// @cond
 AvailabilityManagerNightCycle::AvailabilityManagerNightCycle(std::shared_ptr<detail::AvailabilityManagerNightCycle_Impl> impl)

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
@@ -113,7 +113,7 @@ namespace detail {
     return value.get();
   }
 
-  bool AvailabilityManagerNightCycle_Impl::setAvailabilitySchedule(Schedule& schedule) {
+  bool AvailabilityManagerNightCycle_Impl::setApplicabilitySchedule(Schedule& schedule) {
     bool result = setSchedule(OS_AvailabilityManager_NightCycleFields::ApplicabilitySchedule,
                               "AvailabilityManagerNightCycle",
                               "Applicability Schedule",

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
@@ -38,6 +38,7 @@
 #include "ModelObject.hpp"
 #include "ModelObjectList.hpp"
 #include "ModelObjectList_Impl.hpp"
+#include "Model.hpp"
 #include "Loop.hpp"
 #include "AirLoopHVAC.hpp"
 #include "AirLoopHVAC_Impl.hpp"

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.cpp
@@ -539,20 +539,20 @@ AvailabilityManagerNightCycle::AvailabilityManagerNightCycle(const Model& model)
 
   // Cooling Control Zone List
   ModelObjectList coolingControlThermalZoneList = ModelObjectList(model);
-  controlThermalZoneList.setName(this->name().get() + " Cooling Control Zone List");
+  coolingControlThermalZoneList.setName(this->name().get() + " Cooling Control Zone List");
   ok = setPointer(OS_AvailabilityManager_NightCycleFields::CoolingControlZoneorZoneListName, coolingControlThermalZoneList.handle());
   OS_ASSERT(ok);
 
   // Cooling Control Zone List
   ModelObjectList heatingControlThermalZoneList = ModelObjectList(model);
-  controlThermalZoneList.setName(this->name().get() + " Heating Control Zone List");
+  heatingControlThermalZoneList.setName(this->name().get() + " Heating Control Zone List");
   ok = setPointer(OS_AvailabilityManager_NightCycleFields::HeatingControlZoneorZoneListName, heatingControlThermalZoneList.handle());
   OS_ASSERT(ok);
 
 
   // Heating Zone Fans Only Zone List
   ModelObjectList heatingZoneFansOnlyThermalZoneList = ModelObjectList(model);
-  controlThermalZoneList.setName(this->name().get() + " Heating Zone Fans Only Zone List");
+  heatingZoneFansOnlyThermalZoneList.setName(this->name().get() + " Heating Zone Fans Only Zone List");
   ok = setPointer(OS_AvailabilityManager_NightCycleFields::HeatingZoneFansOnlyZoneorZoneListName, heatingZoneFansOnlyThermalZoneList.handle());
   OS_ASSERT(ok);
 }

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.hpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.hpp
@@ -44,6 +44,7 @@ namespace model {
 
 class Schedule;
 class ThermalZone;
+class AirLoopHVAC;
 
 namespace detail {
 

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle.hpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle.hpp
@@ -63,6 +63,13 @@ class MODEL_API AvailabilityManagerNightCycle : public AvailabilityManager {
 
   static std::vector<std::string> controlTypeValues();
 
+  boost::optional<AirLoopHVAC> airLoopHVAC() const;
+
+  Schedule applicabilitySchedule() const;
+  bool setApplicabilitySchedule(Schedule& schedule);
+
+  /** Helper getter which will fetch the AirLoopHVAC::AvailabilitySchedule */
+  boost::optional<Schedule> fanSchedule() const;
 
   std::string controlType() const;
   bool setControlType(std::string controlType);

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle_Impl.hpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle_Impl.hpp
@@ -69,12 +69,14 @@ namespace detail {
 
     virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
+    boost::optional<AirLoopHVAC> airLoopHVAC() const;
 
     Schedule applicabilitySchedule() const;
     bool setApplicabilitySchedule(Schedule& schedule);
 
-    Schedule fanSchedule() const;
-    bool setFanSchedule(Schedule& schedule);
+    boost::optional<Schedule> fanSchedule() const;
+    // Not implemented, it uses AirLoopHVAC::availabilitySchedule
+    // bool setFanSchedule(Schedule& schedule);
 
     std::string controlType() const;
     bool isControlTypeDefaulted() const;
@@ -122,7 +124,6 @@ namespace detail {
     REGISTER_LOGGER("openstudio.model.AvailabilityManagerNightCycle");
 
     boost::optional<Schedule> optionalApplicabilitySchedule() const;
-    boost::optional<Schedule> optionalFanSchedule() const;
 
     std::vector<std::string> controlTypeValues() const;
     openstudio::Quantity thermostatTolerance_SI() const;
@@ -131,15 +132,6 @@ namespace detail {
     openstudio::Quantity cyclingRunTime_IP() const;
 
     std::vector<std::string> cyclingRunTimeControlTypeValues() const;
-
-
-    boost::optional<ModelObject> applicabilityScheduleAsModelObject() const;
-    boost::optional<ModelObject> fanScheduleAsModelObject() const;
-    // boost::optional<ModelObject> controlThermalZonesAsModelObject() const;
-
-    bool setApplicabilityScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
-    bool setFanScheduleAsModelObject(const boost::optional<ModelObject>& modelObject);
-    // bool setControlThermalZoneAsModelObject(const boost::optional<ModelObject>& modelObject);
 
     ModelObjectList controlThermalZoneList() const;
     void clearControlThermalZoneList();

--- a/openstudiocore/src/model/AvailabilityManagerNightCycle_Impl.hpp
+++ b/openstudiocore/src/model/AvailabilityManagerNightCycle_Impl.hpp
@@ -41,6 +41,7 @@ namespace model {
 
 class Schedule;
 class ThermalZone;
+class AirLoopHVAC;
 
 namespace detail {
 

--- a/openstudiocore/src/model/FanConstantVolume.cpp
+++ b/openstudiocore/src/model/FanConstantVolume.cpp
@@ -148,8 +148,8 @@ namespace detail {
   }
 
   bool FanConstantVolume_Impl::setAvailabilitySchedule(Schedule& schedule) {
-    if (boost::optional<AirLoopHVAC> _airLoopHVAC = airLoopHVAC()) {
-      LOG(Warn, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
+    if (boost::optional<AirLoopHVAC> _airLoop = airLoopHVAC()) {
+      LOG(Info, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
              << "', therefore its Availability Schedule will be overriden by the AirLoopHVAC's one.");
     }
     bool result = setSchedule(OS_Fan_ConstantVolumeFields::AvailabilityScheduleName,

--- a/openstudiocore/src/model/FanConstantVolume.cpp
+++ b/openstudiocore/src/model/FanConstantVolume.cpp
@@ -148,6 +148,10 @@ namespace detail {
   }
 
   bool FanConstantVolume_Impl::setAvailabilitySchedule(Schedule& schedule) {
+    if (boost::optional<AirLoopHVAC> _airLoopHVAC = airLoopHVAC()) {
+      LOG(Warn, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
+             << "', therefore its Availability Schedule will be overriden by the AirLoopHVAC's one.");
+    }
     bool result = setSchedule(OS_Fan_ConstantVolumeFields::AvailabilityScheduleName,
                               "FanConstantVolume",
                               "Availability",

--- a/openstudiocore/src/model/FanVariableVolume.cpp
+++ b/openstudiocore/src/model/FanVariableVolume.cpp
@@ -293,8 +293,8 @@ namespace detail {
   }
 
   bool FanVariableVolume_Impl::setAvailabilitySchedule(Schedule& schedule) {
-    if (boost::optional<AirLoopHVAC> _airLoopHVAC = airLoopHVAC()) {
-      LOG(Warn, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
+    if (boost::optional<AirLoopHVAC> _airLoop = airLoopHVAC()) {
+      LOG(Info, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
              << "', therefore its Availability Schedule will be overriden by the AirLoopHVAC's one.");
     }
     bool result = setSchedule(OS_Fan_VariableVolumeFields::AvailabilityScheduleName,

--- a/openstudiocore/src/model/FanVariableVolume.cpp
+++ b/openstudiocore/src/model/FanVariableVolume.cpp
@@ -293,6 +293,10 @@ namespace detail {
   }
 
   bool FanVariableVolume_Impl::setAvailabilitySchedule(Schedule& schedule) {
+    if (boost::optional<AirLoopHVAC> _airLoopHVAC = airLoopHVAC()) {
+      LOG(Warn, briefDescription() << " is connected to an AirLoopHVAC '" << _airLoop->nameString()
+             << "', therefore its Availability Schedule will be overriden by the AirLoopHVAC's one.");
+    }
     bool result = setSchedule(OS_Fan_VariableVolumeFields::AvailabilityScheduleName,
                               "FanVariableVolume",
                               "Availability",

--- a/openstudiocore/src/model/ScheduleTypeRegistry.cpp
+++ b/openstudiocore/src/model/ScheduleTypeRegistry.cpp
@@ -180,6 +180,7 @@ ScheduleTypeRegistrySingleton::ScheduleTypeRegistrySingleton()
     {"AvailabilityManagerHybridVentilation","Minimum Outdoor Ventilation Air Schedule","minimumOutdoorVentilationAirSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
     {"AvailabilityManagerHybridVentilation","AirflowNetwork Control Type Schedule","airflowNetworkControlTypeSchedule",false,"ControlMode",0.0,1.0},
     {"AvailabilityManagerHybridVentilation","Simple Airflow Control Type Schedule","simpleAirflowControlTypeSchedule",false,"ControlMode",0.0,1.0},
+    {"AvailabilityManagerNightCycle","Applicability Schedule","applicabilitySchedule",false,"Availability",0.0,1.0},
     {"AvailabilityManagerNightVentilation","Applicability Schedule","applicabilitySchedule",false,"Availability",0.0,1.0},
     {"AvailabilityManagerNightVentilation","Ventilation Temperature Schedule","ventilationTemperatureSchedule",true,"Temperature",OptionalDouble(),OptionalDouble()},
     {"AvailabilityManagerOptimumStart","Applicability Schedule","applicabilitySchedule",false,"Availability",0.0,1.0},

--- a/openstudiocore/src/model/test/AvailabilityManagerNightCycle_GTest.cpp
+++ b/openstudiocore/src/model/test/AvailabilityManagerNightCycle_GTest.cpp
@@ -32,6 +32,9 @@
 #include "../AvailabilityManagerNightCycle.hpp"
 #include "../AvailabilityManagerNightCycle_Impl.hpp"
 #include "../ThermalZone.hpp"
+#include "../Schedule.hpp"
+#include "../ScheduleConstant.hpp"
+#include "../AirLoopHVAC.hpp"
 #include "../../utilities/units/Quantity.hpp"
 #include "../../utilities/units/Unit.hpp"
 
@@ -136,4 +139,34 @@ TEST_F(ModelFixture, AvailabilityManagerNightCycle_zoneLists)
   EXPECT_EQ(0, avm.heatingControlThermalZones().size());
   EXPECT_EQ(0, avm.heatingZoneFansOnlyThermalZones().size());
 
+}
+
+TEST_F(ModelFixture, AvailabilityManagerNightCycle_Schedules)
+{
+  Model m;
+
+  Schedule alwaysOnDiscreteSchedule = m.alwaysOnDiscreteSchedule();
+  AvailabilityManagerNightCycle avm(m);
+  EXPECT_EQ(alwaysOnDiscreteSchedule, avm.applicabilitySchedule());
+
+  ScheduleConstant sch_applicability(m);
+  sch_applicability.setName("AVM NightCycle Applicability Schedule");
+  sch.setValue(1.0);
+  EXPECT_TRUE(avm.setApplicabilitySchedule(sch_applicability));
+  EXPECT_EQ(sch_applicability, avm.applicabilitySchedule());
+
+  EXPECT_FALSE(avm.airLoopHVAC());
+  EXPECT_FALSE(avm.fanSchedule());
+
+  AirLoopHVAC a(m);
+  ScheduleConstant sch_op(m);
+  sch_op.setName("HVAC Operation");
+  sch_op.setValue(1.0);
+  EXPECT_TRUE(a.setAvailabilitySchedule(sch_op));
+
+  EXPECT_TRUE(a.addAvailabilityManager(avm));
+  EXPECT_TRUE(avm.airLoopHVAC());
+  boost::optional<Schedule> _sch = avm.fanSchedule();
+  ASSERT_TRUE(_sch);
+  EXPECT_EQ(sch_op, _sch.get());
 }

--- a/openstudiocore/src/model/test/AvailabilityManagerNightCycle_GTest.cpp
+++ b/openstudiocore/src/model/test/AvailabilityManagerNightCycle_GTest.cpp
@@ -151,7 +151,7 @@ TEST_F(ModelFixture, AvailabilityManagerNightCycle_Schedules)
 
   ScheduleConstant sch_applicability(m);
   sch_applicability.setName("AVM NightCycle Applicability Schedule");
-  sch.setValue(1.0);
+  sch_applicability.setValue(1.0);
   EXPECT_TRUE(avm.setApplicabilitySchedule(sch_applicability));
   EXPECT_EQ(sch_applicability, avm.applicabilitySchedule());
 
@@ -165,7 +165,9 @@ TEST_F(ModelFixture, AvailabilityManagerNightCycle_Schedules)
   EXPECT_TRUE(a.setAvailabilitySchedule(sch_op));
 
   EXPECT_TRUE(a.addAvailabilityManager(avm));
-  EXPECT_TRUE(avm.airLoopHVAC());
+  boost::optional<AirLoopHVAC> _a = avm.airLoopHVAC();
+  ASSERT_TRUE(_a);
+  EXPECT_EQ(a, _a.get());
   boost::optional<Schedule> _sch = avm.fanSchedule();
   ASSERT_TRUE(_sch);
   EXPECT_EQ(sch_op, _sch.get());

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -13,7 +13,7 @@
     <rule IddField="Induced Air Outlet Port List" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_AvailabilityManager_NightCycle">
-    <rule IddField="Fan Schedule" Access="LOCKED"/>
+    <rule IddField="Fan Schedule" Access="HIDDEN"/>
     <rule IddField="Control Zone or Zone List Name" Access="HIDDEN"/>
     <rule IddField="Cooling Control Zone or Zone List Name" Access="HIDDEN"/>
     <rule IddField="Heating Control Zone or Zone List Name" Access="HIDDEN"/>

--- a/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/openstudiocore/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -12,6 +12,13 @@
     <rule IddField="Outlet Node" Access="HIDDEN"/>
     <rule IddField="Induced Air Outlet Port List" Access="HIDDEN"/>
   </POLICY>
+  <POLICY IddObjectType="OS_AvailabilityManager_NightCycle">
+    <rule IddField="Fan Schedule" Access="LOCKED"/>
+    <rule IddField="Control Zone or Zone List Name" Access="HIDDEN"/>
+    <rule IddField="Cooling Control Zone or Zone List Name" Access="HIDDEN"/>
+    <rule IddField="Heating Control Zone or Zone List Name" Access="HIDDEN"/>
+    <rule IddField="Heating Zone Fans Only Zone or Zone List Name" Access="HIDDEN"/>
+  </POLICY>
   <POLICY IddObjectType="OS_CentralHeatPumpSystem">
     <rule IddField="Cooling Loop Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Cooling Loop Outlet Node Name" Access="HIDDEN"/>

--- a/openstudiocore/src/osversion/VersionTranslator.hpp
+++ b/openstudiocore/src/osversion/VersionTranslator.hpp
@@ -248,6 +248,7 @@ class OSVERSION_API VersionTranslator {
   std::string update_2_7_0_to_2_7_1(const IdfFile& idf_2_7_0, const IddFileAndFactoryWrapper& idd_2_7_1);
   std::string update_2_7_1_to_2_7_2(const IdfFile& idf_2_7_1, const IddFileAndFactoryWrapper& idd_2_7_2);
   std::string update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, const IddFileAndFactoryWrapper& idd_2_9_0);
+  std::string update_2_9_0_to_2_9_1(const IdfFile& idf_2_9_0, const IddFileAndFactoryWrapper& idd_2_9_1);
 
   IdfObject updateUrlField_0_7_1_to_0_7_2(const IdfObject& object, unsigned index);
 


### PR DESCRIPTION
Fix #3568 and Fix #3702 

* add `Schedule AvailablityManagerNightCycle::applicabilitySchedule` (defaults to m.alwaysOnDiscreteSchedule), `AvailablityManagerNightCycle::setApplicabilitySchedule(Schedule&)` 
* Add a helper getter `boost::optional<Schedule> AvailablityManagerNightCycle::fanSchedule()` which will check if there's an AirLoopHVAC, and if so, will return its Availability Schedule (like the FT does already)

----

Fix #3707: Hide the control zones modelObjectList and the Fan Schedule in OS App

![image](https://user-images.githubusercontent.com/5479063/66397716-b1687280-e9dc-11e9-8031-d5fc084cf05f.png)

----

Relates #3627: Add a LOG Info if trying to use FanConstantVolume::setAvailabilitySchedule or FanVariableVolume::setAvailabilitySchedule while these fans are on a AirLoopHVAC (since they will be overriden)

```
fan.addToNode(airLoopHVAC.supplyOutletNode)
fan.setAvailabilitySchedule(sch)
[openstudio.model.FanConstantVolume] <-1> Object of type 'OS:Fan:ConstantVolume' and named 'Fan Constant Volume 1' is connected to an AirLoopHVAC 'Air Loop HVAC 1', therefore its Availability Schedule will be overriden by the AirLoopHVAC's one.
```
