### PR TITLE
Improve the runtime performance of ViewFactor

### DIFF
--- a/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.cpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.cpp
@@ -65,8 +65,14 @@ std::vector<unsigned> WorkspaceExtensibleGroup::getSourceFieldIndices(const Hand
 
 // SETTERS
 bool WorkspaceExtensibleGroup::setPointer(unsigned fieldIndex, const Handle& targetHandle) {
-  if (!isValid(fieldIndex)) { return false; }
-  return getImpl<detail::WorkspaceObject_Impl>()->setPointer(mf_toIndex(fieldIndex),targetHandle);
+  return setPointer(fieldIndex, targetHandle, true);
+}
+
+bool WorkspaceExtensibleGroup::setPointer(unsigned fieldIndex, const Handle& targetHandle, bool checkValidity) {
+  if (checkValidity) {
+    if (!isValid(fieldIndex)) { return false; }
+  }
+  return getImpl<detail::WorkspaceObject_Impl>()->setPointer(mf_toIndex(fieldIndex),targetHandle,checkValidity);
 }
 
 // QUERIES

--- a/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.hpp
+++ b/openstudiocore/src/utilities/idf/WorkspaceExtensibleGroup.hpp
@@ -74,6 +74,8 @@ class UTILITIES_API WorkspaceExtensibleGroup : public IdfExtensibleGroup {
    *  is greater than enums::None, of a proper type). */
   bool setPointer(unsigned fieldIndex, const Handle& targetHandle);
 
+  bool setPointer(unsigned fieldIndex, const Handle& targetHandle, bool checkValidity);
+
   //@}
   /** @name Queries */
   //@{


### PR DESCRIPTION
close #3713

## OpenStudio Pull Request Template

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStrudio Pull Request protocol.

Time for the test case reference in #3713 is now 

kbenne-27067s:OpenStudio kbenne$ time ./build/Products/openstudio build/test.rb
49 view factors => 0.0 sec
64 view factors => 0.0 sec
81 view factors => 0.01 sec
100 view factors => 0.01 sec
121 view factors => 0.01 sec
144 view factors => 0.02 sec
169 view factors => 0.02 sec
196 view factors => 0.04 sec
225 view factors => 0.05 sec
256 view factors => 0.06 sec
289 view factors => 0.08 sec
324 view factors => 0.11 sec
361 view factors => 0.14 sec
400 view factors => 0.18 sec
441 view factors => 0.23 sec
484 view factors => 0.3 sec
529 view factors => 0.4 sec
576 view factors => 0.49 sec
625 view factors => 0.64 sec
676 view factors => 0.76 sec

We can get better but it will require some lower level workspace effort that I will work on and put in a different commit after release.


