### PR TITLE
removing json/ext check as this is statically linked in cli

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -70,12 +70,7 @@ module Kernel
       return false
     end
     
-    if path.include? 'json/ext'
-      if RUBY_PLATFORM =~ /mswin/
-        raise LoadError.new("Preventing segfault if native JSON is built as MinGW")
-      end
-    end
-    
+  
     extname = File.extname(path)
     if extname.empty? or extname != '.rb'
       rb_path = path + '.rb'


### PR DESCRIPTION
This addresses #3746 but is specific to Windows. Current ruby windows build via conan https://github.com/NREL/conan-openstudio-ruby provides msvc native json/ext statically linked in so this check is no longer needed. 