### PR TITLE
Fix Wrong FT enum value for Table:MultiVariableLookup to Table:Lookup

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
@@ -153,7 +153,7 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
 
   // NormalizationReference
   if ((d = modelObject.normalizationReference())) {
-    tableLookup.setString(Table_LookupFields::NormalizationMethod, "Divisor");
+    tableLookup.setString(Table_LookupFields::NormalizationMethod, "DivisorOnly");
     tableLookup.setDouble(Table_LookupFields::NormalizationDivisor, d.get());
   }
 

--- a/openstudiocore/src/energyplus/Test/TableMultiVariableLookup_GTest.cpp
+++ b/openstudiocore/src/energyplus/Test/TableMultiVariableLookup_GTest.cpp
@@ -77,7 +77,7 @@ TEST_F(EnergyPlusFixture,ForwardTranslator_TableMultiVariableLookup)
     ASSERT_DOUBLE_EQ(idfTable.getExtensibleGroup(2).getDouble(Table_LookupExtensibleFields::OutputValue).get(),0.5);
     ASSERT_DOUBLE_EQ(idfTable.getExtensibleGroup(3).getDouble(Table_LookupExtensibleFields::OutputValue).get(),0.7);
     ASSERT_DOUBLE_EQ(idfTable.getExtensibleGroup(4).getDouble(Table_LookupExtensibleFields::OutputValue).get(),0.9);
-    EXPECT_FALSE(idfTable.getString(Table_LookupFields::NormalizationMethod));
+    EXPECT_FALSE(idfTable.getString(Table_LookupFields::NormalizationMethod, false, true)); // Don't return default, return unitialized empty
     EXPECT_FALSE(idfTable.getDouble(Table_LookupFields::NormalizationDivisor));
 
     std::vector<WorkspaceObject> independentVariableObjects = workspace.getObjectsByType(IddObjectType::Table_IndependentVariable);


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3742 (and #3748)
 - Fixes an enum value in the FT for TableMultiVariableLookup translation to TableLookup. Adds a FT test for that case scenario.
* Add a regression test to see if TableMultiVariableLookup to TableLookup is working as intended: https://github.com/NREL/OpenStudio-resources/pull/83

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [x] Added a test in NREL/OpenStudio-resources: https://github.com/NREL/OpenStudio-resources/pull/83
 - [x] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`): N/A
 - [x] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`): N/A
 - [x] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.: N/A
 - [x] All new and existing tests passes
 - [x] If methods have been deprecated, update rest of code to use the new methods: N/A

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
