### PR TITLE
Add shortcuts for SaveAs and  CTRL+R for Revert to Saved

### DIFF
--- a/openstudiocore/src/openstudio_lib/MainMenu.cpp
+++ b/openstudiocore/src/openstudio_lib/MainMenu.cpp
@@ -67,6 +67,7 @@ MainMenu::MainMenu(bool isIP, bool isPlugin, QWidget *parent) :
   m_fileMenu->addSeparator();
 
   m_revertToSavedAction = new QAction(tr("&Revert to Saved"), this);
+  m_revertToSavedAction->setShortcut(QKeySequence(QKeySequence(tr("Ctrl+R")))); // QKeySequence(Qt::CTRL + Qt::Key_R)
   // m_revertToSavedAction->setDisabled(true);
   m_revertToSavedAction->setDisabled(false);
   m_fileMenu->addAction(m_revertToSavedAction);
@@ -78,6 +79,7 @@ MainMenu::MainMenu(bool isIP, bool isPlugin, QWidget *parent) :
   connect(action, &QAction::triggered, this, &MainMenu::saveFileClicked);
 
   action = new QAction(tr("Save &As"), this);
+  action->setShortcut(QKeySequence(QKeySequence::SaveAs));
   m_fileMenu->addAction(action);
   connect(action, &QAction::triggered, this, &MainMenu::saveAsFileClicked);
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3740: add shortcuts: CTRL+SHIFT+S for SaveAs and  CTRL+R for Revert to Saved

![Screenshot from 2019-11-18 11-27-06](https://user-images.githubusercontent.com/5479063/69045136-8d924680-09f6-11ea-8999-d0e138f2e98f.png)

@MatthewSteen FYI


### Pull Request Author

 - [x] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`: N/A
 - [x] If breaking existing API, add the label `APIChange`: N/A
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
