### PR TITLE
Use cached YearDescription everywhere if available instead of using getUniqueModelObject<YearDescription>

### DIFF
--- a/openstudiocore/src/model/Model.hpp
+++ b/openstudiocore/src/model/Model.hpp
@@ -114,14 +114,14 @@ class MODEL_API Model : public openstudio::Workspace {
   /** Get the Building object if there is one, this implementation uses a cached reference to the Building
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<Building>(). */
   boost::optional<Building> building() const;
-  
+
   /** Get the FoundationKivaSettings object if there is one, this implementation uses a cached reference to the FoundationKivaSettings
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<FoundationKivaSettings>(). */
-  boost::optional<FoundationKivaSettings> foundationKivaSettings() const;  
-  
+  boost::optional<FoundationKivaSettings> foundationKivaSettings() const;
+
   /** Get the PerformancePrecisionTradeoffs object if there is one, this implementation uses a cached reference to the PerformancePrecisionTradeoffs
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<PerformancePrecisionTradeoffs>(). */
-  boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;  
+  boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;
 
   /** Get the LifeCycleCostParameters object if there is one, this implementation uses a cached reference to the LifeCycleCostParameters
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<LifeCycleCostParameters>(). */
@@ -234,7 +234,10 @@ class MODEL_API Model : public openstudio::Workspace {
    *  \todo Use of this template method requires knowledge of the size of the implementation object.
    *  Therefore, to use model.getUniqueModelObject<Facility>() the user must include both
    *  Facility.hpp and Facility_Impl.hpp. It may be better to instantiate each version of this
-   *  template method to avoid exposing the implementation objects, this is an open question. */
+   *  template method to avoid exposing the implementation objects, this is an open question.
+   *  Additionally, you should also prefer using direct getters if they exists and can return a cached object
+   *  since this implementation tests all objects in the model and is slower
+   *  eg: Prefer using `boost::optional<YearDescription> Model::yearDescription())` */
   template <typename T>
   T getUniqueModelObject() {
     std::vector<WorkspaceObject> objects = this->allObjects();

--- a/openstudiocore/src/model/RunPeriodControlDaylightSavingTime.cpp
+++ b/openstudiocore/src/model/RunPeriodControlDaylightSavingTime.cpp
@@ -218,7 +218,13 @@ namespace detail {
   openstudio::Date RunPeriodControlDaylightSavingTime_Impl::getDate(const std::string& text) const
   {
     Date result;
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
+    // Use the cached version if available (faster), otherwise initialize it
+    // try the cached version first
+    boost::optional<YearDescription> yd = this->model().yearDescription();
+    if (!yd) {
+      yd = this->model().getUniqueModelObject<model::YearDescription>();
+    }
+    OS_ASSERT(yd);
 
     /*
      \note  <number>/<number>  (month/day)
@@ -240,7 +246,7 @@ namespace detail {
       std::string dayOfMonthString(matches[2].first, matches[2].second);
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
 
-      result = yd.makeDate(monthOfYear, dayOfMonth);
+      result = yd->makeDate(monthOfYear, dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(\\d+)\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)", boost::regex::icase))){
 
@@ -248,7 +254,7 @@ namespace detail {
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
       std::string monthString(matches[2].first, matches[2].second);
 
-      result = yd.makeDate(monthOfYear(monthString), dayOfMonth);
+      result = yd->makeDate(monthOfYear(monthString), dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)\\s+(\\d+)", boost::regex::icase))){
 
@@ -256,7 +262,7 @@ namespace detail {
       std::string dayOfMonthString(matches[2].first, matches[2].second);
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
 
-      result = yd.makeDate(monthOfYear(monthString), dayOfMonth);
+      result = yd->makeDate(monthOfYear(monthString), dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(1|2|3|4|5|1st|2nd|3rd|4th|5th|Last)\\s+(Sun|Mon|Tue|Wed|Thu|Fri|Sat|Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)\\s+in\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)", boost::regex::icase))){
 
@@ -264,7 +270,7 @@ namespace detail {
       std::string dayOfWeekString(matches[2].first, matches[2].second);
       std::string monthString(matches[3].first, matches[3].second);
 
-      result = yd.makeDate(nthDayOfWeekInMonth(nthString), dayOfWeek(dayOfWeekString), monthOfYear(monthString));
+      result = yd->makeDate(nthDayOfWeekInMonth(nthString), dayOfWeek(dayOfWeekString), monthOfYear(monthString));
       return result;
     }
 

--- a/openstudiocore/src/model/RunPeriodControlSpecialDays.cpp
+++ b/openstudiocore/src/model/RunPeriodControlSpecialDays.cpp
@@ -68,8 +68,6 @@ namespace detail {
 
   Date RunPeriodControlSpecialDays_Impl::startDate() const
   {
-    Date result;
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
     boost::optional<std::string> text = getString(OS_RunPeriodControl_SpecialDaysFields::StartDate);
     OS_ASSERT(text);
     return getDate(*text);
@@ -179,7 +177,13 @@ namespace detail {
   openstudio::Date RunPeriodControlSpecialDays_Impl::getDate(const std::string& text) const
   {
     Date result;
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
+
+    // Use the cached version if available (faster), otherwise initialize it
+    boost::optional<YearDescription> yd = this->model().yearDescription();
+    if (!yd) {
+      yd = this->model().getUniqueModelObject<model::YearDescription>();
+    }
+    OS_ASSERT(yd);
 
     /*
      \note  <number>/<number>  (month/day)
@@ -201,7 +205,7 @@ namespace detail {
       std::string dayOfMonthString(matches[2].first, matches[2].second);
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
 
-      result = yd.makeDate(monthOfYear, dayOfMonth);
+      result = yd->makeDate(monthOfYear, dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(\\d+)\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)", boost::regex::icase))){
 
@@ -209,7 +213,7 @@ namespace detail {
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
       std::string monthString(matches[2].first, matches[2].second);
 
-      result = yd.makeDate(monthOfYear(monthString), dayOfMonth);
+      result = yd->makeDate(monthOfYear(monthString), dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)\\s+(\\d+)", boost::regex::icase))){
 
@@ -217,7 +221,7 @@ namespace detail {
       std::string dayOfMonthString(matches[2].first, matches[2].second);
       unsigned dayOfMonth = boost::lexical_cast<unsigned>(dayOfMonthString);
 
-      result = yd.makeDate(monthOfYear(monthString), dayOfMonth);
+      result = yd->makeDate(monthOfYear(monthString), dayOfMonth);
       return result;
     }else if (boost::regex_search(text, matches, boost::regex("(1|2|3|4|5|1st|2nd|3rd|4th|5th|Last)\\s+(Sun|Mon|Tue|Wed|Thu|Fri|Sat|Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)\\s+in\\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)", boost::regex::icase))){
 
@@ -225,7 +229,7 @@ namespace detail {
       std::string dayOfWeekString(matches[2].first, matches[2].second);
       std::string monthString(matches[3].first, matches[3].second);
 
-      result = yd.makeDate(nthDayOfWeekInMonth(nthString), dayOfWeek(dayOfWeekString), monthOfYear(monthString));
+      result = yd->makeDate(nthDayOfWeekInMonth(nthString), dayOfWeek(dayOfWeekString), monthOfYear(monthString));
       return result;
     }
 

--- a/openstudiocore/src/model/ScheduleYear.cpp
+++ b/openstudiocore/src/model/ScheduleYear.cpp
@@ -109,7 +109,12 @@ namespace detail {
   {
     std::vector<openstudio::Date> result;
 
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
+    // Use the cached version if available (faster), otherwise initialize it
+    boost::optional<YearDescription> yd = this->model().yearDescription();
+    if (!yd) {
+      yd = this->model().getUniqueModelObject<model::YearDescription>();
+    }
+    OS_ASSERT(yd);
 
     for (const ModelExtensibleGroup& group : castVector<ModelExtensibleGroup>(this->extensibleGroups()))
     {
@@ -117,7 +122,7 @@ namespace detail {
       OptionalUnsigned day = group.getUnsigned(1, true);
 
       if (month && day){
-        result.push_back(yd.makeDate(*month, *day));
+        result.push_back(yd->makeDate(*month, *day));
       }else{
         LOG(Error, "Could not read date " << group.groupIndex() << " in " << briefDescription() << "." );
       }
@@ -149,10 +154,15 @@ namespace detail {
 
   boost::optional<ScheduleWeek> ScheduleYear_Impl::getScheduleWeek(const openstudio::Date& date) const
   {
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
+    // Use the cached version if available (faster), otherwise initialize it
+    boost::optional<YearDescription> yd = this->model().yearDescription();
+    if (!yd) {
+      yd = this->model().getUniqueModelObject<model::YearDescription>();
+    }
+    OS_ASSERT(yd);
 
-    if (yd.assumedYear() != date.assumedBaseYear()){
-      LOG(Error, "Assumed base year " << date.assumedBaseYear() << " of date does not match this model's assumed base year of " << yd.assumedYear());
+    if (yd->assumedYear() != date.assumedBaseYear()){
+      LOG(Error, "Assumed base year " << date.assumedBaseYear() << " of date does not match this model's assumed base year of " << yd->assumedYear());
       return boost::none;
     }
 
@@ -182,10 +192,15 @@ namespace detail {
 
   bool ScheduleYear_Impl::addScheduleWeek(const openstudio::Date& untilDate, const ScheduleWeek& scheduleWeek)
   {
-    YearDescription yd = this->model().getUniqueModelObject<YearDescription>();
+    // Use the cached version if available (faster), otherwise initialize it
+    boost::optional<YearDescription> yd = this->model().yearDescription();
+    if (!yd) {
+      yd = this->model().getUniqueModelObject<model::YearDescription>();
+    }
+    OS_ASSERT(yd);
 
-    if (yd.assumedYear() != untilDate.assumedBaseYear()){
-      LOG(Error, "Assumed base year " << untilDate.assumedBaseYear() << " of untilDate does not match this model's assumed base year of " << yd.assumedYear());
+    if (yd->assumedYear() != untilDate.assumedBaseYear()){
+      LOG(Error, "Assumed base year " << untilDate.assumedBaseYear() << " of untilDate does not match this model's assumed base year of " << yd->assumedYear());
       return false;
     }
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3755
 - Use cached `yearDescription()` everywhere if available  instead of using `getUniqueModelObject<YearDescription>` that will always loop through all objects in the model (and therefore incur a huge penalty costs).

The other singleton objects aren't going to be called often so I didn't touch them. (eg SimulationControl isn't going to be accessed more than a couple of times)


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate): N/A
 - [x] Model API methods are tested (in `src/model/test`): tests are already existing, I'm modifying the implemention of existing methods only
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`: N/A
 - [x] If breaking existing API, add the label `APIChange`: N/A
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
