### PR TITLE
3.0-pre comment out warnings

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -102,8 +102,8 @@ module Kernel
     current_directory = Dir.pwd 
     if original_directory != current_directory
       Dir.chdir(original_directory)
-      puts "Directory changed from '#{original_directory}' to '#{current_directory}' while requiring '#{path}', result = #{result}, restoring original_directory"
-      STDOUT.flush
+      #puts "Directory changed from '#{original_directory}' to '#{current_directory}' while requiring '#{path}', result = #{result}, restoring original_directory"
+      #STDOUT.flush
     end
     
     return result
@@ -122,8 +122,8 @@ module Kernel
     current_directory = Dir.pwd 
     if original_directory != current_directory
       Dir.chdir(original_directory)
-      puts "Directory changed from '#{original_directory}' to '#{current_directory}' while require_embedded_absolute '#{path}', result = #{result}, restoring original_directory"
-      STDOUT.flush
+      #puts "Directory changed from '#{original_directory}' to '#{current_directory}' while require_embedded_absolute '#{path}', result = #{result}, restoring original_directory"
+      #STDOUT.flush
     end
     
     return result


### PR DESCRIPTION
This is a pull request for the `v3.0-pre` branch.  It comments out a couple warnings that are interfering with stdout from our OS workflow.
