### PR TITLE
Disallow picking Zones with useIdealAirLoads in the plenum picker in OS App to avoid crash in E+

### DIFF
--- a/openstudiocore/src/openstudio_lib/InspectorView.cpp
+++ b/openstudiocore/src/openstudio_lib/InspectorView.cpp
@@ -918,7 +918,9 @@ NewPlenumDialog::NewPlenumDialog(QWidget * parent)
       it != allZones.end();
       ++it)
   {
-    if( (! it->isPlenum()) && it->equipment().empty() && (! it->airLoopHVAC()) )
+    // equipment() is empty if you useIdealAirLoads, so we have to filter that out explicitly
+    // to match AirLoopHVACSupplyReturnPlenum_Impl::setThermalZone and AirLoopHVACReturnPlenum_Impl::setThermalZone
+    if( (! it->isPlenum()) && it->equipment().empty() && (! it->airLoopHVAC()) && (! it->useIdealAirLoads()) )
     {
       zoneChooser->addItem(QString::fromStdString(it->name().get()),toQString(it->handle()));
     }


### PR DESCRIPTION
**There is a develop3 version at https://github.com/NREL/OpenStudioApplication/pull/43**

------

Pull request overview
---------------------

 - Fixes #3083
 - Do not display zones that have `useIdealAirLoads == true` in the plenum picker in OS app to match `AirLoopHVACSupplyReturnPlenum_Impl::setThermalZone` and `AirLoopHVACReturnPlenum_Impl::setThermalZone`


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
