### PR TITLE
ReverseTranslate ZoneLists to SpaceTypes

### DIFF
--- a/src/energyplus/ReverseTranslator.cpp
+++ b/src/energyplus/ReverseTranslator.cpp
@@ -1057,7 +1057,7 @@ boost::optional<ModelObject> ReverseTranslator::translateAndMapWorkspaceObject(c
   }
   case openstudio::IddObjectType::ZoneList:
     {
-      modelObject = translateZone(workspaceObject);
+      modelObject = translateZoneList(workspaceObject);
       break;
     }
   case openstudio::IddObjectType::ZoneMixing:

--- a/src/energyplus/ReverseTranslator/ReverseTranslateZoneList.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateZoneList.cpp
@@ -48,8 +48,8 @@ namespace energyplus {
 
 OptionalModelObject ReverseTranslator::translateZoneList( const WorkspaceObject & workspaceObject )
 {
-   if( workspaceObject.iddObject().type() != IddObjectType::Zone ){
-    LOG(Error, "WorkspaceObject is not IddObjectType: Zone");
+   if( workspaceObject.iddObject().type() != IddObjectType::ZoneList ){
+    LOG(Error, "WorkspaceObject is not IddObjectType: ZoneList");
     return boost::none;
   }
 
@@ -60,6 +60,9 @@ OptionalModelObject ReverseTranslator::translateZoneList( const WorkspaceObject 
     spaceType.setName(*s);
   }
 
+  // Note that this is coarse: it will create a space type for each Zonelist it finds, but if a zone is referenced by multiple zonelists,
+  // its spaces will end up with a spacetype corresponding to the last Zonelist it found that references it.
+  // You'll get a warning that the previous SpaceType was overwritten though
   for (const IdfExtensibleGroup& idfGroup : workspaceObject.extensibleGroups()){
     WorkspaceExtensibleGroup workspaceGroup = idfGroup.cast<WorkspaceExtensibleGroup>();
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #1019
 - ReverseTranslate ZoneLists to SpaceTypes. There were some typos that prevented it from working when it was already coded for.
 - Add ReverseTranslator test for that

### Pull Request Author

 - [x] Fix typos to make RT for ZoneList functional.
 - [x] EnergyPlus ReverseTranslator Tests (in `src/energyplus/Test`)
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
