### PR TITLE
Add overload to getObjectsByType taking a string instead of IddObjectType and more informative Errror Message for Bad Enum

### DIFF
--- a/src/utilities/core/EnumBase.hpp
+++ b/src/utilities/core/EnumBase.hpp
@@ -71,7 +71,7 @@ template<typename Enum>
         auto itr = m.find(t_value);
         if (itr == m.end())
         {
-          throw std::runtime_error("Invalid domain");
+          throw std::runtime_error("Invalid domain for OpenStudio Enum");
         }
         return itr->second;
       }
@@ -147,7 +147,7 @@ template<typename Enum>
         {
           return itr->second;
         }
-        throw std::runtime_error("Unknown Value");
+        throw std::runtime_error("Unknown OpenStudio Enum Value '" + t_name + "'");
       }
 
       /** Returns t_value if it is in the domain. Otherwise throws std::runtime_error. */
@@ -158,7 +158,7 @@ template<typename Enum>
         {
           return t_value;
         } else {
-          throw std::runtime_error("Unknown value");
+          throw std::runtime_error("Unknown OpenStudio Enum Value = " + std::to_string(t_value));
         }
       }
 

--- a/src/utilities/core/test/Enum_GTest.cpp
+++ b/src/utilities/core/test/Enum_GTest.cpp
@@ -56,8 +56,23 @@ namespace enums {
 TEST(Enum, EnumThrows)
 {
   EXPECT_THROW(openstudio::enums::TestEnum("forth"), std::runtime_error);
+  // #1741, we expect an informative error message
+  try {
+    openstudio::enums::TestEnum("forth");
+  } catch (std::runtime_error& e) {
+    std::string expectedErrorMessage("Unknown OpenStudio Enum Value 'FORTH'");
+    EXPECT_EQ(expectedErrorMessage, std::string(e.what()));
+  }
+
   EXPECT_NO_THROW(openstudio::enums::TestEnum("third"));
   EXPECT_THROW(openstudio::enums::TestEnum(3), std::runtime_error);
+  try {
+    openstudio::enums::TestEnum(3);
+  } catch (std::runtime_error& e) {
+    std::string expectedErrorMessage("Unknown OpenStudio Enum Value = 3");
+    EXPECT_EQ(expectedErrorMessage, std::string(e.what()));
+  }
+
   EXPECT_THROW(openstudio::enums::TestEnum3(4), std::runtime_error);
   EXPECT_THROW(openstudio::enums::TestEnum3("bob"), std::runtime_error);
   EXPECT_NO_THROW(openstudio::enums::TestEnum3("my second"));

--- a/src/utilities/idf/Test/IdfFixture.cpp
+++ b/src/utilities/idf/Test/IdfFixture.cpp
@@ -47,6 +47,7 @@ void IdfFixture::SetUpTestCase() {
 
   // load idfFile and time it
   openstudio::Time start = openstudio::Time::currentTime();
+  // Note: The name implies 5 zones; but there's actually a plenum, so 6 zones in total
   openstudio::path path = resourcesPath()/toPath("energyplus/5ZoneAirCooled/in.idf");
   openstudio::OptionalIdfFile oidf = openstudio::IdfFile::load(path); // should assume IddFileType::EnergyPlus
   ASSERT_TRUE(oidf);

--- a/src/utilities/idf/Workspace.cpp
+++ b/src/utilities/idf/Workspace.cpp
@@ -2932,6 +2932,23 @@ IdfFile Workspace::toIdfFile() const {
   return m_impl->toIdfFile();
 }
 
+// OVERLOADED FUNCTIONS THAT TAKE IN A std::string INSTEAD OF AN IddObjecTtype
+
+std::vector<WorkspaceObject> Workspace::getObjectsByType(const std::string& objectTypeName) const {
+  return getObjectsByType(IddObjectType(objectTypeName));
+}
+
+boost::optional<WorkspaceObject> Workspace::getObjectByTypeAndName(const std::string& objectTypeName,
+                                                                   const std::string& name) const {
+  return getObjectByTypeAndName(IddObjectType(objectTypeName), name);
+}
+
+std::vector<WorkspaceObject> Workspace::getObjectsByTypeAndName(const std::string& objectTypeName,
+                                                                const std::string& name) const {
+  return getObjectsByTypeAndName(IddObjectType(objectTypeName), name);
+}
+
+
 // PROTECTED
 
 Workspace::Workspace(std::shared_ptr<detail::Workspace_Impl> impl)

--- a/src/utilities/idf/Workspace.hpp
+++ b/src/utilities/idf/Workspace.hpp
@@ -228,6 +228,15 @@ class UTILITIES_API Workspace {
   boost::optional<WorkspaceObject> getObjectByNameAndReference(
       std::string name,const std::vector<std::string>& referenceNames) const;
 
+  /** Overloaded functions that take in a std::string instead of an IddObjectType.
+   *  They will internally create an IddObjectType (which may throw!) then forward to the overload method that takes IddObjectType
+   *  eg: `getObjectsByType(IddObjectType objectType)` */
+  std::vector<WorkspaceObject> getObjectsByType(const std::string& objectTypeName) const;
+  boost::optional<WorkspaceObject> getObjectByTypeAndName(const std::string& objectTypeName,
+                                                          const std::string& name) const;
+  std::vector<WorkspaceObject> getObjectsByTypeAndName(const std::string& objectTypeName,
+                                                       const std::string& name) const;
+
   /** Returns true if fast naming is enabled. Fast naming creates UUID-based names for new
    *  objects and does not do any name conflict checking. */
   bool fastNaming() const;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #1531: add overloaded methods that take a std::string for getObjectsByType, getObjectByTypeAndName and getObjectsByTypeAndName
 - Fix #1741: add a more informative error message for Bad Enum


**Before**:
```
[1] OS-build(main)> "WaterHeaterMixed".to_IddObjectType
RuntimeError: Unknown Value
from eval:1:in `initialize'

# Forced to use to_IddObjectType
[2] OS-build(main)> m.getObjectsByType("WaterHeater:Mixed".to_IddObjectType)
```

**After**

```
[1] OS-build(main)> "WaterHeaterMixed".to_IddObjectType
RuntimeError: Unknown OpenStudio Enum Value 'WATERHEATERMIXED'
from eval:1:in `initialize'

[2] OS-build(main)> m = Model.new
=> #<OpenStudio::Model::Model:0x000056203ceea018
 @__swigtype__="_p_openstudio__model__Model">
[3] OS-build(main)> m.getObjectsByType("WaterHeater:Mixed")
=> []
```

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
