### PR TITLE
Use template specialization for getUniqueModelObjects<YearDescription> to use cached object

### DIFF
--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -2578,7 +2578,52 @@ void Model::applySizingValues() {
 }
 
 
-// Template specilization to use caching for YearDescription
+// Template specializations for getUniqueModelObject to use caching
+template<>
+Building Model::getUniqueModelObject<Building>() {
+  if (boost::optional<Building> _b = building()) {
+    return _b.get();
+  } else {
+    return Building(*this);
+  }
+}
+
+template <>
+FoundationKivaSettings Model::getUniqueModelObject<FoundationKivaSettings>() {
+  if (boost::optional<FoundationKivaSettings> _b = foundationKivaSettings()) {
+    return _b.get();
+  } else {
+    return FoundationKivaSettings(*this);
+  }
+}
+
+template <>
+LifeCycleCostParameters Model::getUniqueModelObject<LifeCycleCostParameters>() {
+  if (boost::optional<LifeCycleCostParameters> _l = lifeCycleCostParameters()) {
+    return _l.get();
+  } else {
+    return LifeCycleCostParameters(*this);
+  }
+}
+
+template <>
+PerformancePrecisionTradeoffs Model::getUniqueModelObject<PerformancePrecisionTradeoffs>() {
+  if (boost::optional<PerformancePrecisionTradeoffs> _p = performancePrecisionTradeoffs()) {
+    return _p.get();
+  } else {
+    return PerformancePrecisionTradeoffs(*this);
+  }
+}
+
+template <>
+RunPeriod Model::getUniqueModelObject<RunPeriod>() {
+  if (boost::optional<RunPeriod> _r = runPeriod()) {
+    return _r.get();
+  } else {
+    return RunPeriod(*this);
+  }
+}
+
 template<>
 YearDescription Model::getUniqueModelObject<YearDescription>() {
   if (boost::optional<YearDescription> _yd = yearDescription()) {
@@ -2588,12 +2633,12 @@ YearDescription Model::getUniqueModelObject<YearDescription>() {
   }
 }
 
-template<>
-Building Model::getUniqueModelObject<Building>() {
-  if (boost::optional<Building> _b = building()) {
-    return _b.get();
+template <>
+WeatherFile Model::getUniqueModelObject<WeatherFile>() {
+  if (boost::optional<WeatherFile> _w = weatherFile()) {
+    return _w.get();
   } else {
-    return Building(*this);
+    return WeatherFile(*this);
   }
 }
 

--- a/src/model/Model.cpp
+++ b/src/model/Model.cpp
@@ -2577,6 +2577,26 @@ void Model::applySizingValues() {
   return getImpl<detail::Model_Impl>()->applySizingValues();
 }
 
+
+// Template specilization to use caching for YearDescription
+template<>
+YearDescription Model::getUniqueModelObject<YearDescription>() {
+  if (boost::optional<YearDescription> _yd = yearDescription()) {
+    return _yd.get();
+  } else {
+    return YearDescription(*this);
+  }
+}
+
+template<>
+Building Model::getUniqueModelObject<Building>() {
+  if (boost::optional<Building> _b = building()) {
+    return _b.get();
+  } else {
+    return Building(*this);
+  }
+}
+
 std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> detail::Model_Impl::ModelObjectCreator::getNew(
   Model_Impl * model,
   const IdfObject& obj,

--- a/src/model/Model.hpp
+++ b/src/model/Model.hpp
@@ -516,12 +516,27 @@ MODEL_API Model exampleModel();
 /// Adds example model objects to an existing model.
 MODEL_API void addExampleModelObjects(Model& model);
 
-// Template specilizations for getUniqueModelObject to use caching
+// Template specializations for getUniqueModelObject to use caching
+template <>
+Building Model::getUniqueModelObject<Building>();
+
+template <>
+FoundationKivaSettings Model::getUniqueModelObject<FoundationKivaSettings>();
+
+template <>
+LifeCycleCostParameters Model::getUniqueModelObject<LifeCycleCostParameters>();
+
+template <>
+PerformancePrecisionTradeoffs Model::getUniqueModelObject<PerformancePrecisionTradeoffs>();
+
+template <>
+RunPeriod Model::getUniqueModelObject<RunPeriod>();
+
 template <>
 YearDescription Model::getUniqueModelObject<YearDescription>();
 
 template <>
-Building Model::getUniqueModelObject<Building>();
+WeatherFile Model::getUniqueModelObject<WeatherFile>();
 
 } // model
 } // openstudio

--- a/src/model/Model.hpp
+++ b/src/model/Model.hpp
@@ -114,14 +114,14 @@ class MODEL_API Model : public openstudio::Workspace {
   /** Get the Building object if there is one, this implementation uses a cached reference to the Building
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<Building>(). */
   boost::optional<Building> building() const;
-  
+
   /** Get the FoundationKivaSettings object if there is one, this implementation uses a cached reference to the FoundationKivaSettings
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<FoundationKivaSettings>(). */
-  boost::optional<FoundationKivaSettings> foundationKivaSettings() const;  
-  
+  boost::optional<FoundationKivaSettings> foundationKivaSettings() const;
+
   /** Get the PerformancePrecisionTradeoffs object if there is one, this implementation uses a cached reference to the PerformancePrecisionTradeoffs
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<PerformancePrecisionTradeoffs>(). */
-  boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;  
+  boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;
 
   /** Get the LifeCycleCostParameters object if there is one, this implementation uses a cached reference to the LifeCycleCostParameters
    *  object which can be significantly faster than calling getOptionalUniqueModelObject<LifeCycleCostParameters>(). */
@@ -234,7 +234,11 @@ class MODEL_API Model : public openstudio::Workspace {
    *  \todo Use of this template method requires knowledge of the size of the implementation object.
    *  Therefore, to use model.getUniqueModelObject<Facility>() the user must include both
    *  Facility.hpp and Facility_Impl.hpp. It may be better to instantiate each version of this
-   *  template method to avoid exposing the implementation objects, this is an open question. */
+   *  template method to avoid exposing the implementation objects, this is an open question.
+   *
+   *  Note that template specilizations are provided below for objects were there is a
+   *  performance gain to be had by caching the unique model object
+   *  eg: getUniqueModelObject<YearDescription>() */
   template <typename T>
   T getUniqueModelObject() {
     std::vector<WorkspaceObject> objects = this->allObjects();
@@ -511,6 +515,13 @@ MODEL_API Model exampleModel();
 
 /// Adds example model objects to an existing model.
 MODEL_API void addExampleModelObjects(Model& model);
+
+// Template specilizations for getUniqueModelObject to use caching
+template <>
+YearDescription Model::getUniqueModelObject<YearDescription>();
+
+template <>
+Building Model::getUniqueModelObject<Building>();
 
 } // model
 } // openstudio

--- a/src/model/Model_Impl.hpp
+++ b/src/model/Model_Impl.hpp
@@ -145,11 +145,11 @@ namespace detail {
     /** Get the FoundationKivaSettings object if there is one, this implementation uses a cached reference to the FoundationKivaSettings
      *  object which can be significantly faster than calling getOptionalUniqueModelObject<FoundationKivaSettings>(). */
     boost::optional<FoundationKivaSettings> foundationKivaSettings() const;
-    
+
     /** Get the PerformancePrecisionTradeoffs object if there is one, this implementation uses a cached reference to the PerformancePrecisionTradeoffs
      *  object which can be significantly faster than calling getOptionalUniqueModelObject<PerformancePrecisionTradeoffs>(). */
-    boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;    
-    
+    boost::optional<PerformancePrecisionTradeoffs> performancePrecisionTradeoffs() const;
+
     /** Get the LifeCycleCostParameters object if there is one, this implementation uses a cached reference to the LifeCycleCostParameters
      *  object which can be significantly faster than calling getOptionalUniqueModelObject<LifeCycleCostParameters>(). */
     boost::optional<LifeCycleCostParameters> lifeCycleCostParameters() const;
@@ -304,20 +304,20 @@ namespace detail {
     mutable boost::optional<Building> m_cachedBuilding;
     mutable boost::optional<FoundationKivaSettings> m_cachedFoundationKivaSettings;
     mutable boost::optional<LifeCycleCostParameters> m_cachedLifeCycleCostParameters;
+    mutable boost::optional<PerformancePrecisionTradeoffs> m_cachedPerformancePrecisionTradeoffs;
     mutable boost::optional<RunPeriod> m_cachedRunPeriod;
     mutable boost::optional<YearDescription> m_cachedYearDescription;
     mutable boost::optional<WeatherFile> m_cachedWeatherFile;
-    mutable boost::optional<PerformancePrecisionTradeoffs> m_cachedPerformancePrecisionTradeoffs;
 
   // private slots:
     void clearCachedData();
     void clearCachedBuilding(const Handle& handle);
     void clearCachedFoundationKivaSettings(const Handle& handle);
     void clearCachedLifeCycleCostParameters(const Handle& handle);
+    void clearCachedPerformancePrecisionTradeoffs(const Handle& handle);
     void clearCachedRunPeriod(const Handle& handle);
     void clearCachedYearDescription(const Handle& handle);
     void clearCachedWeatherFile(const Handle& handle);
-    void clearCachedPerformancePrecisionTradeoffs(const Handle& handle);
 
     typedef std::function<std::shared_ptr<openstudio::detail::WorkspaceObject_Impl>(Model_Impl *, const std::shared_ptr<openstudio::detail::WorkspaceObject_Impl>&, bool)> CopyConstructorFunction;
     typedef std::map<IddObjectType, CopyConstructorFunction> CopyConstructorMap;
@@ -327,7 +327,7 @@ namespace detail {
 
     // The purpose of ModelObjectCreator is to support static initialization of two large maps.
     // One is a map from IddObjectType to a function that creates a new ModelObject instance,
-    // The other is a map from IddObjectType to a function that creates a copy of an existing 
+    // The other is a map from IddObjectType to a function that creates a copy of an existing
     //
     // See Model_Impl::createObject implementation to see applicaiton of this class.
     struct ModelObjectCreator {


### PR DESCRIPTION
**This is a develop3 version of #3768**

Pull request overview
---------------------

 - Fixes #3755
 - Use template specialization for `getUniqueModelObject<YearDescription>` that uses the cached YearDescription everywhere if available  instead of using the generic `getUniqueModelObject<>` that will always loop through all objects in the model (and therefore incur a huge penalty cost).
 - The benefit of this is that the getYearDescription that is exposed to ruby bindings in particular will also use caching.
 - I also did it for all other singleton objects that already had caching in Model_Impl:  `Building`, `FoundationKivaSettings`, `LifeCycleCostParameters`, `PerformancePrecisionTradeoffs`, `RunPeriod` and `WeatherFile`

-----

## Timings

I started by creating a model with a bunch of objects (so we see the effect of looping through all objects in the model):

```ruby
require 'openstudio'

m = OpenStudio::Model::exampleModel

z = m.getThermalZones[0]
sch = m.getScheduleRulesets[0]
500.times.each do |i|
  z.clone(m)
  sch.clone(m)
end
m.save('test.osm', true)
assert m.objects.size == 5763   # <= bunch of objects
```

I used the following script for the timings:

```ruby
$VERBOSE = nil

n_times = ARGV[0].to_i
require 'openstudio'

# Helper to load a model in one line
# It will raise if the path (or the model) isn't valid
#
# @param path [String] The path to the osm
# @return [OpenStudio::Model::Model] the resulting model.
def osload(path)
  translator = OpenStudio::OSVersion::VersionTranslator.new
  ospath = OpenStudio::Path.new(path)
  model = translator.loadModel(ospath)
  if model.empty?
      raise "Path '#{path}' is not a valid path to an OpenStudio Model"
  else
      model = model.get
  end
  return model
end


m = osload('test.osm')

n_times.times.each do |i|
 yd = m.getYearDescription
end
```

I use it with `time openstudio test2.rb 100`, or `time /path/to/OS-build-develop-release/Products/openstudio test2.rb 100`

here are the timings at various `n_times`:

| n_times   | Before  | After  | Abs Diff  | % Diff  | Speed Gain (x) |
|-----------|---------|--------|-----------|---------|----------------|
| 1         | 4.211   | 4.740  | 0.529     | 12.56%  | 0.89           |
| 10        | 4.218   | 4.701  | 0.483     | 11.45%  | 0.90           |
| 100       | 4.256   | 4.704  | 0.448     | 10.53%  | 0.90           |
| 1,000     | 4.502   | 4.712  | 0.21      | 4.66%   | 0.96           |
| 10,000    | 7.495   | 4.715  | -2.78     | -37.09% | 1.59           |
| 100,000   | 61.386  | 4.4839 | -56.9021  | -92.70% | 13.69          |
| 1,000,000 | 314.599 | 5.5997 | -308.9993 | -98.22% | 56.18          |

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate): N/A
 - [x] Model API methods are tested (in `src/model/test`): tests are already existing, I'm modifying the implemention of existing methods only
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`: N/A
 - [x] If breaking existing API, add the label `APIChange`: N/A
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
