### PR TITLE
Add missing required schedules in hvac_library.osm for Unit Ventilators

### DIFF
--- a/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
@@ -4475,21 +4475,6 @@ OS:Refrigeration:Subcooler:LiquidSuction,
   16,                                     !- Design Liquid Inlet Temperature {C}
   0;                                      !- Design Vapor Inlet Temperature {C}
 
-OS:Schedule:Ruleset,
-  {fd825879-6f23-4878-89c7-5aa0a612c4b1}, !- Handle
-  Always Off Schedule,                    !- Name
-  {800d56d5-16ef-4ac2-a7d0-6abcfc246032}, !- Schedule Type Limits Name
-  {cf531912-42db-457b-983b-bd936ad4f545}; !- Default Day Schedule Name
-
-OS:Schedule:Day,
-  {cf531912-42db-457b-983b-bd936ad4f545}, !- Handle
-  Always Off Schedule Day,                !- Name
-  {800d56d5-16ef-4ac2-a7d0-6abcfc246032}, !- Schedule Type Limits Name
-  ,                                       !- Interpolate to Timestep
-  24,                                     !- Hour 1
-  0,                                      !- Minute 1
-  0;                                      !- Value Until Time 1
-
 OS:Refrigeration:WalkIn,
   {ee3d06e5-e4a3-4b2d-b500-c9622fffe03c}, !- Handle
   Walk In Cooler,                         !- Name
@@ -4505,7 +4490,7 @@ OS:Refrigeration:WalkIn,
   ,                                       !- Lighting Schedule Name
   Electric,                               !- Defrost Type
   TimeSchedule,                           !- Defrost Control Type
-  {fd825879-6f23-4878-89c7-5aa0a612c4b1}, !- Defrost Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Defrost Schedule Name
   ,                                       !- Defrost Drip-Down Schedule Name
   5512,                                   !- Defrost Power {W}
   ,                                       !- Temperature Termination Defrost Fraction to Ice {dimensionless}
@@ -10161,7 +10146,7 @@ OS:ZoneHVAC:UnitVentilator,
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
-  {fd825879-6f23-4878-89c7-5aa0a612c4b1}, !- Minimum Outdoor Air Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
   {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
@@ -10213,7 +10198,7 @@ OS:ZoneHVAC:UnitVentilator,
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
-  {fd825879-6f23-4878-89c7-5aa0a612c4b1}, !- Minimum Outdoor Air Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
   {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
@@ -10265,7 +10250,7 @@ OS:ZoneHVAC:UnitVentilator,
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
-  {fd825879-6f23-4878-89c7-5aa0a612c4b1}, !- Minimum Outdoor Air Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
   {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name

--- a/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
@@ -10382,7 +10382,7 @@ OS:ZoneHVAC:UnitVentilator,
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {9403933f-2f7f-4c08-9cfc-4a2e4686d6dd}, !- Supply Air Fan Name
-  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Supply Air Fan Operating Mode Schedule Name
   ,                                       !- Heating Coil Name
   0.001,                                  !- Heating Convergence Tolerance
   {837825eb-3562-4dee-9542-e345d3d99923}, !- Cooling Coil Name
@@ -10459,7 +10459,7 @@ OS:ZoneHVAC:UnitVentilator,
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {1de181b7-cdad-45a4-b128-ca4ad5c4bda7}, !- Supply Air Fan Name
-  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Supply Air Fan Operating Mode Schedule Name
   {940edd6c-db24-4569-aa44-e9f1ff13f5eb}, !- Heating Coil Name
   0.001,                                  !- Heating Convergence Tolerance
   ,                                       !- Cooling Coil Name
@@ -10554,7 +10554,7 @@ OS:ZoneHVAC:UnitVentilator,
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {b1bd7d0d-c9f6-43b3-b9ee-e526307bc075}, !- Supply Air Fan Name
-  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Supply Air Fan Operating Mode Schedule Name
   {947c5d3d-53cc-42e1-bd57-cf1298b1712b}, !- Heating Coil Name
   0.001,                                  !- Heating Convergence Tolerance
   {451b5808-a4d4-43f8-a669-5bd272ef8a4d}, !- Cooling Coil Name

--- a/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/openstudiocore/src/openstudio_app/Resources/default/hvac_library.osm
@@ -10372,13 +10372,13 @@ OS:Coil:Cooling:Water,
 OS:ZoneHVAC:UnitVentilator,
   {9c5ad95d-e9b9-430e-a6cb-4de13a068ded}, !- Handle
   Unit Ventilator - OnOff - Cooling,      !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {9403933f-2f7f-4c08-9cfc-4a2e4686d6dd}, !- Supply Air Fan Name
@@ -10449,13 +10449,13 @@ OS:Coil:Heating:Water,
 OS:ZoneHVAC:UnitVentilator,
   {19862f1b-dd00-42f4-8e0a-15cccac4831d}, !- Handle
   Unit Ventilator - OnOff - Heating,      !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {1de181b7-cdad-45a4-b128-ca4ad5c4bda7}, !- Supply Air Fan Name
@@ -10544,13 +10544,13 @@ OS:Coil:Heating:Water,
 OS:ZoneHVAC:UnitVentilator,
   {c6a834ef-f4e8-4c35-80cc-ebb4343908fa}, !- Handle
   Unit Ventilator - OnOff - Heating - Cooling, !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {b1bd7d0d-c9f6-43b3-b9ee-e526307bc075}, !- Supply Air Fan Name
@@ -10604,13 +10604,13 @@ OS:Coil:Cooling:Water,
 OS:ZoneHVAC:UnitVentilator,
   {b77c8f25-94ef-4436-9390-d8d72cac291b}, !- Handle
   Unit Ventilator - Variable - Cooling,   !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {3a5c4d7d-b0cc-4ab2-a4d7-3760f8f8c23d}, !- Supply Air Fan Name
@@ -10664,13 +10664,13 @@ OS:Coil:Heating:Water,
 OS:ZoneHVAC:UnitVentilator,
   {48a4ec47-f045-4041-a161-b587e385f309}, !- Handle
   Unit Ventilator - Variable - Heating,   !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {bad53ddc-aa16-4015-892c-f5ff046eee38}, !- Supply Air Fan Name
@@ -10742,13 +10742,13 @@ OS:Coil:Heating:Water,
 OS:ZoneHVAC:UnitVentilator,
   {4f7a2fae-f037-4db0-b0a5-cb63a1d97393}, !- Handle
   Unit Ventilator - Variable - Heating - Cooling, !- Name
-  ,                                       !- Availability Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
   autosize,                               !- Maximum Supply Air Flow Rate {m3/s}
   VariablePercent,                        !- Outdoor Air Control Type
   autosize,                               !- Minimum Outdoor Air Flow Rate {m3/s}
   {b267e42b-9691-4116-8393-70bb1197dc5b}, !- Minimum Outdoor Air Schedule Name
   autosize,                               !- Maximum Outdoor Air Flow Rate {m3/s}
-  ,                                       !- Maximum Outdoor Air Fraction or Temperature Schedule Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Maximum Outdoor Air Fraction or Temperature Schedule Name
   ,                                       !- Air Inlet Node Name
   ,                                       !- Air Outlet Node Name
   {a225515b-f5e9-4836-8df4-889357ca2700}, !- Supply Air Fan Name


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3778
 - Add missing required schedules in hvac_library.osm for Unit Ventilators

Tested locally with 2.9.0 (I copied the hvac_library.osm over) and added every single type of unit ventilator: file runs fine in E+

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
