### PR TITLE
Remove curves when deleting them directly or deleting a ParentObject if the curves end up unused

### DIFF
--- a/src/model/ParentObject.cpp
+++ b/src/model/ParentObject.cpp
@@ -88,14 +88,16 @@ namespace detail {
 
     // subTree includes this object, make sure to include costs as well
     auto subTree = getRecursiveChildren(getObject<ParentObject>(), true);
-    // drop the Curve instances
+
+    // drop the Curve instances, if they are used by other objects
     // Perhaps this could be done in the getRecursiveChildren, but this way
     // the getRecursiveChildren method might be less surprising
     // This is probably the unique situation where you want to get children minus curves
-    auto isCurve = [](const ModelObject & modelObject) {
-      return modelObject.optionalCast<Curve>();
+    auto isUsedCurve = [](const ModelObject & modelObject) {
+      auto _curve = modelObject.optionalCast<Curve>();
+      return (_curve && _curve->directUseCount() > 1);
     };
-    auto end = std::remove_if(subTree.begin(), subTree.end(), isCurve);
+    auto end = std::remove_if(subTree.begin(), subTree.end(), isUsedCurve);
     std::vector<ModelObject> noCurvesSubTree(subTree.begin(),end);
 
     for (const ModelObject& object : noCurvesSubTree) {

--- a/src/model/test/CoilWaterHeatingDesuperheater_GTest.cpp
+++ b/src/model/test/CoilWaterHeatingDesuperheater_GTest.cpp
@@ -109,8 +109,9 @@ TEST_F(ModelFixture, CoilWaterHeatingDesuperheater_Remove1)
     heatRejectionTargets = model.getModelObjects<WaterHeaterMixed>();
     EXPECT_EQ(1, heatRejectionTargets.size());
 
+    // Curve was used only by this object, so should have been removed
     curves = model.getModelObjects<CurveBiquadratic>();
-    EXPECT_EQ(1, curves.size());
+    EXPECT_EQ(0, curves.size());
 
     nodes = model.getModelObjects<Node>();
     EXPECT_EQ(0, nodes.size());
@@ -166,8 +167,9 @@ TEST_F(ModelFixture, CoilWaterHeatingDesuperheater_Remove2)
     heatingSources = model.getModelObjects<CoilCoolingWaterToAirHeatPumpEquationFit>();
     EXPECT_EQ(1, heatingSources.size());
 
+    // Curve was used only by this object, so should have been removed
     curves = model.getModelObjects<CurveBiquadratic>();
-    EXPECT_EQ(1, curves.size());
+    EXPECT_EQ(0, curves.size());
 
     nodes = model.getModelObjects<Node>();
     EXPECT_EQ(0, nodes.size());
@@ -223,8 +225,9 @@ TEST_F(ModelFixture, CoilWaterHeatingDesuperheater_Remove3)
     heatingSources = model.getModelObjects<CoilCoolingDXMultiSpeed>();
     EXPECT_EQ(1, heatingSources.size());
 
+    // Curve was used only by this object, so should have been removed
     curves = model.getModelObjects<CurveBiquadratic>();
-    EXPECT_EQ(1, curves.size());
+    EXPECT_EQ(0, curves.size());
 
     nodes = model.getModelObjects<Node>();
     EXPECT_EQ(0, nodes.size());

--- a/src/model/test/FanOnOff_GTest.cpp
+++ b/src/model/test/FanOnOff_GTest.cpp
@@ -128,11 +128,11 @@ TEST_F(ModelFixture, FanOnOff_Remove)
   fans = m.getModelObjects<FanOnOff>();
   EXPECT_EQ(0, fans.size());
 
+  // Both curves were used only by this object, so should have been removed
   curveExponents = m.getModelObjects<CurveExponent>();
-  EXPECT_EQ(1, curveExponents.size());
-
+  EXPECT_EQ(0, curveExponents.size());
   curveCubics = m.getModelObjects<CurveCubic>();
-  EXPECT_EQ(1, curveCubics.size());
+  EXPECT_EQ(0, curveCubics.size());
 }
 
 TEST_F(ModelFixture,FanOnOff_addToNode)

--- a/src/model/test/RefrigerationGasCoolerAirCooled_GTest.cpp
+++ b/src/model/test/RefrigerationGasCoolerAirCooled_GTest.cpp
@@ -73,8 +73,9 @@ TEST_F(ModelFixture, RefrigerationGasCoolerAirCooled_Remove)
     refrigerationAirCooledGasCoolers = model.getModelObjects<RefrigerationGasCoolerAirCooled>();
     EXPECT_EQ(0, refrigerationAirCooledGasCoolers.size());
 
+    // Curve was used only by this object, so should have been removed
     ratedTotalHeatRejectionRateCurve = model.getModelObjects<CurveLinear>();
-    EXPECT_EQ(1, ratedTotalHeatRejectionRateCurve.size());
+    EXPECT_EQ(0, ratedTotalHeatRejectionRateCurve.size());
 }
 
 //Test the methods that set and get the fields

--- a/src/model/test/RefrigerationSecondarySystem_GTest.cpp
+++ b/src/model/test/RefrigerationSecondarySystem_GTest.cpp
@@ -122,8 +122,9 @@ TEST_F(ModelFixture, RefrigerationSecondarySystem_Remove)
   refrigerationModelObjectLists = model.getModelObjects<ModelObjectList>();
   EXPECT_EQ(0, refrigerationModelObjectLists.size());
 
+  // Curve was used only by this object, so should have been removed
   refrigerationCurveCubics = model.getModelObjects<CurveCubic>();
-  EXPECT_EQ(1, refrigerationCurveCubics.size());
+  EXPECT_EQ(0, refrigerationCurveCubics.size());
 }
 
 TEST_F(ModelFixture, RefrigerationSecondarySystem_CloneOneModelWithDefaultData)


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3153
 - When deleting a curve directly, or deleting an object that uses a curve, the curve is **never** deleted. This updates ParentObject_Impl::remove() to delete curves if they end up orphaned (unused). 

The historical behavior dates from @kbenne's commit https://github.com/NREL/OpenStudio/commit/aad243b46aab465671c43b163956b5f22216dfab when `Curve`s were made `ResourceObject`s

**Note: This is quite a significant change in functionality compared to historical, so it should be reviewed and weighted carefully.**

An alternative is to only allow direct deletion of a curve (eg: curve.remove()), but never delete when it's a parent that is being deleted.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate): N/A
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`): N/A
 - [x] If a new object or method, added a test in NREL/OpenStudio-resources: N/A
 - [x] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`): N/A
 - [x] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`): N/A
 - [x] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [x] If methods have been deprecated, update rest of code to use the new methods: N/A

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`: N/A
 - [x] If breaking existing API, add the label `APIChange`: **this isn't breaking API per se, but it's a significant change so marking it anyways**
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
