### PR TITLE
Fix PeopleDefinition::thermalComfortModelTypeValues

### DIFF
--- a/src/model/PeopleDefinition.cpp
+++ b/src/model/PeopleDefinition.cpp
@@ -453,8 +453,10 @@ std::vector<std::string> PeopleDefinition::meanRadiantTemperatureCalculationType
 }
 
 std::vector<std::string> PeopleDefinition::thermalComfortModelTypeValues() {
-  return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
-                        OS_People_DefinitionExtensibleFields::ThermalComfortModelType);
+  IddObject obj = IddFactory::instance().getObject(iddObjectType()).get();
+  // Return IddKeyNames in extensible portion
+  return getIddKeyNames(obj,
+                        obj.numFields() + OS_People_DefinitionExtensibleFields::ThermalComfortModelType);
 }
 
 std::string PeopleDefinition::numberofPeopleCalculationMethod() const {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3799
 - `PeopleDefinition::thermalComfortModelTypeValues` was returning an empty array. Handle the fact that this is an extensible field properly.


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions


### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
