### PR TITLE
Removes ShadingControl warning

### DIFF
--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -95,8 +95,6 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
     boost::optional<DaylightingControl> daylightingControl = zone->primaryDaylightingControl();
     if (daylightingControl) {
       idfObject.setString(WindowShadingControlFields::DaylightingControlObjectName, daylightingControl->nameString());
-    } else {
-      LOG(Warn, "Cannot find DaylightingControl for " << modelObject.briefDescription());
     }
   } else {
     LOG(Error, "Cannot find ThermalZone for " << modelObject.briefDescription());

--- a/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/openstudiocore/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -51,8 +51,7 @@ namespace openstudio {
 
 namespace energyplus {
 
-boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::ShadingControl & modelObject )
-{
+boost::optional<IdfObject> ForwardTranslator::translateShadingControl(model::ShadingControl& modelObject) {
   // after pre-processing in ForwardTranslator, all ShadingControls should only reference subsurfaces in a single zone
   // additionally, the additional property "Shading Control Sequence Number" is set as an integer
 
@@ -104,8 +103,8 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
       // We would probably need to warn if "Glare Control Is Active" was "Yes",
       // but there's no setter in Model API and we default it to "No" later in this file
       if (istringEqual("MeetDaylightIlluminanceSetpoint", shadingControlType) || istringEqual("OnIfHighGlare", shadingControlType)) {
-        LOG(Warn, "Cannot find DaylightingControl for " << modelObject.briefDescription()
-               << ", while the Shading Control Type is '" << shadingControlType << "'.");
+        LOG(Warn, "Cannot find DaylightingControl for " << modelObject.briefDescription() << ", while the Shading Control Type is '"
+                                                        << shadingControlType << "'.");
       }
     }
   } else {
@@ -122,32 +121,32 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
   idfObject.setString(WindowShadingControlFields::MultipleSurfaceControlType, "Group");
 
   std::string shadingType = modelObject.shadingType();
-  if (istringEqual("InteriorDaylightRedirectionDevice", shadingType)){
+  if (istringEqual("InteriorDaylightRedirectionDevice", shadingType)) {
     idfObject.setString(WindowShadingControlFields::ShadingType, "InteriorBlind");
-  } else{
+  } else {
     idfObject.setString(WindowShadingControlFields::ShadingType, shadingType);
   }
 
   boost::optional<Construction> construction = modelObject.construction();
   boost::optional<ShadingMaterial> shadingMaterial = modelObject.shadingMaterial();
-  if (construction){
+  if (construction) {
     idfObject.setString(WindowShadingControlFields::ConstructionwithShadingName, construction->name().get());
-  }else if (shadingMaterial){
+  } else if (shadingMaterial) {
     idfObject.setString(WindowShadingControlFields::ShadingDeviceMaterialName, shadingMaterial->name().get());
   }
 
   boost::optional<Schedule> schedule = modelObject.schedule();
-  if (schedule){
+  if (schedule) {
     idfObject.setString(WindowShadingControlFields::ScheduleName, schedule->name().get());
     idfObject.setString(WindowShadingControlFields::ShadingControlIsScheduled, "Yes");
-  }else{
+  } else {
     idfObject.setString(WindowShadingControlFields::ShadingControlIsScheduled, "No");
   }
 
   boost::optional<double> setpoint = modelObject.setpoint();
-  if (istringEqual("OnIfHighSolarOnWindow", shadingControlType)){
-    if (!setpoint){
-      setpoint = 100; // W/m2
+  if (istringEqual("OnIfHighSolarOnWindow", shadingControlType)) {
+    if (!setpoint) {
+      setpoint = 100;  // W/m2
     }
     OS_ASSERT(setpoint);
     idfObject.setDouble(WindowShadingControlFields::Setpoint, *setpoint);
@@ -171,7 +170,6 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl( model::Sh
   return idfObject;
 }
 
-} // energyplus
+}  // namespace energyplus
 
-} // openstudio
-
+}  // namespace openstudio


### PR DESCRIPTION
Removes superfluous warning about daylighting in the ShadingControl FT code. This object does not require a daylighting control, so the warning is confusing/misleading.