### PR TITLE
Allow Installing both OpenStudio (SDK) and OpenStudioApplication via Deb package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1152,7 +1152,7 @@ elseif(UNIX)
   set(CPACK_SET_DESTDIR ON)
   set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
   # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
-  # UNLESS it's from the OpenStudioApplication (we'll handle that over there, path is different)
+  # UNLESS it's from the OpenStudioApplication
   if (NOT hasParent)
     # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
     execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,14 +1151,17 @@ elseif(UNIX)
   # These two will set the .deb install path correctly
   set(CPACK_SET_DESTDIR ON)
   set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
-  # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio
-  # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
-  execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
-  # Plus a versioned one
-  execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
-  # Have this link be installed with the .deb package in /usr/local/bin
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
+  # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
+  # UNLESS it's from the OpenStudioApplication (we'll handle that over there, path is different)
+  if (NOT hasParent)
+    # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
+    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
+    # Plus a versioned one
+    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
+    # Have this link be installed with the .deb package in /usr/local/bin
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
+  endif()
 
   # TODO: for now since Mac and Windows installers aren't doing it for core, not doing it for Unix either.
   ## Copy the icons

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1150,14 +1150,15 @@ elseif(UNIX)
   set(CPACK_IFW_TARGET_DIRECTORY /usr/local/openstudio-${OpenStudio_VERSION}/)
   # These two will set the .deb install path correctly
   set(CPACK_SET_DESTDIR ON)
-  set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
+  # CPACK_INSTALL_PREFIX is undocumented / leftover
+  set(CPACK_PACKAGING_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
   # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
   # UNLESS it's from the OpenStudioApplication
   if (NOT hasParent)
     # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
-    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
+    execute_process(COMMAND ln -sf ${CPACK_PACKAGING_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
     # Plus a versioned one
-    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
+    execute_process(COMMAND ln -sf ${CPACK_PACKAGING_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
     # Have this link be installed with the .deb package in /usr/local/bin
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,14 +1151,14 @@ elseif(UNIX)
   # These two will set the .deb install path correctly
   set(CPACK_SET_DESTDIR ON)
   # CPACK_INSTALL_PREFIX is undocumented / leftover
-  set(CPACK_PACKAGING_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
+  set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
   # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
   # UNLESS it's from the OpenStudioApplication
   if (NOT hasParent)
     # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
-    execute_process(COMMAND ln -sf ${CPACK_PACKAGING_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
+    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
     # Plus a versioned one
-    execute_process(COMMAND ln -sf ${CPACK_PACKAGING_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
+    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
     # Have this link be installed with the .deb package in /usr/local/bin
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1150,7 +1150,6 @@ elseif(UNIX)
   set(CPACK_IFW_TARGET_DIRECTORY /usr/local/openstudio-${OpenStudio_VERSION}/)
   # These two will set the .deb install path correctly
   set(CPACK_SET_DESTDIR ON)
-  # CPACK_INSTALL_PREFIX is undocumented / leftover
   set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
   # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
   # UNLESS it's from the OpenStudioApplication

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,16 +1151,28 @@ elseif(UNIX)
   # These two will set the .deb install path correctly
   set(CPACK_SET_DESTDIR ON)
   set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OpenStudio_VERSION}/)
+
   # Add a symlink to the CLI: /usr/local/bin/openstudio should point to /usr/local/openstudio-${OpenStudio_VERSION}/bin/openstudio,
   # UNLESS it's from the OpenStudioApplication
   if (NOT hasParent)
-    # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
-    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
-    # Plus a versioned one
-    execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
-    # Have this link be installed with the .deb package in /usr/local/bin
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
+    # # Add an arbitrary link (broken) at build/openstudio (if build/ is your build folder) that already points to the **future** /usr/local/openstudio-x.y.z/bin/openstudio
+    # execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio)
+    # # Plus a versioned one
+    # execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}/bin/openstudio ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION})
+    # # Have this link be installed with the .deb package in /usr/local/bin
+    # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio DESTINATION /usr/local/bin COMPONENT CLI)
+    # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openstudio-${OpenStudio_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
+
+    # We use a postinstallation script so we don't get conflicts when we have OSApp installed first (or another OpenStudio (sdk) version)
+    set(POSTINST_FILE "${PROJECT_BINARY_DIR}/postinst")
+    set(POSTRM_FILE "${PROJECT_BINARY_DIR}/postrm")
+    configure_file(${PROJECT_SOURCE_DIR}/debian/postinst.in ${POSTINST_FILE} @ONLY)
+    configure_file(${PROJECT_SOURCE_DIR}/debian/postrm.in ${POSTRM_FILE} @ONLY)
+    execute_process(COMMAND chmod 755 "${POSTINST_FILE}")
+    execute_process(COMMAND chmod 755 "${POSTRM_FILE}")
+
+    set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CPACK_DEBIAN_BIN_PACKAGE_CONTROL_EXTRA};${POSTINST_FILE};${POSTRM_FILE}")
+
   endif()
 
   # TODO: for now since Mac and Windows installers aren't doing it for core, not doing it for Unix either.

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Author: Julien Marrec
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Create symlinks
+ln -sf @CPACK_INSTALL_PREFIX@/bin/openstudio /usr/local/bin/openstudio
+ln -sf @CPACK_INSTALL_PREFIX@/bin/openstudio /usr/local/bin/openstudio-@OPENSTUDIO_VERSION@
+
+# If we want to deal with mimetype and icons for OpenStudio Model / Component
+#cp @CPACK_INSTALL_PREFIX@/Temp/x-openstudio.xml /usr/share/mime/application
+
+#mkdir -p /usr/share/icons/hicolor/16x16/mimetypes
+#mkdir -p /usr/share/icons/hicolor/32x32/mimetypes
+#mkdir -p /usr/share/icons/hicolor/64x64/mimetypes
+#mkdir -p /usr/share/icons/hicolor/128x128/mimetypes
+#mkdir -p /usr/share/icons/hicolor/256x256/mimetypes
+
+## OpenStudio Model
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osm_16.png" "/usr/share/icons/hicolor/16x16/mimetypes/application-x-openstudio.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osm_32.png" "/usr/share/icons/hicolor/32x32/mimetypes/application-x-openstudio.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osm_64.png" "/usr/share/icons/hicolor/64x64/mimetypes/application-x-openstudio.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osm_128.png" "/usr/share/icons/hicolor/128x128/mimetypes/application-x-openstudio.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osm_256.png" "/usr/share/icons/hicolor/256x256/mimetypes/application-x-openstudio.png"
+
+## OpenStudio Component
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_16.png" "/usr/share/icons/hicolor/16x16/mimetypes/application-x-openstudio-component.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_32.png" "/usr/share/icons/hicolor/32x32/mimetypes/application-x-openstudio-component.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_64.png" "/usr/share/icons/hicolor/64x64/mimetypes/application-x-openstudio-component.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_128.png" "/usr/share/icons/hicolor/128x128/mimetypes/application-x-openstudio-component.png"
+#cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_256.png" "/usr/share/icons/hicolor/256x256/mimetypes/application-x-openstudio-component.png"
+
+# Delete the Temp directory
+rm -Rf "@CPACK_INSTALL_PREFIX@/Temp"
+
+exit 0;

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -32,6 +32,6 @@ ln -sf @CPACK_INSTALL_PREFIX@/bin/openstudio /usr/local/bin/openstudio-@OPENSTUD
 #cp "@CPACK_INSTALL_PREFIX@/Temp/icons/osc_256.png" "/usr/share/icons/hicolor/256x256/mimetypes/application-x-openstudio-component.png"
 
 # Delete the Temp directory
-rm -Rf "@CPACK_INSTALL_PREFIX@/Temp"
+# rm -Rf "@CPACK_INSTALL_PREFIX@/Temp"
 
 exit 0;

--- a/debian/postrm.in
+++ b/debian/postrm.in
@@ -1,0 +1,42 @@
+#!/bin/sh
+# prerm script
+#
+# Removes necessary stuff that was created by postinst
+# I use rm -f to avoid having this script fail in case the file was already deleted...
+
+# Removing symlinks makes perfect sense, they'll be broken anyways
+rm -f /usr/local/bin/openstudio
+rm -f /usr/local/bin/openstudio-@OPENSTUDIO_VERSION@
+
+first_osapporsdk_found=$(dpkg -l | grep '^ii  openstudio' | head -1 | awk '{print $2}')
+n_osapporsdks=$(dpkg -l | grep '^ii  openstudio' | awk '{print $2}' | wc -l)
+# echo "Found $n_osapporsdks installations of openstudio/openstudioapplication, first found: $first_osapporsdk_found"
+
+
+if [ "$n_osapporsdks" -gt "0" ]; then
+  echo "Detected another installation of openstudio/openstudioapplication. You will need to recreate the symbolic links, example follows:"
+  echo "ln -sf /usr/local/$first_osapporsdk_found/bin/openstudio /usr/local/bin/openstudio"
+else
+  echo "No Other openstudio/openstudioapplication installation found. Removed symlinks."
+  echo ""
+
+  # If we want to deal with mimetype and icons for OpenStudio Model / Component
+  # rm -f /usr/share/mime/application/x-openstudio.xml
+
+  ## OpenStudio Model
+  #rm -f "/usr/share/icons/hicolor/16x16/mimetypes/application-x-openstudio.png"
+  #rm -f "/usr/share/icons/hicolor/32x32/mimetypes/application-x-openstudio.png"
+  #rm -f "/usr/share/icons/hicolor/64x64/mimetypes/application-x-openstudio.png"
+  #rm -f "/usr/share/icons/hicolor/128x128/mimetypes/application-x-openstudio.png"
+  #rm -f "/usr/share/icons/hicolor/256x256/mimetypes/application-x-openstudio.png"
+
+  ## OpenStudio Component
+  #rm -f "/usr/share/icons/hicolor/16x16/mimetypes/application-x-openstudio-component.png"
+  #rm -f "/usr/share/icons/hicolor/32x32/mimetypes/application-x-openstudio-component.png"
+  #rm -f "/usr/share/icons/hicolor/64x64/mimetypes/application-x-openstudio-component.png"
+  #rm -f "/usr/share/icons/hicolor/128x128/mimetypes/application-x-openstudio-component.png"
+  #rm -f "/usr/share/icons/hicolor/256x256/mimetypes/application-x-openstudio-component.png"
+
+fi;
+
+exit 0;


### PR DESCRIPTION
Companion PR for https://github.com/NREL/OpenStudioApplication/pull/70

I'm using a postinst script here too, because if you install OSApp first then the symlink at /usr/bin/openstudio will already exist and it'll fail if you try to install OpenStudio after that. Also, this allows installing 2 openstudio (sdk) versions too.

I installed OSApp.


```
ls -la /usr/local/bin/op*
lrwxrwxrwx 1 root root 58 Jan 14 09:14 /usr/local/bin/openstudio -> /usr/local/openstudioapplication-1.0.0-pre1/bin/openstudio
lrwxrwxrwx 1 root root 58 Jan 14 09:14 /usr/local/bin/openstudio-3.0.0-rc1 -> /usr/local/openstudioapplication-1.0.0-pre1/bin/openstudio
```

Then I installed OpenStudio package from this PR, without a problem.
```
lrwxrwxrwx 1 root root 47 Jan 14 09:17 /usr/local/bin/openstudio -> /usr/local/openstudio-3.0.0-rc1//bin/openstudio
lrwxrwxrwx 1 root root 47 Jan 14 09:17 /usr/local/bin/openstudio-3.0.0-rc1 -> /usr/local/openstudio-3.0.0-rc1//bin/openstudio
```

Then I uninstalled this:

```
Removing openstudio-3.0.0-rc1 (3.0.0) ...
Detected another installation of openstudio/openstudioapplication. You will need to recreate the symbolic links, example follows:
ln -sf /usr/local/openstudioapplication-1.0.0-pre1/bin/openstudio /usr/local/bin/openstudio
```

