### PR TITLE
Addresses #320, serious bug in MasslessOpaqueMaterial, try 2

### DIFF
--- a/src/model/MasslessOpaqueMaterial.cpp
+++ b/src/model/MasslessOpaqueMaterial.cpp
@@ -67,6 +67,16 @@ namespace detail {
     : OpaqueMaterial_Impl(other,model,keepHandle)
   {}
 
+  const std::vector<std::string>& MasslessOpaqueMaterial_Impl::outputVariableNames() const
+  {
+    static std::vector<std::string> result;
+    return result;
+  }
+
+  IddObjectType MasslessOpaqueMaterial_Impl::iddObjectType() const {
+    return MasslessOpaqueMaterial::iddObjectType();
+  }
+
   std::string MasslessOpaqueMaterial_Impl::roughness() const {
     boost::optional<std::string> value = getString(OS_Material_NoMassFields::Roughness,true);
     OS_ASSERT(value);
@@ -89,6 +99,12 @@ namespace detail {
     return 0.0;
   }
 
+  double MasslessOpaqueMaterial_Impl::thermalResistance() const {
+    boost::optional<double> value = getDouble(OS_Material_NoMassFields::ThermalResistance,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
   double MasslessOpaqueMaterial_Impl::thermalAbsorptance() const {
     boost::optional<double> value = getDouble(OS_Material_NoMassFields::ThermalAbsorptance,true);
     OS_ASSERT(value);
@@ -102,6 +118,12 @@ namespace detail {
       result = (1.0 - *od);
     }
     return result;
+  }
+
+  double MasslessOpaqueMaterial_Impl::solarAbsorptance() const {
+    boost::optional<double> value = getDouble(OS_Material_NoMassFields::SolarAbsorptance,true);
+    OS_ASSERT(value);
+    return value.get();
   }
 
   OptionalDouble MasslessOpaqueMaterial_Impl::solarReflectance() const {
@@ -128,14 +150,21 @@ namespace detail {
     return result;
   }
 
-  const std::vector<std::string>& MasslessOpaqueMaterial_Impl::outputVariableNames() const
-  {
-    static std::vector<std::string> result;
-    return result;
+  bool MasslessOpaqueMaterial_Impl::isThermalAbsorptanceDefaulted() const {
+    return isEmpty(OS_Material_NoMassFields::ThermalAbsorptance);
   }
 
-  IddObjectType MasslessOpaqueMaterial_Impl::iddObjectType() const {
-    return MasslessOpaqueMaterial::iddObjectType();
+  bool MasslessOpaqueMaterial_Impl::isSolarAbsorptanceDefaulted() const {
+    return isEmpty(OS_Material_NoMassFields::SolarAbsorptance);
+  }
+
+  bool MasslessOpaqueMaterial_Impl::isVisibleAbsorptanceDefaulted() const {
+    return isEmpty(OS_Material_NoMassFields::VisibleAbsorptance);
+  }
+
+  bool MasslessOpaqueMaterial_Impl::setRoughness(std::string roughness) {
+    bool result = setString(OS_Material_NoMassFields::Roughness, roughness);
+    return result;
   }
 
   bool MasslessOpaqueMaterial_Impl::setThickness(double value) {
@@ -152,6 +181,11 @@ namespace detail {
 
   bool MasslessOpaqueMaterial_Impl::setThermalResistivity(double value) {
     return false;
+  }
+
+  bool MasslessOpaqueMaterial_Impl::setThermalResistance(double thermalResistance) {
+    bool result = setDouble(OS_Material_NoMassFields::ThermalResistance, thermalResistance);
+    return result;
   }
 
   bool MasslessOpaqueMaterial_Impl::setThermalAbsorptance(OptionalDouble value) {
@@ -197,40 +231,6 @@ namespace detail {
     }
     OptionalDouble od = (1.0 - *value);
     return setVisibleAbsorptance(od);
-  }
-
-  double MasslessOpaqueMaterial_Impl::thermalResistance() const {
-    boost::optional<double> value = getDouble(OS_Material_NoMassFields::ThermalResistance,true);
-    OS_ASSERT(value);
-    return value.get();
-  }
-
-  bool MasslessOpaqueMaterial_Impl::isThermalAbsorptanceDefaulted() const {
-    return isEmpty(OS_Material_NoMassFields::ThermalAbsorptance);
-  }
-
-  double MasslessOpaqueMaterial_Impl::solarAbsorptance() const {
-    boost::optional<double> value = getDouble(OS_Material_NoMassFields::SolarAbsorptance,true);
-    OS_ASSERT(value);
-    return value.get();
-  }
-
-  bool MasslessOpaqueMaterial_Impl::isSolarAbsorptanceDefaulted() const {
-    return isEmpty(OS_Material_NoMassFields::SolarAbsorptance);
-  }
-
-  bool MasslessOpaqueMaterial_Impl::isVisibleAbsorptanceDefaulted() const {
-    return isEmpty(OS_Material_NoMassFields::VisibleAbsorptance);
-  }
-
-  bool MasslessOpaqueMaterial_Impl::setRoughness(std::string roughness) {
-    bool result = setString(OS_Material_NoMassFields::Roughness, roughness);
-    return result;
-  }
-
-  bool MasslessOpaqueMaterial_Impl::setThermalResistance(double thermalResistance) {
-    bool result = setDouble(OS_Material_NoMassFields::ThermalResistance, thermalResistance);
-    return result;
   }
 
   bool MasslessOpaqueMaterial_Impl::setThermalAbsorptance(double thermalAbsorptance) {
@@ -314,10 +314,6 @@ boost::optional<double> MasslessOpaqueMaterial::visibleAbsorptance() const {
   return result;
 }
 
-double MasslessOpaqueMaterial::thermalResistance() const {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->thermalResistance();
-}
-
 bool MasslessOpaqueMaterial::isThermalAbsorptanceDefaulted() const {
   return getImpl<detail::MasslessOpaqueMaterial_Impl>()->isThermalAbsorptanceDefaulted();
 }
@@ -332,10 +328,6 @@ bool MasslessOpaqueMaterial::isVisibleAbsorptanceDefaulted() const {
 
 bool MasslessOpaqueMaterial::setRoughness(std::string roughness) {
   return getImpl<detail::MasslessOpaqueMaterial_Impl>()->setRoughness(roughness);
-}
-
-bool MasslessOpaqueMaterial::setThermalResistance(double thermalResistance) {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->setThermalResistance(thermalResistance);
 }
 
 bool MasslessOpaqueMaterial::setThermalAbsorptance(double thermalAbsorptance) {

--- a/src/model/MasslessOpaqueMaterial.cpp
+++ b/src/model/MasslessOpaqueMaterial.cpp
@@ -93,7 +93,6 @@ namespace detail {
     boost::optional<double> value = getDouble(OS_Material_NoMassFields::ThermalAbsorptance,true);
     OS_ASSERT(value);
     return value.get();
-
   }
 
   OptionalDouble MasslessOpaqueMaterial_Impl::thermalReflectance() const {
@@ -118,7 +117,6 @@ namespace detail {
     boost::optional<double> value = getDouble(OS_Material_NoMassFields::VisibleAbsorptance,true);
     OS_ASSERT(value);
     return value.get();
-
   }
 
   OptionalDouble MasslessOpaqueMaterial_Impl::visibleReflectance() const {
@@ -269,45 +267,6 @@ namespace detail {
     return MasslessOpaqueMaterial::roughnessValues();
   }
 
-  double MasslessOpaqueMaterial_Impl::conductivity() const {
-    OptionalDouble od = getDouble(OS_MaterialFields::Conductivity,true);
-    if (!od) {
-      LOG_AND_THROW("Thermal conductivity is not set for MasslessOpaqueMaterial "
-          << briefDescription() << ".");
-    }
-    return *od;
-  }
-
-  bool MasslessOpaqueMaterial_Impl::setConductivity(double value) {
-    return setDouble(OS_MaterialFields::Conductivity,value);
-  }
-
-  double MasslessOpaqueMaterial_Impl::density() const {
-    OptionalDouble od = getDouble(OS_MaterialFields::Density,true);
-    if (!od) {
-      LOG_AND_THROW("Density is not set for MasslessOpaqueMaterial "
-          << briefDescription() << ".");
-    }
-    return *od;
-  }
-
-  bool MasslessOpaqueMaterial_Impl::setDensity(double value) {
-    return setDouble(OS_MaterialFields::Density,value);
-  }
-
-  double MasslessOpaqueMaterial_Impl::specificHeat() const {
-    OptionalDouble od = getDouble(OS_MaterialFields::SpecificHeat,true);
-    if (!od) {
-      LOG_AND_THROW("Specific heat is not set for MasslessOpaqueMaterial "
-          << briefDescription() << ".");
-    }
-    return *od;
-  }
-
-  bool MasslessOpaqueMaterial_Impl::setSpecificHeat(double value) {
-    return setDouble(OS_MaterialFields::SpecificHeat,value);
-  }
-
 } // detail
 
 MasslessOpaqueMaterial::MasslessOpaqueMaterial(const Model& model,
@@ -401,30 +360,6 @@ bool MasslessOpaqueMaterial::setVisibleAbsorptance(double visibleAbsorptance) {
 
 void MasslessOpaqueMaterial::resetVisibleAbsorptance() {
   getImpl<detail::MasslessOpaqueMaterial_Impl>()->resetVisibleAbsorptance();
-}
-
-double MasslessOpaqueMaterial::conductivity() const {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->conductivity();
-}
-
-bool MasslessOpaqueMaterial::setConductivity(double value) {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->setConductivity(value);
-}
-
-double MasslessOpaqueMaterial::density() const {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->density();
-}
-
-bool MasslessOpaqueMaterial::setDensity(double value) {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->setDensity(value);
-}
-
-double MasslessOpaqueMaterial::specificHeat() const {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->specificHeat();
-}
-
-bool MasslessOpaqueMaterial::setSpecificHeat(double value) {
-  return getImpl<detail::MasslessOpaqueMaterial_Impl>()->setSpecificHeat(value);
 }
 
 /// @cond

--- a/src/model/MasslessOpaqueMaterial.hpp
+++ b/src/model/MasslessOpaqueMaterial.hpp
@@ -67,8 +67,6 @@ class MODEL_API MasslessOpaqueMaterial : public OpaqueMaterial {
 
   std::string roughness() const;
 
-  double thermalResistance() const;
-
   boost::optional<double> thermalAbsorptance() const;
 
   bool isThermalAbsorptanceDefaulted() const;
@@ -86,8 +84,6 @@ class MODEL_API MasslessOpaqueMaterial : public OpaqueMaterial {
   //@{
 
   bool setRoughness(std::string roughness);
-
-  bool setThermalResistance(double thermalResistance);
 
   bool setThermalAbsorptance(double thermalAbsorptance);
 

--- a/src/model/MasslessOpaqueMaterial.hpp
+++ b/src/model/MasslessOpaqueMaterial.hpp
@@ -81,13 +81,6 @@ class MODEL_API MasslessOpaqueMaterial : public OpaqueMaterial {
 
   bool isVisibleAbsorptanceDefaulted() const;
 
-  double conductivity() const;
-
-  double density() const;
-
-  double specificHeat() const;
-
-
   //@}
   /** @name Setters */
   //@{
@@ -107,13 +100,6 @@ class MODEL_API MasslessOpaqueMaterial : public OpaqueMaterial {
   bool setVisibleAbsorptance(double visibleAbsorptance);
 
   void resetVisibleAbsorptance();
-
-  bool setConductivity(double conductivity);
-
-  bool setDensity(double density);
-
-  bool setSpecificHeat(double specificHeat);
-
 
   //@}
   /** @name Other */

--- a/src/model/MasslessOpaqueMaterial_Impl.hpp
+++ b/src/model/MasslessOpaqueMaterial_Impl.hpp
@@ -89,19 +89,13 @@ namespace detail {
 
     virtual double thermalAbsorptance() const override;
 
-    virtual boost::optional<double> thermalReflectance() const override;
+    bool isThermalAbsorptanceDefaulted() const;
 
     virtual double solarAbsorptance() const override;
 
-    virtual boost::optional<double> solarReflectance() const override;
+    bool isSolarAbsorptanceDefaulted() const;
 
     virtual double visibleAbsorptance() const override;
-
-    virtual boost::optional<double> visibleReflectance() const override;
-
-    bool isThermalAbsorptanceDefaulted() const;
-
-    bool isSolarAbsorptanceDefaulted() const;
 
     bool isVisibleAbsorptanceDefaulted() const;
 
@@ -110,9 +104,6 @@ namespace detail {
     //@{
 
     bool setRoughness(std::string roughness);
-
-    /** Set thickness to value (m). */
-    virtual bool setThickness(double value) override;
 
     /** Sets the conductivity of the material in W/m*K, if possible. */
     virtual bool setThermalConductivity(double value) override;
@@ -126,27 +117,15 @@ namespace detail {
     /** Sets the resistance of the material in m^2*K/W, if possible. */
     virtual bool setThermalResistance(double value) override;
 
-    virtual bool setThermalAbsorptance(boost::optional<double> value);
-
-    virtual bool setThermalReflectance(boost::optional<double> value) override;
-
-    virtual bool setSolarAbsorptance(boost::optional<double> value) override;
-
-    virtual bool setSolarReflectance(boost::optional<double> value) override;
-
-    virtual bool setVisibleAbsorptance(boost::optional<double> value) override;
-
-    virtual bool setVisibleReflectance(boost::optional<double> value) override;
-
-    bool setThermalAbsorptance(double thermalAbsorptance) override;
+    virtual bool setThermalAbsorptance(boost::optional<double> value) override;
 
     void resetThermalAbsorptance();
 
-    bool setSolarAbsorptance(double solarAbsorptance);
+    virtual bool setSolarAbsorptance(boost::optional<double> value) override;
 
     void resetSolarAbsorptance();
 
-    bool setVisibleAbsorptance(double visibleAbsorptance);
+    virtual bool setVisibleAbsorptance(boost::optional<double> value) override;
 
     void resetVisibleAbsorptance();
 

--- a/src/model/MasslessOpaqueMaterial_Impl.hpp
+++ b/src/model/MasslessOpaqueMaterial_Impl.hpp
@@ -89,13 +89,19 @@ namespace detail {
 
     virtual double thermalAbsorptance() const override;
 
-    bool isThermalAbsorptanceDefaulted() const;
+    virtual boost::optional<double> thermalReflectance() const override;
 
     virtual double solarAbsorptance() const override;
 
-    bool isSolarAbsorptanceDefaulted() const;
+    virtual boost::optional<double> solarReflectance() const override;
 
     virtual double visibleAbsorptance() const override;
+
+    virtual boost::optional<double> visibleReflectance() const override;
+
+    bool isThermalAbsorptanceDefaulted() const;
+
+    bool isSolarAbsorptanceDefaulted() const;
 
     bool isVisibleAbsorptanceDefaulted() const;
 
@@ -104,6 +110,9 @@ namespace detail {
     //@{
 
     bool setRoughness(std::string roughness);
+
+    /** Set thickness to value (m). */
+    virtual bool setThickness(double value) override;
 
     /** Sets the conductivity of the material in W/m*K, if possible. */
     virtual bool setThermalConductivity(double value) override;
@@ -119,13 +128,25 @@ namespace detail {
 
     virtual bool setThermalAbsorptance(boost::optional<double> value) override;
 
-    void resetThermalAbsorptance();
+    virtual bool setThermalReflectance(boost::optional<double> value) override;
 
     virtual bool setSolarAbsorptance(boost::optional<double> value) override;
 
-    void resetSolarAbsorptance();
+    virtual bool setSolarReflectance(boost::optional<double> value) override;
 
     virtual bool setVisibleAbsorptance(boost::optional<double> value) override;
+
+    virtual bool setVisibleReflectance(boost::optional<double> value) override;
+
+    bool setThermalAbsorptance(double thermalAbsorptance) override;
+
+    void resetThermalAbsorptance();
+
+    bool setSolarAbsorptance(double solarAbsorptance);
+
+    void resetSolarAbsorptance();
+
+    bool setVisibleAbsorptance(double visibleAbsorptance);
 
     void resetVisibleAbsorptance();
 

--- a/src/model/MasslessOpaqueMaterial_Impl.hpp
+++ b/src/model/MasslessOpaqueMaterial_Impl.hpp
@@ -105,13 +105,6 @@ namespace detail {
 
     bool isVisibleAbsorptanceDefaulted() const;
 
-    double conductivity() const;
-
-    double density() const;
-
-    double specificHeat() const;
-
-
     //@}
     /** @name Setters */
     //@{
@@ -156,13 +149,6 @@ namespace detail {
     bool setVisibleAbsorptance(double visibleAbsorptance);
 
     void resetVisibleAbsorptance();
-
-    bool setConductivity(double conductivity);
-
-    bool setDensity(double density);
-
-    bool setSpecificHeat(double specificHeat);
-
 
     //@}
     /** @name Other */

--- a/src/model/OpaqueMaterial.cpp
+++ b/src/model/OpaqueMaterial.cpp
@@ -129,7 +129,7 @@ bool OpaqueMaterial::setThermalResistance(double value) {
   return getImpl<detail::OpaqueMaterial_Impl>()->setThermalResistance(value);
 }
 
-bool OpaqueMaterial::setThermalAbsorptance(double value) {
+bool OpaqueMaterial::setThermalAbsorptance(boost::optional<double> value) {
   return getImpl<detail::OpaqueMaterial_Impl>()->setThermalAbsorptance(value);
 }
 

--- a/src/model/OpaqueMaterial.hpp
+++ b/src/model/OpaqueMaterial.hpp
@@ -131,7 +131,7 @@ class MODEL_API OpaqueMaterial : public Material {
   /** Set the thermal absorptance (dimensionless fraction).
    *
    *  Attribute name: 'thermalAbsorptance' */
-  bool setThermalAbsorptance(double value);
+  bool setThermalAbsorptance(boost::optional<double> value);
 
   /** Set the thermal reflectance (dimensionless fraction).
    *

--- a/src/model/OpaqueMaterial_Impl.hpp
+++ b/src/model/OpaqueMaterial_Impl.hpp
@@ -42,21 +42,6 @@ namespace detail {
 
   class MODEL_API OpaqueMaterial_Impl : public Material_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
 
     // Construct completely new object.

--- a/src/model/OpaqueMaterial_Impl.hpp
+++ b/src/model/OpaqueMaterial_Impl.hpp
@@ -107,7 +107,7 @@ namespace detail {
     /** Sets the resistance of the material in m^2*K/W, if possible. */
     virtual bool setThermalResistance(double value) = 0;
 
-    virtual bool setThermalAbsorptance(double value) = 0;
+    virtual bool setThermalAbsorptance(boost::optional<double> value) = 0;
 
     virtual bool setThermalReflectance(boost::optional<double> value) = 0;
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
