### PR TITLE
Fix (some) bundle test failures

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -72,7 +72,9 @@ module Kernel
     if path.include? 'openstudio/energyplus/find_energyplus'
       return false
     end
-    
+
+    # Returns the extension
+    # (the portion of file name in path starting from the last period).
     extname = File.extname(path)
 
     if extname.empty? or ! RUBY_FILE_EXTS.include? extname
@@ -86,7 +88,7 @@ module Kernel
         return true;
       elsif EmbeddedScripting.private_method_defined? initmethod
         $LOADED << path
-        EmbeddedScripting.send(initmethod) 
+        EmbeddedScripting.send(initmethod)
         return true;
       end
     else
@@ -113,33 +115,33 @@ module Kernel
     end
 
     result = original_require path
-    
-    current_directory = Dir.pwd 
+
+    current_directory = Dir.pwd
     if original_directory != current_directory
       Dir.chdir(original_directory)
       puts "Directory changed from '#{original_directory}' to '#{current_directory}' while requiring '#{path}', result = #{result}, restoring original_directory"
       STDOUT.flush
     end
-    
+
     return result
   end
 
   def require_embedded_absolute path
     original_directory = Dir.pwd
-    
+
     $LOADED << path
     s = EmbeddedScripting::getFileAsString(path)
 
     s = OpenStudio::preprocess_ruby_script(s)
 
     result = Kernel::eval(s,BINDING,path)
-    
-    current_directory = Dir.pwd 
+
+    current_directory = Dir.pwd
     if original_directory != current_directory
       Dir.chdir(original_directory)
       STDOUT.flush
     end
-    
+
     return result
   end
 

--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -63,6 +63,8 @@ module Kernel
   alias :original_require :require
   alias :original_open :open
 
+  RUBY_FILE_EXTS = ['.rb', '.so', '.dll']
+
   def require path
     original_directory = Dir.pwd
     path_with_extension = path
@@ -73,7 +75,7 @@ module Kernel
     
     extname = File.extname(path)
 
-    if extname.empty? #or extname != '.rb'
+    if extname.empty? or ! RUBY_FILE_EXTS.include? extname
       path_with_extension = path + '.rb'
     end
 


### PR DESCRIPTION
close #3851

Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
