### PR TITLE
3840 surface sun wind exposure

### DIFF
--- a/src/model/Surface.cpp
+++ b/src/model/Surface.cpp
@@ -924,6 +924,8 @@ namespace detail {
     if (test){
       test = this->setString(OS_SurfaceFields::OutsideBoundaryCondition, "OtherSideCoefficients");
       OS_ASSERT(test);
+      this->assignDefaultSunExposure();
+      this->assignDefaultWindExposure();
     }
     return test;
   }

--- a/src/model/Surface.cpp
+++ b/src/model/Surface.cpp
@@ -924,8 +924,6 @@ namespace detail {
     if (test){
       test = this->setString(OS_SurfaceFields::OutsideBoundaryCondition, "OtherSideCoefficients");
       OS_ASSERT(test);
-      this->assignDefaultSunExposure();
-      this->assignDefaultWindExposure();
     }
     return test;
   }

--- a/src/model/Surface.cpp
+++ b/src/model/Surface.cpp
@@ -1282,6 +1282,7 @@ namespace detail {
       bool test = this->setSunExposure("SunExposed", driverMethod);
       OS_ASSERT(test);
     }else if (istringEqual("Surface", this->outsideBoundaryCondition()) ||
+              istringEqual("OtherSideCoefficients", this->outsideBoundaryCondition()) ||
               istringEqual("Adiabatic", this->outsideBoundaryCondition()) ||
               istringEqual("Ground", this->outsideBoundaryCondition()) ||
               istringEqual("GroundFCfactorMethod", this->outsideBoundaryCondition()) ||
@@ -1319,6 +1320,7 @@ namespace detail {
       bool test = this->setWindExposure("WindExposed", driverMethod);
       OS_ASSERT(test);
     } else if (istringEqual("Surface", this->outsideBoundaryCondition()) ||
+               istringEqual("OtherSideCoefficients", this->outsideBoundaryCondition()) ||
                istringEqual("Adiabatic", this->outsideBoundaryCondition()) ||
                istringEqual("Ground", this->outsideBoundaryCondition()) ||
                istringEqual("GroundFCfactorMethod", this->outsideBoundaryCondition()) ||

--- a/src/model/test/Surface_GTest.cpp
+++ b/src/model/test/Surface_GTest.cpp
@@ -756,21 +756,6 @@ TEST_F(ModelFixture, AdjacentSurface_SurfacePropertyOtherSideCoefficients)
   EXPECT_EQ("SunExposed", wall2.sunExposure());
   EXPECT_EQ("WindExposed", wall2.windExposure());
 
-  // Test setSurfacePropertyOtherSideCoefficients again, but make sure that sun and wind exposure are preserved
-  // This time we use none default sun and wind exposure
-  Surface wall3(vertices, model);
-  EXPECT_TRUE(wall3.setSunExposure("NoSun"));
-  EXPECT_TRUE(wall3.setWindExposure("NoWind"));
-  EXPECT_EQ("NoSun", wall3.sunExposure());
-  EXPECT_EQ("NoWind", wall3.windExposure());
-
-  SurfacePropertyOtherSideCoefficients osc2(model);
-  EXPECT_TRUE(wall3.setSurfacePropertyOtherSideCoefficients(osc2));
-  ASSERT_TRUE(wall3.surfacePropertyOtherSideCoefficients());
-  EXPECT_EQ(osc2.handle(), wall3.surfacePropertyOtherSideCoefficients()->handle());
-  EXPECT_EQ("NoSun", wall3.sunExposure());
-  EXPECT_EQ("NoWind", wall3.windExposure());
-
   EXPECT_TRUE(wall1.setAdjacentSurface(wall2));
   ASSERT_TRUE(wall1.adjacentSurface());
   EXPECT_EQ(wall2.handle(), wall1.adjacentSurface()->handle());

--- a/src/model/test/Surface_GTest.cpp
+++ b/src/model/test/Surface_GTest.cpp
@@ -750,8 +750,8 @@ TEST_F(ModelFixture, AdjacentSurface_SurfacePropertyOtherSideCoefficients)
   EXPECT_FALSE(wall1.adjacentSurface());
   EXPECT_FALSE(wall2.adjacentSurface());
   EXPECT_EQ("OtherSideCoefficients", wall1.outsideBoundaryCondition());
-  EXPECT_EQ("SunExposed", wall1.sunExposure());
-  EXPECT_EQ("WindExposed", wall1.windExposure());
+  EXPECT_EQ("NoSun", wall1.sunExposure());
+  EXPECT_EQ("NoWind", wall1.windExposure());
   EXPECT_EQ("Outdoors", wall2.outsideBoundaryCondition());
   EXPECT_EQ("SunExposed", wall2.sunExposure());
   EXPECT_EQ("WindExposed", wall2.windExposure());

--- a/src/model/test/Surface_GTest.cpp
+++ b/src/model/test/Surface_GTest.cpp
@@ -756,6 +756,21 @@ TEST_F(ModelFixture, AdjacentSurface_SurfacePropertyOtherSideCoefficients)
   EXPECT_EQ("SunExposed", wall2.sunExposure());
   EXPECT_EQ("WindExposed", wall2.windExposure());
 
+  // Test setSurfacePropertyOtherSideCoefficients again, but make sure that sun and wind exposure are preserved
+  // This time we use none default sun and wind exposure
+  Surface wall3(vertices, model);
+  EXPECT_TRUE(wall3.setSunExposure("NoSun"));
+  EXPECT_TRUE(wall3.setWindExposure("NoWind"));
+  EXPECT_EQ("NoSun", wall3.sunExposure());
+  EXPECT_EQ("NoWind", wall3.windExposure());
+
+  SurfacePropertyOtherSideCoefficients osc2(model);
+  EXPECT_TRUE(wall3.setSurfacePropertyOtherSideCoefficients(osc2));
+  ASSERT_TRUE(wall3.surfacePropertyOtherSideCoefficients());
+  EXPECT_EQ(osc2.handle(), wall3.surfacePropertyOtherSideCoefficients()->handle());
+  EXPECT_EQ("NoSun", wall3.sunExposure());
+  EXPECT_EQ("NoWind", wall3.windExposure());
+
   EXPECT_TRUE(wall1.setAdjacentSurface(wall2));
   ASSERT_TRUE(wall1.adjacentSurface());
   EXPECT_EQ(wall2.handle(), wall1.adjacentSurface()->handle());


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3840  (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
