### PR TITLE
Add two issue templates: one for bug, one of enhancement request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Use this template for reporting an issue.
+labels: Triage
+---
+Issue overview
+--------------
+<!--- Provide a general summary of the issue -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Steps to Reproduce
+<!-- Provide an unambiguous set of steps to reproduce this bug. -->
+<!--- Provide a link to a model that has the bug (a minimum complete and verifiable example (MCVE) is preferred) and/or code to reproduce -->
+1.
+2.
+3.
+4.
+
+## Possible Solution
+<!--- Optional, but if you can, suggest a fix/reason for the bug, -->
+
+## Details
+
+### Environment
+
+Some additional details about your environment for this issue (if relevant):
+ - Platform (Operating system, version):
+ - Version of OpenStudio (if using an intermediate build, include SHA):
+
+### Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,14 @@
+---
+name: Enhancement Request
+about: Use this template for suggesting an enhancement.
+labels: Triage, Enhancement Request
+---
+Enhancement Request
+--------------
+<!--- Provide a general summary of the feature you would like to see implemented -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing. Include screenshot/schemas as appropriate -->
+
+## Possible Implementation
+<!--- Not mandatory, but if you can, suggest an idea for implementing the feature -->


### PR DESCRIPTION
Pull request overview
---------------------

Add two issue templates: one for bug, one of enhancement request. Both get labeled as Triage (+ "Enhancement Request" potentially).

This should maximize our chances of correctly processing incoming issues.

This is similar to what I did for OS App: https://github.com/NREL/OpenStudioApplication/issues/new/choose