### PR TITLE
Fix #3870 - Remove deprecated Active Year/Instiution fields in OS:ClimateZones

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -771,27 +771,17 @@ OS:RadianceParameters,
 OS:ClimateZones,
        \unique-object
        \extensible:4
-       \min-fields 7
   A1, \field Handle
        \type handle
        \required-field
-  A2, \field Active Institution
-       \deprecated
-       \type alpha
-       \default ASHRAE
-  N1, \field Active Year
-       \deprecated
-       \type integer
-       \minimum 0
-       \default 2006
-  A3, \field Climate Zone Institution Name
+  A2, \field Climate Zone Institution Name
        \type alpha
        \begin-extensible
        \default ASHRAE
-  A4, \field Climate Zone Document Name
+  A3, \field Climate Zone Document Name
        \type alpha
        \default ANSI/ASHRAE Standard 169
-  N2, \field Climate Zone Document Year
+  N1, \field Climate Zone Document Year
        \type integer
        \minimum 0
        \default 2006

--- a/src/model/ClimateZones.cpp
+++ b/src/model/ClimateZones.cpp
@@ -111,20 +111,7 @@ namespace detail {
     }
     return result;
   }
-/*
-  ClimateZone ClimateZones_Impl::activeClimateZone() const {
-    std::string activeInstitution = getString(OS_ClimateZonesFields::ActiveInstitution,true).get();
-    unsigned activeYear = getUnsigned(OS_ClimateZonesFields::ActiveYear,true).get();
-    return getClimateZone(activeInstitution,activeYear);
-  }
 
-  std::string ClimateZones_Impl::activeClimateZoneValue() const {
-    std::string result;
-    ClimateZone cz = activeClimateZone();
-    if (!cz.empty()) { result = cz.value(); }
-    return result;
-  }
-*/
   boost::optional<ParentObject> ClimateZones_Impl::parent() const {
     OptionalParentObject result;
     OptionalSite oSite = site();
@@ -145,40 +132,7 @@ namespace detail {
     clearExtensibleGroups();
     return (numExtensibleGroups() == 0u);
   }
-/*
-  ClimateZone ClimateZones_Impl::setActiveClimateZone(const std::string& institution) {
-    std::shared_ptr<ClimateZones_Impl> p;
-    ClimateZone result(p,numFields());
 
-    ClimateZoneVector czs = getClimateZones(institution);
-    if (czs.empty()) { result = appendClimateZone(institution); }
-    else {
-      if (czs.size() > 1) {
-        LOG(Warn,"Multiple climate zones have institution '" << institution << "'. Setting the first "
-            << "to be active.");
-      }
-      result = czs[0];
-    }
-    OS_ASSERT(!result.empty());
-    bool ok = setString(OS_ClimateZonesFields::ActiveInstitution,result.institution());
-    OS_ASSERT(ok);
-    ok = setUnsigned(OS_ClimateZonesFields::ActiveYear,result.year());
-    OS_ASSERT(ok);
-    return result;
-  }
-
-  ClimateZone ClimateZones_Impl::setActiveClimateZone(const std::string& institution, unsigned year) {
-    ClimateZone result = getClimateZone(institution,year);
-    if (result.empty()) {
-      result = appendClimateZone(institution,year,"");
-    }
-    bool ok = setString(OS_ClimateZonesFields::ActiveInstitution,result.institution());
-    OS_ASSERT(ok);
-    ok = setUnsigned(OS_ClimateZonesFields::ActiveYear,result.year());
-    OS_ASSERT(ok);
-    return result;
-  }
-*/
   ClimateZone ClimateZones_Impl::setClimateZone(const std::string& institution,
                                                 const std::string& value)
   {
@@ -471,27 +425,11 @@ ClimateZone ClimateZones::getClimateZone(const std::string& institution,unsigned
 std::vector<ClimateZone> ClimateZones::getClimateZones(const std::string& institution) const {
   return getImpl<detail::ClimateZones_Impl>()->getClimateZones(institution);
 }
-/*
-ClimateZone ClimateZones::activeClimateZone() const {
-  return getImpl<detail::ClimateZones_Impl>()->activeClimateZone();
-}
 
-std::string ClimateZones::activeClimateZoneValue() const {
-  return getImpl<detail::ClimateZones_Impl>()->activeClimateZoneValue();
-}
-*/
 bool ClimateZones::clear() {
   return getImpl<detail::ClimateZones_Impl>()->clear();
 }
-/*
-ClimateZone ClimateZones::setActiveClimateZone(const std::string& institution) {
-  return getImpl<detail::ClimateZones_Impl>()->setActiveClimateZone(institution);
-}
 
-ClimateZone ClimateZones::setActiveClimateZone(const std::string& institution,unsigned year) {
-  return getImpl<detail::ClimateZones_Impl>()->setActiveClimateZone(institution,year);
-}
-*/
 ClimateZone ClimateZones::setClimateZone(const std::string& institution,
                                          const std::string& value)
 {
@@ -537,12 +475,7 @@ unsigned ClimateZones::numClimateZones() const {
 /// @cond
 ClimateZones::ClimateZones(Model& model)
   : ModelObject(ClimateZones::iddObjectType(),model)
-{
-  // add empty climate zone to define default institution
-  pushExtensibleGroup(StringVector());
-  // Programming note: This line of code cannot be in the _Impl constructor because
-  // pushExtensibleGroup constructs an IdfExtensibleGroup from the _Impl.
-}
+{}
 
 ClimateZones::ClimateZones(std::shared_ptr<detail::ClimateZones_Impl> impl)
   : ModelObject(std::move(impl))

--- a/src/model/ClimateZones.hpp
+++ b/src/model/ClimateZones.hpp
@@ -165,35 +165,12 @@ class MODEL_API ClimateZones : public ModelObject {
   /** Return the ClimateZone defintions for institution (e.g. "ASHRAE" or "CEC"). */
   std::vector<ClimateZone> getClimateZones(const std::string& institution) const;
 
-  /** Return the active ClimateZone definition. If no ClimateZone is designated as active, the
-   *  return value will be .empty(). The active climate zone is the one that will be accessed
-   *  by the standardsinterface::OpenStudioStandardsInterface, perhaps in the course of applying a
-   *  ruleset::StandardsRuleset using a rulesengine::OpenStudioRulesEngine. */
-  //ClimateZone activeClimateZone() const;
-
-  /** Return the active ClimateZone value. If no ClimateZone is designated as active, the return
-   *  value will be .empty(). The active climate zone is the one that will be accessed by the
-   *  standardsinterface::OpenStudioStandardsInterface, perhaps in the course of applying a
-   *  ruleset::StandardsRuleset using a rulesengine::OpenStudioRulesEngine. */
-  //std::string activeClimateZoneValue() const;
-
   //@}
   /** @name Setters */
   //@{
 
   /** Clear all ClimateZone definitions. */
   bool clear();
-
-  /** Sets the active ClimateZone to be one defined by institution. If there are no such
-   *  definitions, this method is equivalent to appendClimateZone(institution). If there are
-   *  multiple climate zones associated with institution, the first one is set as active and
-   *  a warning is logged. The return value of this method should never be .empty(). */
-  //ClimateZone setActiveClimateZone(const std::string& institution);
-
-  /** Sets the active ClimateZone to be one defined by institution and year. If there are no such
-   *  definitions, this method is equivalent to appendClimateZone(institution,year). The return
-   *  value of this method should never be .empty(). */
-  //ClimateZone setActiveClimateZone(const std::string& institution,unsigned year);
 
   /** Sets the ClimateZone definition for institution to value and returns the modified (or
    *  created) ClimateZone. If there are no definitions for institution, this method is equivalent

--- a/src/model/ClimateZones_Impl.hpp
+++ b/src/model/ClimateZones_Impl.hpp
@@ -73,10 +73,6 @@ namespace detail {
 
     std::vector<ClimateZone> getClimateZones(const std::string& institution) const;
 
-    //ClimateZone activeClimateZone() const;
-
-    //std::string activeClimateZoneValue() const;
-
     // return the parent object in the hierarchy
     virtual boost::optional<ParentObject> parent() const override;
 
@@ -90,10 +86,6 @@ namespace detail {
     //@{
 
     bool clear();
-
-    //ClimateZone setActiveClimateZone(const std::string& institution);
-
-    //ClimateZone setActiveClimateZone(const std::string& institution,unsigned year);
 
     ClimateZone setClimateZone(const std::string& institution,
                                const std::string& value);

--- a/src/model/test/ClimateZones_GTest.cpp
+++ b/src/model/test/ClimateZones_GTest.cpp
@@ -49,20 +49,13 @@ TEST_F(ModelFixture, ClimateZones)
   ClimateZones czs = model.getUniqueModelObject<ClimateZones>();
 
   // default
-  ASSERT_EQ(1u,czs.numClimateZones());
-  ASSERT_EQ(1u,czs.climateZones().size());
-  ClimateZone acz = czs.climateZones()[0];
-  ASSERT_FALSE(acz.empty());
-  EXPECT_EQ(ClimateZones::ashraeInstitutionName(),acz.institution());
-  EXPECT_EQ(ClimateZones::ashraeDocumentName(),acz.documentName());
-  EXPECT_EQ(ClimateZones::ashraeDefaultYear(),acz.year());
-  EXPECT_EQ("",acz.value());
+  ASSERT_EQ(0u,czs.numClimateZones());
+  ASSERT_EQ(0u,czs.climateZones().size());
 
   // after clear
   czs.clear();
   EXPECT_EQ(0u,czs.numClimateZones());
   EXPECT_EQ(0,czs.climateZones().size());
-  EXPECT_TRUE(acz.empty());
 
   // append a climate zone
   ClimateZone cz = czs.appendClimateZone(ClimateZones::cecInstitutionName(),


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3870
 - Bare minimum changes to fix #3870 without revamping entire object and making it non unique


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
