### PR TITLE
Followup to #3871: I deleted fields in OS:ClimateZones so need VT Rules

### DIFF
--- a/ruby/test/ClimateZones_Test.rb
+++ b/ruby/test/ClimateZones_Test.rb
@@ -38,8 +38,10 @@ class ClimateZones_Test < MiniTest::Unit::TestCase
     model = OpenStudio::Model::Model.new
 
     climateZones = model.getClimateZones
+    assert_equal(0, climateZones.numClimateZones)
+    climateZones.pushExtensibleGroup # same as the old Ctor
 
-    assert_equal(1,climateZones.numClimateZones)
+    assert_equal(1, climateZones.numClimateZones)
     individualZones = climateZones.climateZones
     assert_equal(1,individualZones.size)
     defaultZone = individualZones[0]

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -4959,6 +4959,26 @@ std::string VersionTranslator::update_2_9_1_to_3_0_0(const IdfFile& idf_2_9_1, c
       m_refactored.push_back(RefactoredObjectData(object, newObject));
       ss << newObject;
 
+    } else if (iddname == "OS:ClimateZones") {
+      auto iddObject = idd_3_0_0.getObject(iddname);
+      IdfObject newObject(iddObject.get());
+
+      // Deleted Field 1 & 2 (0-indexed): 'Active Institution' and 'Active Year'
+      for (size_t i = 0; i < object.numFields(); ++i) {
+         if ((value = object.getString(i))) {
+          if (i < 1) {
+            // 0 Unchanged
+            newObject.setString(i, value.get());
+          } else if (i > 2) {
+            // 3-End shifted -2
+            newObject.setString(i-2, value.get());
+          }
+        }
+      }
+
+      m_refactored.push_back(RefactoredObjectData(object, newObject));
+      ss << newObject;
+
     } else if (iddname == "OS:Boiler:HotWater") {
       auto iddObject = idd_3_0_0.getObject(iddname);
       IdfObject newObject(iddObject.get());


### PR DESCRIPTION
cf #3780

Pull request overview
---------------------

 - Fixes #3871 

## Test VT

**Using 2.9.1:**

```ruby
m = Model.new
cz = m.getClimateZones
cz.appendClimateZone(OpenStudio::Model::ClimateZones.cecInstitutionName, "12")
cz.setClimateZone("ASHRAE", "12")
m.save('cz291.osm', true)
```

**Content of cz291.osm:**

```
OS:Version,
  {1a88540c-7ceb-4dba-92e1-b901cd59504d}, !- Handle
  2.9.1;                                  !- Version Identifier

OS:ClimateZones,
  {52b66531-b540-4a57-a3ba-eb8ec698db08}, !- Handle
  ,                                       !- Active Institution
  ,                                       !- Active Year
  ,                                       !- Climate Zone Institution Name 1
  ,                                       !- Climate Zone Document Name 1
  ,                                       !- Climate Zone Document Year 1
  12,                                     !- Climate Zone Value 1
  CEC,                                    !- Climate Zone Institution Name 2
  California Climate Zone Descriptions,   !- Climate Zone Document Name 2
  1995,                                   !- Climate Zone Document Year 2
  12;                                     !- Climate Zone Value 2
```

**Before fix:** I cannot load this using current develop;

```
m = osload('cz291.osm')
[utilities.idf.IdfObject] <1> Could not convert 'CEC' to int
[utilities.idf.IdfObject] <1> Could not convert 'CEC' to int
[openstudio.osversion.VersionTranslator] <1> Model with Version 3.0.0 IDD is not valid to draft strictness level.
[utilities.idf.IdfObject] <1> Could not convert 'CEC' to int
[utilities.idf.IdfObject] <1> Could not convert 'CEC' to int
[openstudio.osversion.VersionTranslator] <1> The collection is INVALID at strictness level 'Draft', because of the errors:
Field      level data error of type DataType          .
Error is in an object of type 'OS:ClimateZones', named '', in field 7.
Additional information about the error type: field-level data is of an incorrect type.
RuntimeError: Path 'cz291.osm' is not a valid path to an OpenStudio Model
from /home/julien/.pryrc:145:in `osload'
```

**After fix:**

```
[1] osversion(main)> m = osload('cz291.osm')
=> #<OpenStudio::Model::Model:0x000055eeeaab6d30
 @__swigtype__="_p_openstudio__model__Model">
[2] osversion(main)> puts m

OS:Version,
  {bedb46b5-ff61-4659-a4ff-abc4eb47d3c0}, !- Handle
  3.0.0;                                  !- Version Identifier

OS:ClimateZones,
  {52b66531-b540-4a57-a3ba-eb8ec698db08}, !- Handle
  ,                                       !- Climate Zone Institution Name 1
  ,                                       !- Climate Zone Document Name 1
  ,                                       !- Climate Zone Document Year 1
  12,                                     !- Climate Zone Value 1
  CEC,                                    !- Climate Zone Institution Name 2
  California Climate Zone Descriptions,   !- Climate Zone Document Name 2
  1995,                                   !- Climate Zone Document Year 2
  12;                                     !- Climate Zone Value 2
```

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [x] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
