### PR TITLE
adding separate Jenkins files for each platform

### DIFF
--- a/Jenkinsfile_develop_linux
+++ b/Jenkinsfile_develop_linux
@@ -1,7 +1,7 @@
 
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@develop') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {

--- a/Jenkinsfile_develop_linux
+++ b/Jenkinsfile_develop_linux
@@ -1,3 +1,4 @@
+
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
 @Library('cbci_shared_libs@develop') _

--- a/Jenkinsfile_develop_linux
+++ b/Jenkinsfile_develop_linux
@@ -1,10 +1,10 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs') _
+@Library('cbci_shared_libs@develop') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {
 
-  openstudio_incremental_develop()
+  openstudio_incremental_develop_linux()
 
 }

--- a/Jenkinsfile_develop_osx
+++ b/Jenkinsfile_develop_osx
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@develop') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {

--- a/Jenkinsfile_develop_osx
+++ b/Jenkinsfile_develop_osx
@@ -1,0 +1,10 @@
+//Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
+
+@Library('cbci_shared_libs@develop') _
+
+// Build for PR to develop branch only.
+if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {
+
+  openstudio_incremental_develop_osx()
+
+}

--- a/Jenkinsfile_develop_windows
+++ b/Jenkinsfile_develop_windows
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@develop') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {

--- a/Jenkinsfile_develop_windows
+++ b/Jenkinsfile_develop_windows
@@ -1,0 +1,10 @@
+//Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
+
+@Library('cbci_shared_libs@windows') _
+
+// Build for PR to develop branch only.
+if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {
+
+  openstudio_incremental_develop_windows()
+
+}

--- a/Jenkinsfile_develop_windows
+++ b/Jenkinsfile_develop_windows
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@windows') _
+@Library('cbci_shared_libs@develop') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {


### PR DESCRIPTION
Changing Jenkins to run CI for each platform (Windows, Linux, OS) separately versus parallel. 
This is preferred as you can replay a job specific to a platform versus having to replay a job to run on all platforms. 

