### PR TITLE
#3892 - For SimulationControl wrap DoHVACSizingSimulationforSizingPeriods and MaximumNumberofHVACSizingSimulationPasses

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -416,7 +416,7 @@ OS:SimulationControl,
        \type integer
        \minimum> 0
        \default 25
-  N5; \field Minimum Number of Warmup Days
+  N5, \field Minimum Number of Warmup Days
        \note The minimum number of warmup days that produce enough temperature and flux history
        \note to start EnergyPlus simulation for all reference buildings was suggested to be 6.
        \note When this field is greater than the maximum warmup days defined previous field
@@ -425,6 +425,19 @@ OS:SimulationControl,
        \type integer
        \minimum> 0
        \default 6
+  A8, \field Do HVAC Sizing Simulation for Sizing Periods
+      \note If Yes, SizingPeriod:* objects are exectuted additional times for advanced sizing.
+      \note Currently limited to use with coincident plant sizing, see Sizing:Plant object
+      \type choice
+      \key Yes
+      \key No
+      \default No
+  N6; \field Maximum Number of HVAC Sizing Simulation Passes
+      \note the entire set of SizingPeriod:* objects may be repeated to fine tune size results
+      \note this input sets a limit on the number of passes that the sizing algorithms can repeate the set
+      \type integer
+      \minimum 1
+      \default 1
 
 OS:PerformancePrecisionTradeoffs,
        \unique-object

--- a/src/energyplus/CMakeLists.txt
+++ b/src/energyplus/CMakeLists.txt
@@ -621,6 +621,7 @@ set(${target_name}_test_src
   Test/ScheduleRuleset_GTest.cpp
   Test/SetpointManagerFollowGroundTemperature_GTest.cpp
   Test/ShadingSurface_GTest.cpp
+  Test/SimulationControl_GTest.cpp
   Test/Space_GTest.cpp
   Test/SpaceInfiltrationDesignFlowRate_GTest.cpp
   Test/SpaceInfiltrationEffectiveLeakageArea_GTest.cpp

--- a/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
@@ -133,10 +133,14 @@ boost::optional<IdfObject> ForwardTranslator::translateSimulationControl( Simula
     {
       simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"Yes");
     } else {
-      simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+      if (!modelObject.isDoZoneSizingCalculationDefaulted()) {
+        simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+      }
     }
   } else {
-    simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+    if (!modelObject.isDoZoneSizingCalculationDefaulted()) {
+      simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+    }
   }
 
   if (!modelObject.isMaximumNumberofHVACSizingSimulationPassesDefaulted()) {

--- a/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
@@ -35,6 +35,8 @@
 #include "../../model/SimulationControl.hpp"
 #include "../../model/SizingPeriod.hpp"
 #include "../../model/SizingPeriod_Impl.hpp"
+#include "../../model/SizingPlant.hpp"
+#include "../../model/SizingPlant_Impl.hpp"
 #include "../../model/ThermalZone.hpp"
 #include "../../model/ThermalZone_Impl.hpp"
 #include <utilities/idd/SimulationControl_FieldEnums.hxx>
@@ -118,6 +120,27 @@ boost::optional<IdfObject> ForwardTranslator::translateSimulationControl( Simula
   else
   {
     simCon.setString(openstudio::SimulationControlFields::RunSimulationforWeatherFileRunPeriods,"No");
+  }
+
+  if( modelObject.doHVACSizingSimulationforSizingPeriods() ) {
+    simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"Yes");
+  } else if (numSizingPeriods > 0) {
+    // Sizing:Plant I/O: "The use of 'Coincident' sizing option requires that the object
+    // be set to YES for the input field called Do HVAC Sizing Simulation for Sizing Periods"
+    std::vector<PlantLoop> plantLoops = modelObject.model().getConcreteModelObjects<PlantLoop>();
+    if (std::any_of(plantLoops.begin(), plantLoops.end(),
+          [](const PlantLoop& p) { return openstudio::istringEqual("Coincident", p.sizingPlant().sizingOption()); }))
+    {
+      simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"Yes");
+    } else {
+      simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+    }
+  } else {
+    simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,"No");
+  }
+
+  if (!modelObject.isMaximumNumberofHVACSizingSimulationPassesDefaulted()) {
+    simCon.setInt(openstudio::SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, modelObject.maximumNumberofHVACSizingSimulationPasses());
   }
 
   // other fields mapped to Building

--- a/src/energyplus/ReverseTranslator/ReverseTranslateSimulationControl.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateSimulationControl.cpp
@@ -125,6 +125,19 @@ OptionalModelObject ReverseTranslator::translateSimulationControl( const Workspa
     }
   }
 
+  optS = workspaceObject.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods);
+  if(optS)
+  {
+    if (openstudio::istringEqual("Yes", optS.get())) {
+      simCon.setRunSimulationforWeatherFileRunPeriods(true);
+    }
+  }
+
+  // Don't return default
+  if (boost::optional<int> _i = workspaceObject.getInt(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false)) {
+    simCon.setMaximumNumberofHVACSizingSimulationPasses(_i.get());
+  }
+
   result = simCon;
   return result;
 }

--- a/src/energyplus/ReverseTranslator/ReverseTranslateSimulationControl.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateSimulationControl.cpp
@@ -129,7 +129,9 @@ OptionalModelObject ReverseTranslator::translateSimulationControl( const Workspa
   if(optS)
   {
     if (openstudio::istringEqual("Yes", optS.get())) {
-      simCon.setRunSimulationforWeatherFileRunPeriods(true);
+      simCon.setDoHVACSizingSimulationforSizingPeriods(true);
+    } else {
+      simCon.setDoHVACSizingSimulationforSizingPeriods(false);
     }
   }
 

--- a/src/energyplus/Test/SimulationControl_GTest.cpp
+++ b/src/energyplus/Test/SimulationControl_GTest.cpp
@@ -1,0 +1,145 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+#include "EnergyPlusFixture.hpp"
+
+#include "../ForwardTranslator.hpp"
+#include "../ReverseTranslator.hpp"
+
+#include "../../model/Model.hpp"
+#include "../../model/SimulationControl.hpp"
+#include "../../model/SimulationControl_Impl.hpp"
+
+#include "../../model/PlantLoop.hpp"
+#include "../../model/SizingPlant.hpp"
+#include "../../model/DesignDay.hpp"
+
+#include "../../utilities/idf/IdfFile.hpp"
+#include "../../utilities/idf/Workspace.hpp"
+#include "../../utilities/idf/IdfObject.hpp"
+#include "../../utilities/idf/WorkspaceObject.hpp"
+#include "../../utilities/idf/IdfExtensibleGroup.hpp"
+#include "../../utilities/idf/WorkspaceExtensibleGroup.hpp"
+
+#include <utilities/idd/SimulationControl_FieldEnums.hxx>
+#include <utilities/idd/IddEnums.hxx>
+
+using namespace openstudio::energyplus;
+using namespace openstudio::model;
+using namespace openstudio;
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_SimulationControl) {
+
+  ForwardTranslator ft;
+
+  // Create a model
+  Model m;
+
+  // Get the unique object
+  SimulationControl simCon = m.getUniqueModelObject<SimulationControl>();
+
+  {
+    Workspace w = ft.translateModel(m);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::SimulationControl);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_simCon(idfObjs[0]);
+
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoZoneSizingCalculation, false).get());
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoSystemSizingCalculation, false).get());
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
+    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+  }
+
+  // Add a plantLoop, and a SizingPeriod, so it forces DoPlantSizingCalculation
+  PlantLoop p(m);
+  SizingPlant sizingPlant = p.sizingPlant();
+  EXPECT_TRUE(sizingPlant.setSizingOption("NonCoincident"));
+  DesignDay dd(m);
+
+  {
+    Workspace w = ft.translateModel(m);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::SimulationControl);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_simCon(idfObjs[0]);
+
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoZoneSizingCalculation, false).get());
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoSystemSizingCalculation, false).get());
+    // Now it's 'Yes' automagically
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
+    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+  }
+
+  // Set the SizingPlant to "Coincident" => should force the "DoHVACSizingSimulationforSizingPeriods"
+  EXPECT_TRUE(sizingPlant.setSizingOption("Coincident"));
+  {
+    Workspace w = ft.translateModel(m);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::SimulationControl);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_simCon(idfObjs[0]);
+
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoZoneSizingCalculation, false).get());
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoSystemSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
+    // Now it's 'Yes' automagically
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+  }
+
+  // Check if the new Integer is translated too
+  EXPECT_TRUE(simCon.setMaximumNumberofHVACSizingSimulationPasses(2));
+  {
+    Workspace w = ft.translateModel(m);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::SimulationControl);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_simCon(idfObjs[0]);
+
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoZoneSizingCalculation, false).get());
+    EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoSystemSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
+    // Now it's 'Yes' automagically
+    EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
+    EXPECT_EQ(2, idf_simCon.getInt(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+  }
+
+}

--- a/src/energyplus/Test/SimulationControl_GTest.cpp
+++ b/src/energyplus/Test/SimulationControl_GTest.cpp
@@ -117,8 +117,9 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_SimulationControl_Logic) {
     EXPECT_EQ("No", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
-    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
-    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+
+    EXPECT_FALSE(idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false, false));
+    EXPECT_FALSE(idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false, false));
   }
 
   // Add a plantLoop, and a SizingPeriod, so it forces DoPlantSizingCalculation
@@ -140,8 +141,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_SimulationControl_Logic) {
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoPlantSizingCalculation, false).get());
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforSizingPeriods, false).get());
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
-    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
-    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+    EXPECT_FALSE(idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false, false));
+    EXPECT_FALSE(idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false, false));
   }
 
   // Set the SizingPlant to "Coincident" => should force the "DoHVACSizingSimulationforSizingPeriods"
@@ -160,7 +161,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_SimulationControl_Logic) {
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::RunSimulationforWeatherFileRunPeriods, false).get());
     // Now it's 'Yes' automagically
     EXPECT_EQ("Yes", idf_simCon.getString(SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, false).get());
-    EXPECT_EQ("", idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false).get());
+    EXPECT_FALSE(idf_simCon.getString(SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, false, false));
   }
 
   // Check if the new Integer is translated too

--- a/src/model/SimulationControl.cpp
+++ b/src/model/SimulationControl.cpp
@@ -569,6 +569,48 @@ namespace detail{
     return result;
   }
 
+  bool SimulationControl_Impl::doHVACSizingSimulationforSizingPeriods() const {
+    boost::optional<std::string> value = getString(OS_SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,true);
+    OS_ASSERT(value);
+    return openstudio::istringEqual(value.get(), "Yes");
+  }
+
+  bool SimulationControl_Impl::isDoHVACSizingSimulationforSizingPeriodsDefaulted() const {
+    return isEmpty(OS_SimulationControlFields::DoHVACSizingSimulationforSizingPeriods);
+  }
+
+  bool SimulationControl_Impl::setDoHVACSizingSimulationforSizingPeriods(bool doHVACSizingSimulationforSizingPeriods) {
+    bool result = setBooleanFieldValue(OS_SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, doHVACSizingSimulationforSizingPeriods);
+    OS_ASSERT(result);
+    return result;
+  }
+
+  void SimulationControl_Impl::resetDoHVACSizingSimulationforSizingPeriods() {
+    bool result = setString(OS_SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, "");
+    OS_ASSERT(result);
+  }
+
+
+  int SimulationControl_Impl::maximumNumberofHVACSizingSimulationPasses() const {
+    boost::optional<int> value = getInt(OS_SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses,true);
+    OS_ASSERT(value);
+    return value.get();
+  }
+
+  bool SimulationControl_Impl::isMaximumNumberofHVACSizingSimulationPassesDefaulted() const {
+    return isEmpty(OS_SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses);
+  }
+
+  bool SimulationControl_Impl::setMaximumNumberofHVACSizingSimulationPasses(int maximumNumberofHVACSizingSimulationPasses) {
+    bool result = setInt(OS_SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, maximumNumberofHVACSizingSimulationPasses);
+    return result;
+  }
+
+  void SimulationControl_Impl::resetMaximumNumberofHVACSizingSimulationPasses() {
+    bool result = setString(OS_SimulationControlFields::MaximumNumberofHVACSizingSimulationPasses, "");
+    OS_ASSERT(result);
+  }
+
 } // detail
 
 SimulationControl::SimulationControl( const Model& model ):
@@ -837,6 +879,43 @@ std::vector<std::string> SimulationControl::partialYearEnvironmentPeriods() cons
 
 std::vector<std::string> SimulationControl::repeatedIntervalEnvironmentPeriods() const {
   return getImpl<detail::SimulationControl_Impl>()->repeatedIntervalEnvironmentPeriods();
+}
+
+bool SimulationControl::doHVACSizingSimulationforSizingPeriods() const {
+  return getImpl<detail::SimulationControl_Impl>()->doHVACSizingSimulationforSizingPeriods();
+}
+
+bool SimulationControl::isDoHVACSizingSimulationforSizingPeriodsDefaulted() const {
+  return getImpl<detail::SimulationControl_Impl>()->isDoHVACSizingSimulationforSizingPeriodsDefaulted();
+}
+
+bool SimulationControl::setDoHVACSizingSimulationforSizingPeriods(bool doHVACSizingSimulationforSizingPeriods) {
+  return getImpl<detail::SimulationControl_Impl>()->setDoHVACSizingSimulationforSizingPeriods(doHVACSizingSimulationforSizingPeriods);
+}
+
+void SimulationControl::setDoHVACSizingSimulationforSizingPeriodsNoFail(bool doHVACSizingSimulationforSizingPeriods) {
+  bool result = getImpl<detail::SimulationControl_Impl>()->setDoHVACSizingSimulationforSizingPeriods(doHVACSizingSimulationforSizingPeriods);
+  OS_ASSERT(result);
+}
+
+void SimulationControl::resetDoHVACSizingSimulationforSizingPeriods() {
+  getImpl<detail::SimulationControl_Impl>()->resetDoHVACSizingSimulationforSizingPeriods();
+}
+
+int SimulationControl::maximumNumberofHVACSizingSimulationPasses() const {
+  return getImpl<detail::SimulationControl_Impl>()->maximumNumberofHVACSizingSimulationPasses();
+}
+
+bool SimulationControl::isMaximumNumberofHVACSizingSimulationPassesDefaulted() const {
+  return getImpl<detail::SimulationControl_Impl>()->isMaximumNumberofHVACSizingSimulationPassesDefaulted();
+}
+
+bool SimulationControl::setMaximumNumberofHVACSizingSimulationPasses(int maximumNumberofHVACSizingSimulationPasses) {
+  return getImpl<detail::SimulationControl_Impl>()->setMaximumNumberofHVACSizingSimulationPasses(maximumNumberofHVACSizingSimulationPasses);
+}
+
+void SimulationControl::resetMaximumNumberofHVACSizingSimulationPasses() {
+  getImpl<detail::SimulationControl_Impl>()->resetMaximumNumberofHVACSizingSimulationPasses();
 }
 
 }

--- a/src/model/SimulationControl.hpp
+++ b/src/model/SimulationControl.hpp
@@ -121,6 +121,12 @@ class MODEL_API SimulationControl : public ParentObject {
 
   bool isMinimumNumberofWarmupDaysDefaulted() const;
 
+  bool doHVACSizingSimulationforSizingPeriods() const;
+  bool isDoHVACSizingSimulationforSizingPeriodsDefaulted() const;
+
+  int maximumNumberofHVACSizingSimulationPasses() const;
+  bool isMaximumNumberofHVACSizingSimulationPassesDefaulted() const;
+
   //@}
   /** @name Setters */
   //@{
@@ -174,6 +180,13 @@ class MODEL_API SimulationControl : public ParentObject {
   bool setMinimumNumberofWarmupDays(int minimumNumberofWarmupDays);
 
   void resetMinimumNumberofWarmupDays();
+
+  bool setDoHVACSizingSimulationforSizingPeriods(bool doHVACSizingSimulationforSizingPeriods);
+  void setDoHVACSizingSimulationforSizingPeriodsNoFail(bool doHVACSizingSimulationforSizingPeriods);
+  void resetDoHVACSizingSimulationforSizingPeriods();
+
+  bool setMaximumNumberofHVACSizingSimulationPasses(int maximumNumberofHVACSizingSimulationPasses);
+  void resetMaximumNumberofHVACSizingSimulationPasses();
 
   //@}
 

--- a/src/model/SimulationControl_Impl.hpp
+++ b/src/model/SimulationControl_Impl.hpp
@@ -54,42 +54,6 @@ namespace detail {
 
   class MODEL_API SimulationControl_Impl : public ParentObject_Impl {
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
    public:
 
     /** @name Constructors and Destructors */
@@ -174,6 +138,12 @@ namespace detail {
 
     bool isMinimumNumberofWarmupDaysDefaulted() const;
 
+    bool doHVACSizingSimulationforSizingPeriods() const;
+    bool isDoHVACSizingSimulationforSizingPeriodsDefaulted() const;
+
+    int maximumNumberofHVACSizingSimulationPasses() const;
+    bool isMaximumNumberofHVACSizingSimulationPassesDefaulted() const;
+
     //@}
     /** @name Setters */
     //@{
@@ -217,6 +187,12 @@ namespace detail {
     bool setMinimumNumberofWarmupDays(int minimumNumberofWarmupDays);
 
     void resetMinimumNumberofWarmupDays();
+
+    bool setDoHVACSizingSimulationforSizingPeriods(bool doHVACSizingSimulationforSizingPeriods);
+    void resetDoHVACSizingSimulationforSizingPeriods();
+
+    bool setMaximumNumberofHVACSizingSimulationPasses(int maximumNumberofHVACSizingSimulationPasses);
+    void resetMaximumNumberofHVACSizingSimulationPasses();
 
     //@}
 

--- a/src/model/test/SimulationControl_GTest.cpp
+++ b/src/model/test/SimulationControl_GTest.cpp
@@ -192,6 +192,36 @@ TEST_F(ModelFixture,SimulationControl_GettersSetters) {
   EXPECT_EQ(6, simulationControl.minimumNumberofWarmupDays());
   EXPECT_TRUE(simulationControl.isMinimumNumberofWarmupDaysDefaulted());
 
+
+  // Do HVAC Sizing Simulation for Sizing Periods:  Boolean
+  // Check Idd default: false
+  EXPECT_TRUE(simulationControl.isDoHVACSizingSimulationforSizingPeriodsDefaulted());
+  EXPECT_FALSE(simulationControl.doHVACSizingSimulationforSizingPeriods());
+  // Test true
+  EXPECT_TRUE(simulationControl.setDoHVACSizingSimulationforSizingPeriods(true));
+  EXPECT_TRUE(simulationControl.doHVACSizingSimulationforSizingPeriods());
+  EXPECT_FALSE(simulationControl.isDoHVACSizingSimulationforSizingPeriodsDefaulted());
+  // Test false
+  EXPECT_TRUE(simulationControl.setDoHVACSizingSimulationforSizingPeriods(false));
+  EXPECT_FALSE(simulationControl.doHVACSizingSimulationforSizingPeriods());
+  // Test reset
+  simulationControl.resetDoHVACSizingSimulationforSizingPeriods();
+  EXPECT_TRUE(simulationControl.isDoHVACSizingSimulationforSizingPeriodsDefaulted());
+  EXPECT_FALSE(simulationControl.doHVACSizingSimulationforSizingPeriods());
+
+
+  // Maximum Number of HVAC Sizing Simulation Passes:  Integer
+  // Check Idd default: 1
+  EXPECT_TRUE(simulationControl.isMaximumNumberofHVACSizingSimulationPassesDefaulted());
+  EXPECT_EQ(1, simulationControl.maximumNumberofHVACSizingSimulationPasses());
+  EXPECT_TRUE(simulationControl.setMaximumNumberofHVACSizingSimulationPasses(12));
+  EXPECT_FALSE(simulationControl.isMaximumNumberofHVACSizingSimulationPassesDefaulted());
+  EXPECT_EQ(12, simulationControl.maximumNumberofHVACSizingSimulationPasses());
+  // Test reset
+  simulationControl.resetMaximumNumberofHVACSizingSimulationPasses();
+  EXPECT_EQ(1, simulationControl.maximumNumberofHVACSizingSimulationPasses());
+  EXPECT_TRUE(simulationControl.isMaximumNumberofHVACSizingSimulationPassesDefaulted());
+
 }
 
 TEST_F(ModelFixture,SimulationControl_LifeCycleCost) {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3892 
 - Wrap two new fields on SimulationControl

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [x] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`): **Not Needed, added at end of object**
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [x] If methods have been deprecated, update rest of code to use the new methods: N/A

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
