### PR TITLE
Fix failing ModelFixture.SurfacePropertyOtherSideCoefficients test (follow up #3867)

### DIFF
--- a/src/model/Surface.cpp
+++ b/src/model/Surface.cpp
@@ -1281,19 +1281,19 @@ namespace detail {
     if (istringEqual("Outdoors", outsideBoundaryCondition)){
       bool test = this->setSunExposure("SunExposed", driverMethod);
       OS_ASSERT(test);
-    }else if (istringEqual("Surface", this->outsideBoundaryCondition()) ||
-              istringEqual("OtherSideCoefficients", this->outsideBoundaryCondition()) ||
-              istringEqual("Adiabatic", this->outsideBoundaryCondition()) ||
-              istringEqual("Ground", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundFCfactorMethod", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundSlabPreprocessorAverage", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundSlabPreprocessorCore", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundSlabPreprocessorPerimeter", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundBasementPreprocessorAverageWall", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundBasementPreprocessorAverageFloor", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundBasementPreprocessorUpperWall", this->outsideBoundaryCondition()) ||
-              istringEqual("GroundBasementPreprocessorLowerWall", this->outsideBoundaryCondition()) ||
-              istringEqual("Foundation", this->outsideBoundaryCondition())){
+    }else if (istringEqual("Surface", outsideBoundaryCondition) ||
+              istringEqual("OtherSideCoefficients", outsideBoundaryCondition) ||
+              istringEqual("Adiabatic", outsideBoundaryCondition) ||
+              istringEqual("Ground", outsideBoundaryCondition) ||
+              istringEqual("GroundFCfactorMethod", outsideBoundaryCondition) ||
+              istringEqual("GroundSlabPreprocessorAverage", outsideBoundaryCondition) ||
+              istringEqual("GroundSlabPreprocessorCore", outsideBoundaryCondition) ||
+              istringEqual("GroundSlabPreprocessorPerimeter", outsideBoundaryCondition) ||
+              istringEqual("GroundBasementPreprocessorAverageWall", outsideBoundaryCondition) ||
+              istringEqual("GroundBasementPreprocessorAverageFloor", outsideBoundaryCondition) ||
+              istringEqual("GroundBasementPreprocessorUpperWall", outsideBoundaryCondition) ||
+              istringEqual("GroundBasementPreprocessorLowerWall", outsideBoundaryCondition) ||
+              istringEqual("Foundation", outsideBoundaryCondition)){
       bool test = this->setSunExposure("NoSun", driverMethod);
       OS_ASSERT(test);
     }else{
@@ -1319,19 +1319,19 @@ namespace detail {
     if (istringEqual("Outdoors", outsideBoundaryCondition)){
       bool test = this->setWindExposure("WindExposed", driverMethod);
       OS_ASSERT(test);
-    } else if (istringEqual("Surface", this->outsideBoundaryCondition()) ||
-               istringEqual("OtherSideCoefficients", this->outsideBoundaryCondition()) ||
-               istringEqual("Adiabatic", this->outsideBoundaryCondition()) ||
-               istringEqual("Ground", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundFCfactorMethod", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundSlabPreprocessorAverage", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundSlabPreprocessorCore", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundSlabPreprocessorPerimeter", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundBasementPreprocessorAverageWall", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundBasementPreprocessorAverageFloor", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundBasementPreprocessorUpperWall", this->outsideBoundaryCondition()) ||
-               istringEqual("GroundBasementPreprocessorLowerWall", this->outsideBoundaryCondition()) ||
-               istringEqual("Foundation", this->outsideBoundaryCondition())){
+    } else if (istringEqual("Surface", outsideBoundaryCondition) ||
+               istringEqual("OtherSideCoefficients", outsideBoundaryCondition) ||
+               istringEqual("Adiabatic", outsideBoundaryCondition) ||
+               istringEqual("Ground", outsideBoundaryCondition) ||
+               istringEqual("GroundFCfactorMethod", outsideBoundaryCondition) ||
+               istringEqual("GroundSlabPreprocessorAverage", outsideBoundaryCondition) ||
+               istringEqual("GroundSlabPreprocessorCore", outsideBoundaryCondition) ||
+               istringEqual("GroundSlabPreprocessorPerimeter", outsideBoundaryCondition) ||
+               istringEqual("GroundBasementPreprocessorAverageWall", outsideBoundaryCondition) ||
+               istringEqual("GroundBasementPreprocessorAverageFloor", outsideBoundaryCondition) ||
+               istringEqual("GroundBasementPreprocessorUpperWall", outsideBoundaryCondition) ||
+               istringEqual("GroundBasementPreprocessorLowerWall", outsideBoundaryCondition) ||
+               istringEqual("Foundation", outsideBoundaryCondition)){
       bool test = this->setWindExposure("NoWind", driverMethod);
       OS_ASSERT(test);
     } else{

--- a/src/model/test/Surface_GTest.cpp
+++ b/src/model/test/Surface_GTest.cpp
@@ -862,13 +862,13 @@ TEST_F(ModelFixture, SurfacePropertyOtherSideCoefficients)
   ASSERT_TRUE(wall1.surfacePropertyOtherSideCoefficients());
   EXPECT_EQ(osc.handle(), wall1.surfacePropertyOtherSideCoefficients()->handle());
   EXPECT_EQ("OtherSideCoefficients", wall1.outsideBoundaryCondition());
-  EXPECT_EQ("SunExposed", wall1.sunExposure());
-  EXPECT_EQ("WindExposed", wall1.windExposure());
+  EXPECT_EQ("NoSun", wall1.sunExposure());
+  EXPECT_EQ("NoWind", wall1.windExposure());
 
   EXPECT_FALSE(wall1.setOutsideBoundaryCondition("FlibbityGibbit"));
   EXPECT_EQ("OtherSideCoefficients", wall1.outsideBoundaryCondition());
-  EXPECT_EQ("SunExposed", wall1.sunExposure());
-  EXPECT_EQ("WindExposed", wall1.windExposure());
+  EXPECT_EQ("NoSun", wall1.sunExposure());
+  EXPECT_EQ("NoWind", wall1.windExposure());
 
   EXPECT_TRUE(wall1.setOutsideBoundaryCondition("Adiabatic"));
   EXPECT_EQ("Adiabatic", wall1.outsideBoundaryCondition());


### PR DESCRIPTION
Fix failing test (follow up #3867)

```
2063: [ RUN      ] ModelFixture.SurfacePropertyOtherSideCoefficients
2063: C:\src\OpenStudio\src\model\test\Surface_GTest.cpp(865): error: Expected equality of these values:
2063:   "SunExposed"
2063:   wall1.sunExposure()
2063:     Which is: "NoSun"
2063: C:\src\OpenStudio\src\model\test\Surface_GTest.cpp(866): error: Expected equality of these values:
2063:   "WindExposed"
2063:   wall1.windExposure()
2063:     Which is: "NoWind"
2063: C:\src\OpenStudio\src\model\test\Surface_GTest.cpp(870): error: Expected equality of these values:
2063:   "SunExposed"
2063:   wall1.sunExposure()
2063:     Which is: "NoSun"
2063: C:\src\OpenStudio\src\model\test\Surface_GTest.cpp(871): error: Expected equality of these values:
2063:   "WindExposed"
2063:   wall1.windExposure()
2063:     Which is: "NoWind"
```