### PR TITLE
#3917 - Properly disallow connecting two ThermalZones in Series on an AirLoopHVAC demand branch

### DIFF
--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -2075,7 +2075,16 @@ namespace detail {
       auto outletObj = node.outletModelObject();
 
       if( inletObj && outletObj ) {
-        if( (! inletObj->optionalCast<ThermalZone>()) && outletObj->optionalCast<Mixer>() ) {
+        // Rules for allowing connection:
+        // * It must be the last node on the demand branch, meaning the outlet must be the Mixer
+        // * There must not be any ThermalZone on the branch already
+        //     * (If ok, then the inletObj is usually an AirTerminal)
+        //     * In the most common case where not ok, inletObj is a PortList that connects to the ThermalZone
+        //     * inletObj can also be OS:AirLoopHVAC:ReturnPlenum
+        //     * => can't really check if inletObj is a Class, instead we check that the demand branch (between splitter and node) doesn't have a
+        //     ThermalZone already
+        if( (airLoop->demandComponents(airLoop->demandSplitter(), node, IddObjectType::OS_ThermalZone).empty()) &&
+            (outletObj->optionalCast<Mixer>()) ) {
           Node newNode(_model);
           auto thisobj = getObject<ThermalZone>();
           auto _inletPortList = inletPortList();

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -358,10 +358,16 @@ namespace detail {
 
     bool setUseIdealAirLoads(bool useIdealAirLoads);
 
-    bool addToNode(Node & node) override;
-
+    // Handles the logic of connecting the thermal zone to a Node: allowing or disallowing, and adding the equipment (AirTerminal) to the
+    // ZoneEquipmentList as appropriate
+    // Only allows connection to a node that's on the demand branch of an AirLoopHVAC, on the node right before the Demand Mixer, and as long as there
+    // are no other ThermalZones already connected on the branch
     bool addToNodeImpl(Node & node);
 
+    // Calls addToNodeImpl, then removes connections to all pre-existing AirLoopHVAC
+    bool addToNode(Node & node) override;
+
+    // Calls addToNodeImpl, not touching connections to all pre-existing AirLoopHVAC
     bool multiAddToNode(Node & node);
 
     PortList inletPortList() const;

--- a/src/model/test/ThermalZone_GTest.cpp
+++ b/src/model/test/ThermalZone_GTest.cpp
@@ -33,6 +33,7 @@
 
 #include "../AirLoopHVAC.hpp"
 #include "../AirLoopHVACZoneSplitter.hpp"
+#include "../AirLoopHVACZoneMixer.hpp"
 #include "../AirTerminalSingleDuctConstantVolumeNoReheat.hpp"
 #include "../CoilCoolingDXSingleSpeed.hpp"
 #include "../CoilHeatingWater.hpp"
@@ -760,4 +761,70 @@ TEST_F(ModelFixture, ThermalZone_ZoneControlHumidistat)
     EXPECT_NE(zone.zoneControlHumidistat()->handle(), zone2.zoneControlHumidistat()->handle());
     EXPECT_EQ(2u,m.getModelObjects<model::ZoneControlHumidistat>().size());
   }
+}
+
+
+TEST_F(ModelFixture,ThermalZone_AddToNode_NotInSeries)
+{
+  Model m;
+  AirLoopHVAC a(m);
+  ThermalZone z1(m);
+  ThermalZone z2(m);
+  ScheduleCompact s(m);
+  AirTerminalSingleDuctConstantVolumeNoReheat atu(m,s);
+
+  AirLoopHVACZoneMixer mixer = a.zoneMixer();
+  AirLoopHVACZoneSplitter splitter = a.zoneSplitter();
+
+  EXPECT_EQ(5u, a.demandComponents().size());
+
+  EXPECT_TRUE(a.addBranchForHVACComponent(atu));
+  EXPECT_EQ(7u, a.demandComponents().size());
+
+  // 9 components:
+  // Inlet -- (Mixer) -- Node ----- ATU ----- Node ---- ThermalZone ----- Node ----- (SPlitter) -------- OutletNode
+
+  //            -----o-----ATU-----o-----TZ-----o-----
+  // -----o-----|                                    |-----o------
+
+
+  Node connectingNode = mixer.lastInletModelObject()->cast<Node>();
+  EXPECT_TRUE(z1.multiAddToNode(connectingNode));
+  EXPECT_EQ(9u, a.demandComponents().size());
+
+  // Try to add Zone 1 twice in series
+  connectingNode = mixer.lastInletModelObject()->cast<Node>();
+  EXPECT_FALSE(z1.multiAddToNode(connectingNode));
+  EXPECT_EQ(9u, a.demandComponents().size());
+
+  // Try to add Zone 2 in series with zone 1
+  connectingNode = mixer.lastInletModelObject()->cast<Node>();
+  EXPECT_FALSE(z2.multiAddToNode(connectingNode));
+  EXPECT_EQ(9u, a.demandComponents().size());
+
+
+  // TRY WITH PLENUMS NOW
+  ThermalZone supplyPlenumZone(m);
+  ThermalZone returnPlenumZone(m);
+
+  EXPECT_TRUE(supplyPlenumZone.canBePlenum());
+  EXPECT_TRUE(z1.setSupplyPlenum(supplyPlenumZone));
+  // Added one one and the plenum
+  EXPECT_EQ(11u, a.demandComponents().size());
+
+  // Try to add Zone 2 in series with zone 1
+  connectingNode = mixer.lastInletModelObject()->cast<Node>();
+  EXPECT_FALSE(z2.multiAddToNode(connectingNode));
+  EXPECT_EQ(11u, a.demandComponents().size());
+
+  EXPECT_TRUE(returnPlenumZone.canBePlenum());
+  EXPECT_TRUE(z1.setReturnPlenum(returnPlenumZone));
+  // Added one node and the plenum
+  EXPECT_EQ(13u, a.demandComponents().size());
+
+  // Try to add Zone 2 in series with zone 1
+  connectingNode = mixer.lastInletModelObject()->cast<Node>();
+  EXPECT_FALSE(z2.multiAddToNode(connectingNode));
+  EXPECT_EQ(13u, a.demandComponents().size());
+
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3917
 - Properly disallow connecting two ThermalZones in parallel on an AirLoopHVAC demand branch

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [x] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
