### PR TITLE
Fix #871: disable fast naming for the model in RT

### DIFF
--- a/src/energyplus/ReverseTranslator.cpp
+++ b/src/energyplus/ReverseTranslator.cpp
@@ -155,7 +155,7 @@ Model ReverseTranslator::translateWorkspace(const Workspace & workspace, Progres
   }
 
   m_model = Model();
-  m_model.setFastNaming(true);
+  m_model.setFastNaming(false);
 
   m_workspace = workspace.clone();
 


### PR DESCRIPTION
I'm pretty sure it was a copy paste error from the loadModel one that creates a and (IDF) Workspace first

Pull request overview
---------------------

 - Fix #871: disable fast naming for the model in RT

I'm pretty sure it was a copy paste error from the loadModel one that creates a and (IDF) Workspace first
Before:

```
3.0.0-beta, rt'ing 5ZoneAirCooled.idf (E+ example)
```
m = rt.loadModel('5ZoneAirCooled.idf')
[...]
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to '{9fcb35f6-e6e2-4a44-8fd4-64d0908f7ffe}' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to '{7991a04f-c1e4-4c44-8fee-984efeaa052b}' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to '{8dc8fbf3-e2bf-4bce-8644-deade814a3d2}' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to '{6ddf24e8-60cc-41e8-a8a3-24ef0144cae1}' to avoid a name conflict upon WorkspaceObject addition.
```

After:

```
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to 'DualSetPoint 1' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to 'DualSetPoint 2' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to 'DualSetPoint 3' to avoid a name conflict upon WorkspaceObject addition.
[utilities.idf.Workspace] <-1> Renamed Object of type 'OS:ThermostatSetpoint:DualSetpoint' and named 'DualSetPoint' to 'DualSetPoint 4' to avoid a name conflict upon WorkspaceObject addition.
```

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
