### PR TITLE
Prevent CLI error

### DIFF
--- a/src/cli/openstudio_cli.rb
+++ b/src/cli/openstudio_cli.rb
@@ -1757,7 +1757,11 @@ begin
   result = CLI.new(ARGV).execute
 rescue Exception => e
   puts "Error executing argv: #{ARGV}"
-  puts "Error: #{e.message} in #{e.backtrace.join("\n")}"
+  if e.backtrace.nil?
+    puts "Error: #{e.message}"
+  else
+    puts "Error: #{e.message} in #{e.backtrace.join("\n")}"
+  end
   result = 1
 end
 STDOUT.flush


### PR DESCRIPTION
Prevents an error in OS CLI exception handling when e.backtrace is nil. 

Example:
```
C:/openstudio-3.0.0-beta/bin/openstudio.exe -e "require 'rubocop/rake_task'" -e "RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--auto-correct', '--format', 'simple', '--only', 'Layout,Lint/DeprecatedClassMethods,Lint/StringConversionInInterpolation,Style/AndOr,Style/HashSyntax,Style/Next,Style/NilComparison,Style/RedundantParentheses,Style/RedundantSelf,Style/ReturnNil,Style/SelfAssignment,Style/StringLiterals,Style/StringLiteralsInInterpolation'] end" -e "Rake.application[:rubocop].invoke"
Ignoring pycall-1.2.1 because its extensions are not built. Try: gem pristine pycall --version 1.2.1
Running RuboCop...

2 files inspected, no offenses detected
Error executing argv: ["-e", "require 'rubocop/rake_task'", "-e", "RuboCop::RakeTask.new(:rubocop) do |t| t.options = ['--auto-correct', '--format', 'simple', '--only', 'Layout,Lint/DeprecatedClassMethods,Lint/StringConversionInInterpolation,Style/AndOr,Style/HashSyntax,Style/Next,Style/NilComparison,Style/RedundantParentheses,Style/RedundantSelf,Style/ReturnNil,Style/SelfAssignment,Style/StringLiterals,Style/StringLiteralsInInterpolation'] end", "-e", "Rake.application[:rubocop].invoke"]

Error: undefined method `join' for nil:NilClass
Backtrace:
        :/openstudio_cli.rb:1760:in `rescue in <main>'
        :/openstudio_cli.rb:1756:in `<main>'
        eval:137:in `eval'
        eval:137:in `require_embedded_absolute'
        eval:110:in `block in require'
        eval:104:in `each'
        eval:104:in `require'
        eval:3:in `<main>'
Exception: undefined method `join' for nil:NilClass
ruby: unexpected return
```