### PR TITLE
Add missing API exports necessary for OSApp

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.hpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.hpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <boost/optional.hpp>
+#include "../EnergyPlusAPI.hpp"
 
 namespace openstudio {
 
@@ -49,15 +50,15 @@ namespace energyplus{
 
   enum class ComponentType {HEATING, COOLING, BOTH, NONE};
 
-  ComponentType componentType(const openstudio::model::HVACComponent & component);
+  ENERGYPLUS_API ComponentType componentType(const openstudio::model::HVACComponent & component);
 
   bool _isSetpointComponent(const openstudio::model::PlantLoop & plantLoop,const openstudio::model::ModelObject & comp);
 
-  boost::optional<openstudio::model::Node> inletNode(const openstudio::model::PlantLoop & plantLoop, const openstudio::model::HVACComponent & component);
+  ENERGYPLUS_API boost::optional<openstudio::model::Node> inletNode(const openstudio::model::PlantLoop & plantLoop, const openstudio::model::HVACComponent & component);
 
-  boost::optional<double> flowrate(const openstudio::model::HVACComponent & component);
+  ENERGYPLUS_API boost::optional<double> flowrate(const openstudio::model::HVACComponent & component);
 
-  boost::optional<openstudio::model::Node> outletNode(const openstudio::model::PlantLoop & plantLoop, const openstudio::model::HVACComponent & component);
+  ENERGYPLUS_API boost::optional<openstudio::model::Node> outletNode(const openstudio::model::PlantLoop & plantLoop, const openstudio::model::HVACComponent & component);
 
   /*
    * Check the overall type of a plantLoop by checking what is on the supply side
@@ -67,22 +68,22 @@ namespace energyplus{
    * * If there is no cooling, no heating, no "both": None
    * * All other cases: "both"
    */
-  ComponentType plantLoopType(const openstudio::model::PlantLoop & plantLoop);
+  ENERGYPLUS_API ComponentType plantLoopType(const openstudio::model::PlantLoop & plantLoop);
 
   /* Some plant components air in a containingHVACComponent() and it is that
    * container which needs to go on the plant operation scheme. Here is a filter to figure that out.
    */
-  openstudio::model::HVACComponent operationSchemeComponent(const openstudio::model::HVACComponent & component);
+  ENERGYPLUS_API openstudio::model::HVACComponent operationSchemeComponent(const openstudio::model::HVACComponent & component);
 
-  std::vector<openstudio::model::HVACComponent> setpointComponents(const openstudio::model::PlantLoop & plantLoop);
+  ENERGYPLUS_API std::vector<openstudio::model::HVACComponent> setpointComponents(const openstudio::model::PlantLoop & plantLoop);
 
   /* Loops on all plant loop supply side components to find the ones that have a type cooling.
    * Calls operationSchemeComponent(comp) for each comp of type ComponentType::Cooling */
-  std::vector<openstudio::model::HVACComponent> coolingComponents(const openstudio::model::PlantLoop & plantLoop);
+  ENERGYPLUS_API std::vector<openstudio::model::HVACComponent> coolingComponents(const openstudio::model::PlantLoop & plantLoop);
 
-  std::vector<openstudio::model::HVACComponent> heatingComponents(const openstudio::model::PlantLoop & plantLoop);
+  ENERGYPLUS_API std::vector<openstudio::model::HVACComponent> heatingComponents(const openstudio::model::PlantLoop & plantLoop);
 
-  std::vector<openstudio::model::HVACComponent> uncontrolledComponents(const openstudio::model::PlantLoop & plantLoop);
+  ENERGYPLUS_API std::vector<openstudio::model::HVACComponent> uncontrolledComponents(const openstudio::model::PlantLoop & plantLoop);
 
 
 } // energyplus


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
