### PR TITLE
3940 workaround

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -41,6 +41,12 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   # You do want to rebuild packages if there's a newer recipe in the remote (which applies mostly to our own openstudio_ruby where we don't
   # bump the actual package version when we make changes) than the binaries were built with
   # 'outdated' also acts like 'missing': if no binary, will build them.
+
+  # TODO: TEMP. If MSVC >= 1925 (16.5.1), build boost?
+  #if(NOT MSVC_VERSION VERSION_LESS 1925)
+  #  list(APPEND CONAN_BUILD "boost")
+  #endif()
+
   list(APPEND CONAN_BUILD "outdated")
 
   if (BUILD_TESTING)
@@ -87,8 +93,9 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     OPTIONS ${CONAN_OPTIONS}
     BUILD ${CONAN_BUILD}
     # Passes `-u, --update`    to conan install: Check updates exist from upstream remotes
-    # That and build=outdated should ensure we track the right
-    UPDATE
+    # That and build=outdated should ensure we track the right openstudio_ruby
+    # Instead, we will pin the RREV for the openstudio_ruby
+    # UPDATE
   )
 
   set(CONAN_OPENSTUDIO_ALREADY_RUN TRUE)


### PR DESCRIPTION
Pull request overview
---------------------

Facts:
* `boost/1.71` released a new version, which forces you to upgrade conan to 1.24
* MSVC 2019 released an update that changes `_MSC_VER` from 1924 to 1925. conan-openstudio-ruby will throw an error because it checks in its config.h for the exact MSC_VER. A workaround is to comment that out.

in `C:\Users\julien\.conan\data\openstudio_ruby\2.5.5\nrel\stable\package\45b3b9a1aa73fdb3ff32afdc2b2ddc0affca7928\include\ruby-2.5.0\x64-mswin64_140\ruby\config.h`

```
#ifndef INCLUDE_RUBY_CONFIG_H
#define INCLUDE_RUBY_CONFIG_H 1
// Manual fix by commenting these three lines out
//#if _MSC_VER != 1924
//#error MSC version unmatch: _MSC_VER: 1924 is expected.
//#endif
```

* Not sure whether the boost/1.71 new package is broken, or if my update to MSVC 16.5.1 is guilty, but suddenly I was getting a ton of include errors, so I had to rebuild boost/1.71 from source.

### Workaround

Pending addressing #3940 properly:

* Not sure if people that upgrade their MSVC 2019 to latest (16.5.1, _MSC_VER 1925 versus 1924 before) will have the same boost problem as me, but they will have the conan openstudio ruby one which is easily fixed by commenting out in config.h the offending check. When in doubt, don't upgrade. (Note: CI uses MSVC 2017 so won't be affected anyways)

* Comment out the `UPDATE` here: . That'll avoid people realizing their need conan 1.24 now due to boost/1.71 change a few hours ago ... (that includes CI..)