### PR TITLE
Fix ruby windows crash with system ruby

### DIFF
--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -69,17 +69,38 @@ foreach(OPENSTUDIO_FILE ${OPENSTUDIO_FILES})
   )
 endforeach()
 
+
 target_link_libraries(
   openstudio_rb
   PRIVATE
   init_openstudio
   ${ALL_RUBY_BINDING_TARGETS}
-  PUBLIC
-  openstudiolib
 )
 
 if( WIN32 )
+  # Dynamically link to openstudiolib.dll on Windows only
+  target_link_libraries(
+    openstudio_rb
+    PUBLIC
+    openstudiolib
+  )
   target_link_libraries(openstudio_rb PRIVATE ${RUBY_MINGW_STUB_LIB})
+else()
+  # statically link everywhere else
+  target_link_libraries(
+    openstudio_rb
+    PRIVATE
+    openstudio_utilities
+    openstudio_airflow
+    openstudio_model
+    openstudio_energyplus
+    openstudio_measure
+    openstudio_osversion
+    openstudio_sdd
+    openstudio_isomodel
+    openstudio_gbxml
+    openstudio_radiance
+  )
 endif()
 
 if (APPLE)

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -74,16 +74,8 @@ target_link_libraries(
   PRIVATE
   init_openstudio
   ${ALL_RUBY_BINDING_TARGETS}
-  openstudio_utilities
-  openstudio_airflow
-  openstudio_model
-  openstudio_energyplus
-  openstudio_measure
-  openstudio_osversion
-  openstudio_sdd
-  openstudio_isomodel
-  openstudio_gbxml
-  openstudio_radiance
+  PUBLIC
+  openstudiolib
 )
 
 if( WIN32 )

--- a/ruby/openstudio.rb
+++ b/ruby/openstudio.rb
@@ -30,20 +30,19 @@
 # add binary dir to system path
 original_path = ENV['PATH']
 if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
-  front = []
-  back = []
-  original_path.split(';').each do |p|
-    if /SketchUp/.match(p)
-      front << p
-    else
-      back << p
-    end
+  cur_location = File.dirname(__FILE__)  
+  
+  build_type = File.basename(cur_location)
+
+  if build_type == "Debug" or build_type == "Release" or build_type == "RelWithDebugInfo" or build_type == "RelMinSize"
+    # in build dir execution
+    relative_dll_path = File.join(File.dirname(File.dirname(cur_location)), build_type)  
+    RubyInstaller::Runtime.add_dll_directory(relative_dll_path)
+  else 
+    # install dir execution
+    RubyInstaller::Runtime.add_dll_directory(File.join(File.dirname(cur_location), "lib"))
   end
-
-  ENV['PATH'] = "#{front.join(';')};#{File.dirname(__FILE__)};#{back.join(';')}"
-
-else
-
+else  
   # Do something here for Mac OSX environments
   ENV['PATH'] = "#{File.dirname(__FILE__)}:#{original_path}"
 end

--- a/src/utilities/core/Singleton.hpp
+++ b/src/utilities/core/Singleton.hpp
@@ -49,9 +49,7 @@ namespace openstudio {
       static object_type obj;
       return obj;
     }   
-  }
-};
-
+  };
 }  // namespace openstudio
 
 #endif  // UTILITIES_CORE_SINGLETON_HPP

--- a/src/utilities/core/Singleton.hpp
+++ b/src/utilities/core/Singleton.hpp
@@ -32,55 +32,29 @@
 
 // Warning: If T's constructor throws, instance() will return a null reference.
 
-namespace openstudio{
+namespace openstudio {
 
   // Ripped from boost http://www.boost.org/doc/libs/1_42_0/libs/pool/doc/implementation/singleton.html
   // T must be: no-throw default constructible and no-throw destructible
   template <typename T>
   class Singleton
   {
-    private:
-      struct object_creator
-      {
-        // This constructor does nothing more than ensure that instance()
-        //  is called before main() begins, thus creating the static
-        //  T object before multithreading race issues can come up.
-        object_creator() { Singleton<T>::instance(); }
-        inline void do_nothing() const {  }
-      };
-      static object_creator create_object;
-
-      Singleton();
-
     public:
+    Singleton() = delete;
+    typedef T object_type;
 
-      typedef T object_type;
+    // If, at any point (in user code), Singleton<T>::instance()
+    //  is called, then the following function is instantiated.
+    static object_type& instance() {
+      static object_type obj;
+      return obj;
+    }   
+  }
+};
 
-      // If, at any point (in user code), Singleton<T>::instance()
-      //  is called, then the following function is instantiated.
-      static object_type & instance()
-      {
-        // This is the object that we return a reference to.
-        // It is guaranteed to be created before main() begins because of
-        //  the next line.
-        static object_type obj;
+}  // namespace openstudio
 
-        // The following line does nothing else than force the instantiation
-        //  of Singleton<T>::create_object, whose constructor is
-        //  called before main() begins.
-        create_object.do_nothing();
-
-        return obj;
-      }
-  };
-  template <typename T>
-  typename Singleton<T>::object_creator
-  Singleton<T>::create_object;
-
-}; // openstudio
-
-#endif // UTILITIES_CORE_SINGLETON_HPP
-
+#endif  // UTILITIES_CORE_SINGLETON_HPP
 
 /* EXAMPLE USAGE
 


### PR DESCRIPTION
Move to dynamic linking of openstudiolib.dll to ruby openstudio.dll to pretend like we have some control over the Undefined Behavior caused by ruby's definition of `fclose` and other system library functions.