### PR TITLE
Fix #3311 - Bundle tests take too much space

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,7 +5,7 @@
 # * Use only full 40-character hashes
 # * Here's an example of a way to grep the commit history to find commits to exclude:
 # ```
-# git log --all --reverse --grep='copyright' --pretty='format:# %C(auto)%s [%an, %as]%n%H%n' >> .git-blame-ignore-revs
+# git log --all --reverse --grep='copyright' --grep='\[chore\]' --pretty='format:# %C(auto)%s [%an, %as]%n%H%n' >> .git-blame-ignore-revs
 #
 # ```
 # Note: On older git (like 2.17 which is default in 18.04, without `sudo add-apt-repository ppa:git-core/ppa`),
@@ -127,3 +127,6 @@ b2d77f6923934f6cabe86560d46ef37002f1732b
 
 # Updated copyrights for 2020 [Alex Swindler, 2020-02-28]
 1a0500de74b83093e22892a1f3ff3b67b799e648
+
+# whitespace changes in bundle tests [chore] [Julien Marrec, 2020-04-21]
+fa7a5b99830bcab336eba7ebf6bf799948ba0cc4

--- a/src/cli/test/bundle/Gemfile
+++ b/src/cli/test/bundle/Gemfile
@@ -1,7 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'openstudio-standards', '0.2.0'
+gem 'openstudio-workflow', '2.0.0.pre1' # This is compatible with bundler 2.1 (OS 3.x), and already older than currently used at this time
 gem 'tilt', '2.0.8'
-
-# CLI requires json_pure gem if JSON will be used
-gem 'json_pure', '= 2.1.0'

--- a/src/cli/test/bundle/test.rb
+++ b/src/cli/test/bundle/test.rb
@@ -15,7 +15,9 @@ puts Tilt::VERSION
 raise "Tilt version does not match" unless Tilt::VERSION == '2.0.8'
 
 # test a more complex / larger gem, that should override the existing version installed
+# openstudio-workflow 2.0.0.pre1 is compatible with bundler 2.1 (OS 3.x),
+# and already older than currently used at this time (2.0.0)
 require 'openstudio'
-require 'openstudio-standards'
-puts OpenstudioStandards::VERSION
-raise "OpenStudio Standards version does not match" unless OpenstudioStandards::VERSION == '0.2.0'
+require 'openstudio-workflow'
+puts OpenStudio::Workflow::VERSION
+raise "OpenStudio Workflow gem version does not match" unless OpenStudio::Workflow::VERSION == '2.0.0.pre1'

--- a/src/cli/test/bundle/test.rb
+++ b/src/cli/test/bundle/test.rb
@@ -5,8 +5,8 @@ def local_gems
 end
 
 # list installed gems
-puts local_gems.map{ |name, specs| 
-  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ') 
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
 }
 
 # test a simple gem

--- a/src/cli/test/bundle_default/test.rb
+++ b/src/cli/test/bundle_default/test.rb
@@ -5,8 +5,8 @@ def local_gems
 end
 
 # list installed gems
-puts local_gems.map{ |name, specs| 
-  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ') 
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
 }
 
 # test a more complex / larger gem, that should override the existing version installed

--- a/src/cli/test/bundle_native/test.rb
+++ b/src/cli/test/bundle_native/test.rb
@@ -5,8 +5,8 @@ def local_gems
 end
 
 # list installed gems
-puts local_gems.map{ |name, specs| 
-  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ') 
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
 }
 # test a gem that required native extensions
 require 'ffi'

--- a/src/cli/test/bundle_no_install/test.rb
+++ b/src/cli/test/bundle_no_install/test.rb
@@ -5,8 +5,8 @@ def local_gems
 end
 
 # list installed gems
-puts local_gems.map{ |name, specs| 
-  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ') 
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
 }
 
 # test a simple gem

--- a/src/cli/test/no_bundle/test.rb
+++ b/src/cli/test/no_bundle/test.rb
@@ -5,11 +5,10 @@ def local_gems
 end
 
 # list installed gems
-puts local_gems.map{ |name, specs| 
-  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ') 
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
 }
 
-# test a more complex / larger gem, that should override the existing version installed
 require 'openstudio'
 require 'openstudio-standards'
 puts OpenstudioStandards::VERSION

--- a/src/cli/test/test_bundle.rb
+++ b/src/cli/test/test_bundle.rb
@@ -16,116 +16,116 @@ class Bundle_Test < Minitest::Test
   def test_bundle
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), 'bundle'))
-    
+
     rm_if_exist('Gemfile.lock')
     rm_if_exist('./test_gems')
     rm_if_exist('./bundle')
-    
+
     assert(system('bundle install --path ./test_gems'))
     assert(system('bundle lock --add_platform ruby'))
     assert(system("'#{OpenStudio::getOpenStudioCLI}' --bundle Gemfile --bundle_path './test_gems' --verbose test.rb"))
-    
+
   ensure
-    Dir.chdir(original_dir)  
+    Dir.chdir(original_dir)
   end
-  
+
   def test_bundle_git
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), 'bundle_git'))
-    
+
     rm_if_exist('Gemfile.lock')
     rm_if_exist('./test_gems')
     rm_if_exist('./bundle')
-    
+
     assert(system('bundle install --path ./test_gems'))
     assert(system('bundle lock --add_platform ruby'))
     assert(system("'#{OpenStudio::getOpenStudioCLI}' --bundle Gemfile --bundle_path './test_gems' --verbose test.rb"))
-    
+
   ensure
-    Dir.chdir(original_dir)  
-  end  
-  
+    Dir.chdir(original_dir)
+  end
+
   def test_bundle_native
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), 'bundle_native'))
-    
+
     if /mingw/.match(RUBY_PLATFORM) || /mswin/.match(RUBY_PLATFORM)
-      skip("Native gems not supported on Windows") 
+      skip("Native gems not supported on Windows")
     else
-	  skip("Native gems not supported on Unix or Mac") 
+	  skip("Native gems not supported on Unix or Mac")
     end
-    
+
     rm_if_exist('Gemfile.lock')
     rm_if_exist('./test_gems')
     rm_if_exist('./bundle')
-    
+
     assert(system('bundle install --path ./test_gems'))
     #assert(system('bundle lock --add_platform ruby'))
     if /mingw/.match(RUBY_PLATFORM) || /mswin/.match(RUBY_PLATFORM)
       assert(system('bundle lock --add_platform mswin64'))
-    end    
+    end
     assert(system("'#{OpenStudio::getOpenStudioCLI}' --bundle Gemfile --bundle_path './test_gems' --verbose test.rb"))
-    
+
   ensure
-    Dir.chdir(original_dir)  
-  end  
-  
+    Dir.chdir(original_dir)
+  end
+
   def test_bundle_no_install
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), 'bundle_no_install'))
-    
+
     rm_if_exist('Gemfile.lock')
     rm_if_exist('./test_gems')
     rm_if_exist('./bundle')
-    
+
     #assert(system('bundle install --path ./test_gems'))
     #assert(system('bundle lock --add_platform ruby'))
-    
+
     # intentionally called with dependencies not found in the CLI, expected to fail
     assert_equal(system("'#{OpenStudio::getOpenStudioCLI}' --bundle Gemfile --verbose test.rb"), false)
-    
+
   ensure
-    Dir.chdir(original_dir)  
-  end  
-  
+    Dir.chdir(original_dir)
+  end
+
   def test_no_bundle
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), 'no_bundle'))
 
     puts "'#{OpenStudio::getOpenStudioCLI}' --verbose test.rb"
     assert(system("'#{OpenStudio::getOpenStudioCLI}' --verbose test.rb"))
-    
+
   ensure
-    Dir.chdir(original_dir)  
-  end   
-  
+    Dir.chdir(original_dir)
+  end
+
   def test_bundle_default
-    
+
     original_dir = Dir.pwd
-    
+
     if !defined?(OpenStudio::CLI) || !OpenStudio::CLI
-      skip("Embedded gems not available unless CLI") 
+      skip("Embedded gems not available unless CLI")
     end
-    
+
     Dir.chdir(File.join(File.dirname(__FILE__), 'bundle_default'))
-    
+
     rm_if_exist('openstudio-gems.gemspec')
     rm_if_exist('Gemfile')
     rm_if_exist('Gemfile.lock')
     rm_if_exist('./test_gems')
     rm_if_exist('./bundle')
-    
+
     assert(EmbeddedScripting::hasFile(':/openstudio-gems.gemspec'))
     assert(EmbeddedScripting::hasFile(':/Gemfile'))
     assert(EmbeddedScripting::hasFile(':/Gemfile.lock'))
-    
+
     File.open(File.join(File.dirname(__FILE__), 'bundle_default', 'openstudio-gems.gemspec'), 'w') do |f|
       f.puts EmbeddedScripting::getFileAsString(':/openstudio-gems.gemspec')
       begin
         f.fsync
       rescue
         f.flush
-      end      
+      end
     end
     File.open(File.join(File.dirname(__FILE__), 'bundle_default', 'Gemfile'), 'w') do |f|
       f.puts EmbeddedScripting::getFileAsString(':/Gemfile')
@@ -133,7 +133,7 @@ class Bundle_Test < Minitest::Test
         f.fsync
       rescue
         f.flush
-      end      
+      end
     end
     File.open(File.join(File.dirname(__FILE__), 'bundle_default', 'Gemfile.lock'), 'w') do |f|
       f.puts EmbeddedScripting::getFileAsString(':/Gemfile.lock')
@@ -141,18 +141,18 @@ class Bundle_Test < Minitest::Test
         f.fsync
       rescue
         f.flush
-      end      
+      end
     end
-    
+
     # just use embedded gems
     assert(system("'#{OpenStudio::getOpenStudioCLI}' --verbose test.rb"))
-    
+
     # DLM: do we need to be able to pass a Gemfile without a bundle?
     # don't pass bundle_path since we want to use embedded gems
     #assert(system("'#{OpenStudio::getOpenStudioCLI}' --bundle './Gemfile' --verbose test.rb"))
-    
+
   ensure
-    Dir.chdir(original_dir)  
-  end   
-  
+    Dir.chdir(original_dir)
+  end
+
 end

--- a/src/cli/test/test_embedded_help.rb
+++ b/src/cli/test/test_embedded_help.rb
@@ -9,7 +9,7 @@ class EmbeddedHelp_Test < Minitest::Test
   def test_dir_glob
     original_dir = Dir.pwd
     Dir.chdir(File.join(File.dirname(__FILE__), '..'))
-  
+
     # test things that should work in ruby or CLI
     no_block_glob = Dir["*.txt", "*.rb"]
     assert_instance_of(Array, no_block_glob)
@@ -17,7 +17,7 @@ class EmbeddedHelp_Test < Minitest::Test
     assert_includes(no_block_glob, 'embedded_help.rb')
     puts no_block_glob.index('test_embedded_help.rb')
     assert_nil(no_block_glob.index('test_embedded_help.rb'))
-    
+
     no_block_glob = Dir.glob(["*.txt", "*.rb"])
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, 'CMakeLists.txt')
@@ -29,42 +29,42 @@ class EmbeddedHelp_Test < Minitest::Test
     assert_includes(no_block_glob, 'CMakeLists.txt')
     assert_nil(no_block_glob.index('embedded_help.rb'))
     assert_nil(no_block_glob.index('test_embedded_help.rb'))
-    
+
     no_block_glob = Dir["**/*.txt", "**/*.rb"]
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, 'CMakeLists.txt')
     assert_includes(no_block_glob, 'embedded_help.rb')
     assert_includes(no_block_glob, 'test/test_embedded_help.rb')
-    
+
     no_block_glob = Dir["*{.txt,.rb}"]
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, 'CMakeLists.txt')
     assert_includes(no_block_glob, 'embedded_help.rb')
     assert_nil(no_block_glob.index('test_embedded_help.rb'))
     assert_nil(no_block_glob.index('test/test_embedded_help.rb'))
-    
+
     no_block_glob = Dir["{,*,*/*}.{txt,rb}"]
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, 'CMakeLists.txt')
     assert_includes(no_block_glob, 'embedded_help.rb')
     assert_includes(no_block_glob, 'test/test_embedded_help.rb')
-    
+
     no_block_glob = Dir.glob("{,*,*/*}.{txt,rb}")
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, 'CMakeLists.txt')
     assert_includes(no_block_glob, 'embedded_help.rb')
-    assert_includes(no_block_glob, 'test/test_embedded_help.rb')    
-    
+    assert_includes(no_block_glob, 'test/test_embedded_help.rb')
+
     no_block_glob = Dir["./**/*.txt", "./**/*.rb"]
     assert_instance_of(Array, no_block_glob)
     assert_includes(no_block_glob, './CMakeLists.txt')
     assert_includes(no_block_glob, './embedded_help.rb')
     assert_includes(no_block_glob, './test/test_embedded_help.rb')
-    
+
     block_glob = []
     Dir["*.txt", "*.rb"].each do |p|
       block_glob << p
-    end    
+    end
     assert_includes(block_glob, 'CMakeLists.txt')
     assert_includes(block_glob, 'embedded_help.rb')
     assert_nil(block_glob.index('test_embedded_help.rb'))
@@ -82,47 +82,47 @@ class EmbeddedHelp_Test < Minitest::Test
     assert(File.fnmatch( ":/**/help.rb", ":/test/help.rb", File::FNM_EXTGLOB))
     assert(!File.fnmatch( ":/**/help{.rb,.txt}", ":/test/help.rb", 0))
     assert(File.fnmatch( ":/**/help{.rb,.txt}", ":/test/help.rb", File::FNM_EXTGLOB))
-    
+
     # test things that should only work in the CLI
     if defined?(OpenStudio::CLI) && OpenStudio::CLI
 
       no_block_glob = Dir[":/*.txt", ":/*.rb"]
       assert_instance_of(Array, no_block_glob)
       assert(no_block_glob.size > 0)
-      
+
       no_block_glob = Dir.glob(":/*.txt")
       assert_instance_of(Array, no_block_glob)
       assert(no_block_glob.size == 0)
-      
+
       no_block_glob = Dir[":/**/*.txt", ":/**/*.rb"]
       assert_instance_of(Array, no_block_glob)
       assert(no_block_glob.size > 0)
-      
+
       no_block_glob = Dir[":/{,*,*/*}.rb"]
       assert_instance_of(Array, no_block_glob)
       assert(no_block_glob.size > 0)
-      
+
       block_glob = []
       Dir[":/*.txt", ":/*.rb"].each do |p|
         block_glob << p
-      end   
+      end
       assert_instance_of(Array, block_glob)
-      assert(block_glob.size > 0)      
+      assert(block_glob.size > 0)
     end
-    
+
   ensure
     Dir.chdir(original_dir)
   end
-  
-  
+
+
   def test_file_read
     test_json = { :test_int => 10, :test_string => 'String'}
-    
+
     if File.exist?('test.json')
       FileUtils.rm('test.json')
     end
     assert(!File.exist?('test.json'))
-    
+
     File.open('test.json', 'w') do |f|
       f.puts JSON.generate(test_json)
       # make sure data is written to the disk one way or the other
@@ -133,38 +133,38 @@ class EmbeddedHelp_Test < Minitest::Test
       end
     end
     assert(File.exist?('test.json'))
-  
+
     test_json2 = JSON.parse(File.read('test.json'), symbolize_names: true)
     assert_equal(test_json2[:test_int], 10)
     assert_equal(test_json2[:test_string], 'String')
-    
+
     test_json3 = nil
     File.open('test.json', 'r') do |f|
       test_json3 = JSON.parse(f.read, symbolize_names: true)
     end
     assert_equal(test_json3[:test_int], 10)
     assert_equal(test_json3[:test_string], 'String')
-    
+
   ensure
     if File.exist?('test.json')
       FileUtils.rm('test.json')
     end
   end
-  
-  
+
+
   def test_fileutils_mv
     test_json = { :test_int => 10, :test_string => 'String'}
-    
+
     if File.exist?('mv_test.json')
       FileUtils.rm('mv_test.json')
     end
     assert(!File.exist?('mv_test.json'))
-    
+
     if File.exist?('mv_test2.json')
       FileUtils.rm('mv_test2.json')
     end
     assert(!File.exist?('mv_test2.json'))
-    
+
     File.open('mv_test.json', 'w') do |f|
       f.puts JSON.generate(test_json)
       # make sure data is written to the disk one way or the other
@@ -176,18 +176,18 @@ class EmbeddedHelp_Test < Minitest::Test
     end
     assert(File.exist?('mv_test.json'))
     assert(!File.exist?('mv_test2.json'))
-  
+
     FileUtils.mv('mv_test.json', 'mv_test2.json', force: true)
     assert(!File.exist?('mv_test.json'))
     assert(File.exist?('mv_test2.json'))
-    
+
   ensure
     if File.exist?('mv_test.json')
       FileUtils.rm('mv_test.json')
     end
     if File.exist?('mv_test2.json')
       FileUtils.rm('mv_test2.json')
-    end    
+    end
   end
-  
+
 end


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3311
 - Use `openstudio-workflow` instead of `openstudio-standards` in`CLITest-test_bundle-bundle`

**TL;DR**: **The `CLITest-test_bundle-bundle` test got skinned by 480 MB, and the test runs in half the time needed (8s versus 15s)**

## Before:

```
$ ctest -j10 -R bundle

Test project /home/julien/Software/Others/OS-build-release
    Start 2804: CLITest-test_bundle-bundle_git
    Start 2808: CLITest-test_bundle-bundle_default
    Start 2807: CLITest-test_bundle-no_bundle
    Start 2803: CLITest-test_bundle-bundle
    Start 2806: CLITest-test_bundle-bundle_no_install
    Start 2805: CLITest-test_bundle-bundle_native
1/6 Test #2805: CLITest-test_bundle-bundle_native .......   Passed    3.85 sec
2/6 Test #2806: CLITest-test_bundle-bundle_no_install ...   Passed    4.82 sec
3/6 Test #2808: CLITest-test_bundle-bundle_default ......   Passed    6.29 sec
4/6 Test #2807: CLITest-test_bundle-no_bundle ...........   Passed    6.30 sec
5/6 Test #2803: CLITest-test_bundle-bundle ..............   Passed   15.07 sec
6/6 Test #2804: CLITest-test_bundle-bundle_git ..........   Passed   15.22 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  19.56 sec
```

```
$ du -sh ./* | sort -rh
481M	./bundle
25M	./bundle_git
24K	./bundle_native
20K	./bundle_default
12K	./bundle_no_install
```

## After
```
$ ctest -j10 -R bundle
Test project /home/julien/Software/Others/OS-build-release
    Start 2804: CLITest-test_bundle-bundle_git
    Start 2803: CLITest-test_bundle-bundle
    Start 2808: CLITest-test_bundle-bundle_default
    Start 2807: CLITest-test_bundle-no_bundle
    Start 2806: CLITest-test_bundle-bundle_no_install
    Start 2805: CLITest-test_bundle-bundle_native
1/6 Test #2805: CLITest-test_bundle-bundle_native .......   Passed    3.59 sec
2/6 Test #2806: CLITest-test_bundle-bundle_no_install ...   Passed    4.83 sec
3/6 Test #2808: CLITest-test_bundle-bundle_default ......   Passed    6.16 sec
4/6 Test #2807: CLITest-test_bundle-no_bundle ...........   Passed    6.35 sec
5/6 Test #2803: CLITest-test_bundle-bundle ..............   Passed    7.97 sec
6/6 Test #2804: CLITest-test_bundle-bundle_git ..........   Passed   13.51 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  17.87 sec
```

```
$ du -sh ./* | sort -rh
25M	./bundle_git
1,1M	./bundle
24K	./bundle_native
20K	./bundle_default
12K	./bundle_no_install
```
