### PR TITLE
Allow embedded gems even with --bundle

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -53,7 +53,6 @@ module Kernel
   $LOAD_PATH << ':/ruby/2.5.0'
   $LOAD_PATH << ':/ruby/2.5.0/x86_64-darwin16'
   $LOAD_PATH << ':/ruby/2.5.0/x64-mswin64_140'
-  $LOAD_PATH << ':/ruby/2.5.0/bundler/gems/pycall.rb-3d4041b8fb9d/lib'
   # DLM: now done in embedded gem initialization section in openstudio_cli.rb
   #$LOAD_PATH << EmbeddedScripting::findFirstFileByName('openstudio-standards.rb').gsub('/openstudio-standards.rb', '')
   #$LOAD_PATH << EmbeddedScripting::findFirstFileByName('openstudio-workflow.rb').gsub('/openstudio-workflow.rb', '')
@@ -71,7 +70,7 @@ module Kernel
     'liboga' => 'init_liboga',\
     'sqlite3/sqlite3_native' => 'init_sqlite3_native',\
     'jaro_winkler_ext' => 'init_jaro_winkler_ext',\
-    'pycall.so' => 'init_pycall', \
+    'pycall.so' => 'init_pycall',\
     'pycall.dll' => 'init_pycall'
   }
 
@@ -86,10 +85,6 @@ module Kernel
   end
 
   def require path
-    if require_embedded_extension path
-      return true
-    end
-
     original_directory = Dir.pwd
     path_with_extension = path
 
@@ -126,12 +121,18 @@ module Kernel
       end
     end
 
-    result = original_require path
+    begin
+      result = original_require path
+    rescue Exception => e 
+      result = require_embedded_extension path
+      if not result
+        raise e
+      end
+    end
 
     current_directory = Dir.pwd
     if original_directory != current_directory
       Dir.chdir(original_directory)
-      puts "Directory changed from '#{original_directory}' to '#{current_directory}' while requiring '#{path}', result = #{result}, restoring original_directory"
       STDOUT.flush
     end
 

--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -85,58 +85,84 @@ module Kernel
   end
 
   def require path
+    result = false
     original_directory = Dir.pwd
     path_with_extension = path
 
-    if path.include? 'openstudio/energyplus/find_energyplus'
-      return false
-    end
-
-    # Returns the extension
-    # (the portion of file name in path starting from the last period).
-    extname = File.extname(path)
-
-    if extname.empty? or ! RUBY_FILE_EXTS.include? extname
-      path_with_extension = path + '.rb'
-    end
-
-    if path_with_extension.to_s.chars.first == ':'
-      if $LOADED.include?(path_with_extension)
-         return true
-      else
-        return require_embedded_absolute(path_with_extension)
-      end
-    elsif path_with_extension == 'openstudio.rb'
-      return true
-    else
-      $LOAD_PATH.each do |p|
-        if p.to_s.chars.first == ':'
-          embedded_path = p + '/' + path_with_extension
-          if $LOADED.include?(embedded_path)
-            return true
-          elsif EmbeddedScripting::hasFile(embedded_path)
-            return require_embedded_absolute(embedded_path)
-          end
-        end
-      end
-    end
-
     begin
-      result = original_require path
-    rescue Exception => e 
-      result = require_embedded_extension path
+      # Returns the extension
+      # (the portion of file name in path starting from the last period).
+      extname = File.extname(path)
+
+      if extname.empty? or ! RUBY_FILE_EXTS.include? extname
+        path_with_extension = path + '.rb'
+      end
+
+      if path.include? 'openstudio/energyplus/find_energyplus'
+        return false
+      elsif path_with_extension.to_s.chars.first == ':'
+        # Give absolute embedded paths first priority
+        if $LOADED.include?(path_with_extension)
+           return true
+        else
+          return require_embedded_absolute(path_with_extension)
+        end
+      elsif path_with_extension == 'openstudio.rb'
+        # OpenStudio is loaded by default and does not need to be required
+        return true
+      elsif require_embedded(path_with_extension, $LOAD_PATH)
+        # Load embedded files that are no required using full paths now
+        # This does not included the openstudio-gems set of default, baked in gems
+        # because we want to give anything provided by --bundle the first chance
+        return true
+      else
+        # This will pick up files from the normal filesystem,
+        # including things in the --bundle
+        result = original_require path
+      end
+    rescue Exception => e
+      # This picks up the embedded gems
+      # Important to do this now, so that --bundle has first chance
+      # using rescue in normal program flow, might have poor performance
+      # (it does in C++) but this is perhaps the only way
+      # $EMBEDDED_GEM_PATH is populated in openstudio_cli.rb during startup
+      result = require_embedded(path_with_extension, $EMBEDDED_GEM_PATH)
+
+      # Finally try to load any supported native extensions
+      if not result
+        result = require_embedded_extension path
+      end
+
+      # Give up. original_require will throw and so
+      # this will preserve that behavior
       if not result
         raise e
       end
-    end
-
-    current_directory = Dir.pwd
-    if original_directory != current_directory
-      Dir.chdir(original_directory)
-      STDOUT.flush
+    ensure
+      current_directory = Dir.pwd
+      if original_directory != current_directory
+        Dir.chdir(original_directory)
+        STDOUT.flush
+      end
     end
 
     return result
+  end
+
+  def require_embedded(path, search_paths)
+    search_paths = [] if not search_paths
+    search_paths.each do |p|
+      if p.to_s.chars.first == ':'
+        embedded_path = p + '/' + path
+        if $LOADED.include?(embedded_path)
+          return true
+        elsif EmbeddedScripting::hasFile(embedded_path)
+          require_embedded_absolute(embedded_path)
+          return true
+        end
+      end
+    end
+    return false
   end
 
   def require_embedded_absolute path
@@ -144,9 +170,7 @@ module Kernel
 
     $LOADED << path
     s = EmbeddedScripting::getFileAsString(path)
-
     s = OpenStudio::preprocess_ruby_script(s)
-
     result = Kernel::eval(s,BINDING,path)
 
     current_directory = Dir.pwd


### PR DESCRIPTION
This is significant @tijcolem @nllong @brianlball

Previously, when --bundle is used then even the baked in libraries from openstudio-gems are made unavailable, with this change the baked in openstudio-gems (even native ones like pycall) are still available. Anything defined in --bundle will override the baked in stuff. So for instance it is possible to define a bundle with a custom version of the OpenStudio standards gem and that version of standards will be used instead of the baked in version.

close #3957
close #3933

Also, minor fix to annoying messages shown when NOT using --bundle...
"Ignoring jaro_winkler-1.5.4 because its extensions are not built. Try: gem pristine jaro_winkler --version 1.5.4"
This is not true as jaro_winkler is actually still available from the embedded system. The message has been silenced.

OpenStudio Server might want to change the policy of defining a bundle with all of the openstudio-gems and instead define a bundle such as openstudio-server-gems which may only define what server wants to override or add. That said I think Server can keep doing what it is doing and things will "just work".

This should specifically address @brianlball's issue about not being able to access pycall when using the --bundle option. 

