### PR TITLE
Bump to conan fmt/6.2.0, and use the recipe option to define FMT_HEADER_ONLY

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -38,6 +38,8 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   # set(BOOST_VERSION "1.71.0")
 
   list(APPEND CONAN_OPTIONS "zlib:minizip=True")
+  list(APPEND CONAN_OPTIONS "fmt:header_only=True")
+
   # You do want to rebuild packages if there's a newer recipe in the remote (which applies mostly to our own openstudio_ruby where we don't
   # bump the actual package version when we make changes) than the binaries were built with
   # 'outdated' also acts like 'missing': if no binary, will build them.
@@ -73,7 +75,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     pugixml/1.10@bincrafters/stable
     jsoncpp/1.9.2
     zlib/1.2.11@nrel/testing # TODO: Temp, pending merging of https://github.com/conan-io/conan-center-index/pull/1526, to resolve #3961
-    fmt/6.0.0
+    fmt/6.2.0
     sqlite3/3.30.1
     cpprestsdk/2.10.14@bincrafters/stable
     websocketpp/0.8.1@bincrafters/stable

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -38,7 +38,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   # set(BOOST_VERSION "1.71.0")
 
   list(APPEND CONAN_OPTIONS "zlib:minizip=True")
-  list(APPEND CONAN_OPTIONS "fmt:header_only=True")
+  # TODO:  list(APPEND CONAN_OPTIONS "fmt:header_only=True")
 
   # You do want to rebuild packages if there's a newer recipe in the remote (which applies mostly to our own openstudio_ruby where we don't
   # bump the actual package version when we make changes) than the binaries were built with

--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleFixedInterval.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleFixedInterval.cpp
@@ -47,7 +47,6 @@
 #include <utilities/idd/IddEnums.hxx>
 #include <utilities/idd/IddFactory.hxx>
 
-#define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <fmt/printf.h>
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleVariableInterval.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleVariableInterval.cpp
@@ -42,8 +42,6 @@
 #include <utilities/idd/IddEnums.hxx>
 #include <utilities/idd/IddFactory.hxx>
 
-
-#define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <fmt/printf.h>
 

--- a/src/utilities/filetypes/EpwFile.cpp
+++ b/src/utilities/filetypes/EpwFile.cpp
@@ -35,8 +35,6 @@
 #include "../core/StringHelpers.hpp"
 #include "../core/Assert.hpp"
 
-#define FMT_HEADER_ONLY
-
 #include <fmt/format.h>
 
 namespace openstudio{


### PR DESCRIPTION
Pull request overview
---------------------

Bump to conan fmt/6.2.0, and use the recipe option to define FMT_HEADER_ONLY instead of doing it in all files.

@lefticus You added conan fmt to these files when replacing QString, so a quick look from you would make sense please.

If we do want to use `FMT_HEADER_ONLY` (perhaps we don't), then we should use this option to the conan recipe.

https://github.com/conan-io/conan-center-index/blob/f65f7e668d39431a2d1330b49646f648220fcb04/recipes/fmt/all/conanfile.py#L87-L88
