### PR TITLE
#3972 - ScheduleRuleset remove winterDD/summerDD/holiday ScheduleDay in reset

### DIFF
--- a/src/model/ScheduleRuleset.cpp
+++ b/src/model/ScheduleRuleset.cpp
@@ -308,9 +308,9 @@ namespace detail {
       }
     }
 
-    if (!this->isSummerDesignDayScheduleDefaulted()){
-      ScheduleDay summerDesignDaySchedule = this->summerDesignDaySchedule();
-      summerDesignDaySchedule.remove();
+    boost::optional<ScheduleDay> existingSummerDDSchedule;
+    if (!this->isSummerDesignDayScheduleDefaulted()) {
+      existingSummerDDSchedule = this->summerDesignDaySchedule();
     }
     ModelObject clone = schedule.clone();
     bool result = setPointer(OS_Schedule_RulesetFields::SummerDesignDayScheduleName, clone.handle());
@@ -319,17 +319,23 @@ namespace detail {
       result = summerDesignDaySchedule().setScheduleTypeLimits(*limits);
       OS_ASSERT(result);
     }
+    if (existingSummerDDSchedule) {
+      existingSummerDDSchedule->remove();
+    }
     return result;
   }
 
   void ScheduleRuleset_Impl::resetSummerDesignDaySchedule()
   {
-    if (!this->isSummerDesignDayScheduleDefaulted()){
-      ScheduleDay summerDesignDaySchedule = this->summerDesignDaySchedule();
-      summerDesignDaySchedule.remove();
+    boost::optional<ScheduleDay> existingSummerDDSchedule;
+    if (!this->isSummerDesignDayScheduleDefaulted()) {
+      existingSummerDDSchedule = this->summerDesignDaySchedule();
     }
     bool test = this->setString(OS_Schedule_RulesetFields::SummerDesignDayScheduleName, "");
     OS_ASSERT(test);
+    if (existingSummerDDSchedule) {
+      existingSummerDDSchedule->remove();
+    }
   }
 
   bool ScheduleRuleset_Impl::setWinterDesignDaySchedule(const ScheduleDay& schedule)
@@ -345,9 +351,9 @@ namespace detail {
       }
     }
 
-    if (!this->isWinterDesignDayScheduleDefaulted()){
-      ScheduleDay winterDesignDaySchedule = this->winterDesignDaySchedule();
-      winterDesignDaySchedule.remove();
+    boost::optional<ScheduleDay> existingWinterDDSchedule;
+    if (!this->isWinterDesignDayScheduleDefaulted()) {
+      ScheduleDay existingWinterDDSchedule = this->winterDesignDaySchedule();
     }
     ModelObject clone = schedule.clone();
     bool result = setPointer(OS_Schedule_RulesetFields::WinterDesignDayScheduleName, clone.handle());
@@ -356,17 +362,23 @@ namespace detail {
       result = winterDesignDaySchedule().setScheduleTypeLimits(*limits);
       OS_ASSERT(result);
     }
+    if (existingWinterDDSchedule) {
+      existingWinterDDSchedule->remove();
+    }
     return result;
   }
 
   void ScheduleRuleset_Impl::resetWinterDesignDaySchedule()
   {
-    if (!this->isWinterDesignDayScheduleDefaulted()){
-      ScheduleDay winterDesignDaySchedule = this->winterDesignDaySchedule();
-      winterDesignDaySchedule.remove();
+    boost::optional<ScheduleDay> existingWinterDDSchedule;
+    if (!this->isWinterDesignDayScheduleDefaulted()) {
+      existingWinterDDSchedule = this->winterDesignDaySchedule();
     }
     bool test = this->setString(OS_Schedule_RulesetFields::WinterDesignDayScheduleName, "");
     OS_ASSERT(test);
+    if (existingWinterDDSchedule) {
+      existingWinterDDSchedule->remove();
+    }
   }
 
   bool ScheduleRuleset_Impl::setHolidaySchedule(const ScheduleDay& schedule)
@@ -382,9 +394,9 @@ namespace detail {
       }
     }
 
-    if (!this->isHolidayScheduleDefaulted()){
-      ScheduleDay holidaySchedule = this->holidaySchedule();
-      holidaySchedule.remove();
+    boost::optional<ScheduleDay> existingHolidaySchedule;
+    if (!this->isHolidayScheduleDefaulted()) {
+      existingHolidaySchedule = this->holidaySchedule();
     }
     ModelObject clone = schedule.clone();
     bool result = setPointer(OS_Schedule_RulesetFields::HolidayScheduleName, clone.handle());
@@ -393,17 +405,23 @@ namespace detail {
       result = holidaySchedule().setScheduleTypeLimits(*limits);
       OS_ASSERT(result);
     }
+    if (existingHolidaySchedule) {
+      existingHolidaySchedule->remove();
+    }
     return result;
   }
 
   void ScheduleRuleset_Impl::resetHolidaySchedule()
   {
-    if (!this->isHolidayScheduleDefaulted()){
-      ScheduleDay holidaySchedule = this->holidaySchedule();
-      holidaySchedule.remove();
+    boost::optional<ScheduleDay> existingHolidaySchedule;
+    if (!this->isHolidayScheduleDefaulted()) {
+      existingHolidaySchedule = this->holidaySchedule();
     }
     bool test = this->setString(OS_Schedule_RulesetFields::HolidayScheduleName, "");
     OS_ASSERT(test);
+    if (existingHolidaySchedule) {
+      existingHolidaySchedule->remove();
+    }
   }
 
   struct ScheduleRuleIndexCompare {

--- a/src/model/test/ScheduleRuleset_GTest.cpp
+++ b/src/model/test/ScheduleRuleset_GTest.cpp
@@ -846,6 +846,65 @@ TEST_F(ModelFixture, ScheduleRuleset_SpecialDays)
   EXPECT_FALSE(summerSchedule.handle().isNull());
 }
 
+TEST_F(ModelFixture, ScheduleRuleset_resetSpecialDays)
+{
+  Model model;
+  ScheduleTypeLimits typeLimits(model);
+
+  ScheduleRuleset schedule(model);
+  schedule.setName("Always_On");
+  EXPECT_EQ("Always_On", schedule.name().get());
+  schedule.setScheduleTypeLimits(typeLimits);
+
+  EXPECT_EQ(1u, model.getConcreteModelObjects<ScheduleDay>().size());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.holidaySchedule().handle());
+
+  // For each of these, the setter clones the original schedule
+  ScheduleDay winterSchedule(model);
+  ScheduleDay summerSchedule(model);
+  ScheduleDay holidaySchedule(model);
+  EXPECT_EQ(4u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  schedule.setWinterDesignDaySchedule(winterSchedule);
+  EXPECT_EQ(5u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  schedule.setSummerDesignDaySchedule(summerSchedule);
+  EXPECT_EQ(6u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  schedule.setHolidaySchedule(holidaySchedule);
+  // DefaultDay, the 3 schedules we created, and the 3 clones made by setters = 7
+  EXPECT_EQ(7u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  EXPECT_NE(winterSchedule.handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_NE(summerSchedule.handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_NE(holidaySchedule.handle(), schedule.holidaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.holidaySchedule().handle());
+
+
+  // reset should delete the special clone it made when setting
+  schedule.resetWinterDesignDaySchedule();
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.holidaySchedule().handle());
+  EXPECT_EQ(6u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  schedule.resetSummerDesignDaySchedule();
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_NE(schedule.defaultDaySchedule().handle(), schedule.holidaySchedule().handle());
+  EXPECT_EQ(5u, model.getConcreteModelObjects<ScheduleDay>().size());
+
+  schedule.resetHolidaySchedule();
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.winterDesignDaySchedule().handle());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.summerDesignDaySchedule().handle());
+  EXPECT_EQ(schedule.defaultDaySchedule().handle(), schedule.holidaySchedule().handle());
+  EXPECT_EQ(4u, model.getConcreteModelObjects<ScheduleDay>().size());
+}
+
 /*
 January
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3972
 - ScheduleRuleset remove winterDD/summerDD/holiday ScheduleDay in reset

`ScheduleRuleset::setSummerDesignDaySchedule(ScheduleDay&)` will make a copy of the `ScheduleDay` passed for itself. 

`ScheduleRuleset::resetSummerDesignDaySchedule` clearly means to remove that copy, except it calls `ScheduleDay::remove()` before it clears the field, and that guy will check if the ScheduleDay is used by a parent before remove, so it doesn't remove it.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
