### PR TITLE
Fix #2033 - Properly connected the secondary/induced air node for ATUs

### DIFF
--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -33,6 +33,10 @@
 #include "AirLoopHVACSupplyPlenum_Impl.hpp"
 #include "AirTerminalSingleDuctParallelPIUReheat.hpp"
 #include "AirTerminalSingleDuctParallelPIUReheat_Impl.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat.hpp"
+#include "AirTerminalSingleDuctSeriesPIUReheat_Impl.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction.hpp"
+#include "AirTerminalSingleDuctConstantVolumeFourPipeInduction_Impl.hpp"
 #include "AirLoopHVACReturnPlenum.hpp"
 #include "AirLoopHVACReturnPlenum_Impl.hpp"
 #include "ZoneHVACEquipmentList.hpp"
@@ -2121,6 +2125,38 @@ namespace detail {
                               secondaryInletNode.outletPort(),
                               terminal.get(),
                               terminal->secondaryAirInletPort() );
+            }
+            else if( boost::optional<AirTerminalSingleDuctSeriesPIUReheat> terminal = inletObj->optionalCast<AirTerminalSingleDuctSeriesPIUReheat>() )
+            {
+              Node secondaryInletNode(_model);
+
+              PortList t_exhaustPortList = exhaustPortList();
+
+              _model.connect( t_exhaustPortList,
+                              t_exhaustPortList.nextPort(),
+                              secondaryInletNode,
+                              secondaryInletNode.inletPort() );
+
+              _model.connect( secondaryInletNode,
+                              secondaryInletNode.outletPort(),
+                              terminal.get(),
+                              terminal->secondaryAirInletPort() );
+            }
+            else if( boost::optional<AirTerminalSingleDuctConstantVolumeFourPipeInduction> terminal = inletObj->optionalCast<AirTerminalSingleDuctConstantVolumeFourPipeInduction>() )
+            {
+              Node inducedAirInletNode(_model);
+
+              PortList t_exhaustPortList = exhaustPortList();
+
+              _model.connect( t_exhaustPortList,
+                              t_exhaustPortList.nextPort(),
+                              inducedAirInletNode,
+                              inducedAirInletNode.inletPort() );
+
+              _model.connect( inducedAirInletNode,
+                              inducedAirInletNode.outletPort(),
+                              terminal.get(),
+                              terminal->inducedAirInletPort() );
             }
           }
 

--- a/src/model/test/AirTerminalSingleDuctConstantVolumeFourPipeInduction_GTest.cpp
+++ b/src/model/test/AirTerminalSingleDuctConstantVolumeFourPipeInduction_GTest.cpp
@@ -171,3 +171,70 @@ TEST_F(ModelFixture, AirTerminalSingleDuctConstantVolumeFourPipeInduction_clone)
   EXPECT_NE(testObjectClone2.heatingCoil(),testObject.heatingCoil());
   EXPECT_NE(testObjectClone2.coolingCoil().get(),testObject.coolingCoil().get());
 }
+
+TEST_F(ModelFixture,AirTerminalSingleDuctConstantVolumeFourPipeInduction_connectSecondaryAirInlet_regularCase_2033) {
+
+  // Test for #2033
+  // Base case: works fine
+  Model m;
+  Schedule s = m.alwaysOnDiscreteSchedule();
+  CoilHeatingWater heatingCoil(m,s);
+  AirTerminalSingleDuctConstantVolumeFourPipeInduction atu(m,heatingCoil);
+
+  ThermalZone zone(m);
+  AirLoopHVAC airLoopHVAC(m);
+
+  EXPECT_FALSE(atu.inducedAirInletNode());
+  EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+  // Connect simulateanously the branch and atu
+  EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone,atu));
+
+  ASSERT_TRUE(atu.inducedAirInletNode());
+  ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+  EXPECT_EQ(atu.inducedAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+}
+
+TEST_F(ModelFixture,AirTerminalSingleDuctConstantVolumeFourPipeInduction_connectSecondaryAirInlet_atuFirst_2033) {
+
+  // Test for #2033: When you connect the atu first, then add a zone it should work as well.
+  Model m;
+  Schedule s = m.alwaysOnDiscreteSchedule();
+  CoilHeatingWater heatingCoil(m,s);
+  AirTerminalSingleDuctConstantVolumeFourPipeInduction atu(m,heatingCoil);
+  AirLoopHVAC airLoopHVAC(m);
+
+  // Connect atu only first
+  airLoopHVAC.addBranchForHVACComponent(atu);
+  EXPECT_FALSE(atu.inducedAirInletNode());
+
+  // First zone: this is the problematic case
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+    ASSERT_TRUE(atu.inducedAirInletNode());   // <===== Actual test is here
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(atu.inducedAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+
+  // Should work for any zone added after that too
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+
+    // Get the cloned ATU
+    ASSERT_EQ(1u, zone.equipment().size());
+    auto _atu = zone.equipment()[0].optionalCast<AirTerminalSingleDuctConstantVolumeFourPipeInduction>();
+    ASSERT_TRUE(_atu);
+
+    ASSERT_TRUE(_atu->inducedAirInletNode());
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(_atu->inducedAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+}

--- a/src/model/test/AirTerminalSingleDuctParallelPIUReheat_GTest.cpp
+++ b/src/model/test/AirTerminalSingleDuctParallelPIUReheat_GTest.cpp
@@ -168,3 +168,73 @@ TEST_F(ModelFixture,AirTerminalSingleDuctParallelPIUReheat) {
     EXPECT_FALSE(zoneImpl->exhaustPortList().lastModelObject());
   }
 }
+
+TEST_F(ModelFixture,AirTerminalSingleDuctParallelPIUReheat_connectSecondaryAirInlet_regularCase_2033) {
+
+  // Test for #2033
+  // Base case: works fine
+  Model m;
+  Schedule schedule = m.alwaysOnDiscreteSchedule();
+  FanConstantVolume fan(m,schedule);
+  CoilHeatingElectric coil(m,schedule);
+  AirTerminalSingleDuctParallelPIUReheat atu(m,schedule,fan,coil);
+
+  ThermalZone zone(m);
+  AirLoopHVAC airLoopHVAC(m);
+
+  EXPECT_FALSE(atu.secondaryAirInletNode());
+  EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+  // Connect simulateanously the branch and atu
+  EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone,atu));
+
+  ASSERT_TRUE(atu.secondaryAirInletNode());
+  ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+  EXPECT_EQ(atu.secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+}
+
+TEST_F(ModelFixture,AirTerminalSingleDuctParallelPIUReheat_connectSecondaryAirInlet_atuFirst_2033) {
+
+  // Test for #2033: When you connect the atu first, then add a zone it should work as well.
+  Model m;
+  Schedule schedule = m.alwaysOnDiscreteSchedule();
+  FanConstantVolume fan(m,schedule);
+  CoilHeatingElectric coil(m,schedule);
+  AirTerminalSingleDuctParallelPIUReheat atu(m,schedule,fan,coil);
+
+  AirLoopHVAC airLoopHVAC(m);
+
+  // Connect atu only first
+  airLoopHVAC.addBranchForHVACComponent(atu);
+  EXPECT_FALSE(atu.secondaryAirInletNode());
+
+  // First zone: this is the problematic case
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+    ASSERT_TRUE(atu.secondaryAirInletNode());   // <===== Actual test is here
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(atu.secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+
+  // Should work for any zone added after that too
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+
+    // Get the cloned ATU
+    ASSERT_EQ(1u, zone.equipment().size());
+    auto _atu = zone.equipment()[0].optionalCast<AirTerminalSingleDuctParallelPIUReheat>();
+    ASSERT_TRUE(_atu);
+
+    ASSERT_TRUE(_atu->secondaryAirInletNode());
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(_atu->secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+}

--- a/src/model/test/AirTerminalSingleDuctSeriesPIUReheat_GTest.cpp
+++ b/src/model/test/AirTerminalSingleDuctSeriesPIUReheat_GTest.cpp
@@ -171,3 +171,72 @@ TEST_F(ModelFixture,AirTerminalSingleDuctSeriesPIUReheat)
   }
 }
 
+TEST_F(ModelFixture,AirTerminalSingleDuctSeriesPIUReheat_connectSecondaryAirInlet_regularCase_2033) {
+
+  // Test for #2033
+  // Base case: works fine
+  Model m;
+  Schedule schedule = m.alwaysOnDiscreteSchedule();
+  FanConstantVolume fan(m,schedule);
+  CoilHeatingElectric coil(m,schedule);
+  AirTerminalSingleDuctSeriesPIUReheat atu(m,fan,coil);
+
+  ThermalZone zone(m);
+  AirLoopHVAC airLoopHVAC(m);
+
+  EXPECT_FALSE(atu.secondaryAirInletNode());
+  EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+  // Connect simulateanously the branch and atu
+  EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone,atu));
+
+  ASSERT_TRUE(atu.secondaryAirInletNode());
+  ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+  EXPECT_EQ(atu.secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+}
+
+TEST_F(ModelFixture,AirTerminalSingleDuctSeriesPIUReheat_connectSecondaryAirInlet_atuFirst_2033) {
+
+  // Test for #2033: When you connect the atu first, then add a zone it should work as well.
+  Model m;
+  Schedule schedule = m.alwaysOnDiscreteSchedule();
+  FanConstantVolume fan(m,schedule);
+  CoilHeatingElectric coil(m,schedule);
+  AirTerminalSingleDuctSeriesPIUReheat atu(m,fan,coil);
+
+  AirLoopHVAC airLoopHVAC(m);
+
+  // Connect atu only first
+  airLoopHVAC.addBranchForHVACComponent(atu);
+  EXPECT_FALSE(atu.secondaryAirInletNode());
+
+  // First zone: this is the problematic case
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+    ASSERT_TRUE(atu.secondaryAirInletNode());   // <===== Actual test is here
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(atu.secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+
+  // Should work for any zone added after that too
+  {
+    ThermalZone zone(m);
+    EXPECT_FALSE(zone.exhaustPortList().lastModelObject());
+
+    // Now add zone (this was the problematic case)
+    EXPECT_TRUE(airLoopHVAC.addBranchForZone(zone));
+
+    // Get the cloned ATU
+    ASSERT_EQ(1u, zone.equipment().size());
+    auto _atu = zone.equipment()[0].optionalCast<AirTerminalSingleDuctSeriesPIUReheat>();
+    ASSERT_TRUE(_atu);
+
+    ASSERT_TRUE(_atu->secondaryAirInletNode());
+    ASSERT_TRUE(zone.exhaustPortList().lastModelObject());
+    EXPECT_EQ(_atu->secondaryAirInletNode().get(), zone.exhaustPortList().lastModelObject().get());
+  }
+}


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #2033
 - Properly connected the secondary/induced air node for ATUs

Three terminals are concerned:

* `AirTerminalSingleParallePIUReheat`: this one already works because of a special case that's existing in `ThermalZone::addToNode` (cf review comment below)

* `AirTerminalSingleDuctSeriesPIUReheat`
* `AirTerminalSingleDuctConstantVolumeFourPipeInduction`

Though #2033 mentioned a way of avoid duplicate code, which is to disconnect the ATU first, I just fixed it following the pattern for `AirTerminalSingleParallePIUReheat`



### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
