### PR TITLE
Fix #2977 - Make VAVReheat Method consistent with IDD and other objects

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVNoReheat.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVNoReheat.cpp
@@ -159,7 +159,7 @@ boost::optional<IdfObject> ForwardTranslator::translateAirTerminalSingleDuctVAVN
     idfObject.setString(AirTerminal_SingleDuct_VAV_NoReheatFields::MaximumAirFlowRate,"Autosize");
   }
 
-  // ZoneMinimumAirFlowMethod
+  // ZoneMinimumAirFlowInputMethod
   s = modelObject.zoneMinimumAirFlowInputMethod();
   if( s )
   {

--- a/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVReheat.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateAirTerminalSingleDuctVAVReheat.cpp
@@ -161,8 +161,8 @@ boost::optional<IdfObject> ForwardTranslator::translateAirTerminalSingleDuctVAVR
     idfObject.setString(AirTerminal_SingleDuct_VAV_ReheatFields::MaximumAirFlowRate,"Autosize");
   }
 
-  // ZoneMinimumAirFlowMethod
-  s = modelObject.zoneMinimumAirFlowMethod();
+  // ZoneMinimumAirFlowInputMethod
+  s = modelObject.zoneMinimumAirFlowInputMethod();
   if( s )
   {
     idfObject.setString(AirTerminal_SingleDuct_VAV_ReheatFields::ZoneMinimumAirFlowInputMethod,s.get());

--- a/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVReheat.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateAirTerminalSingleDuctVAVReheat.cpp
@@ -119,7 +119,7 @@ OptionalModelObject ReverseTranslator::translateAirTerminalSingleDuctVAVReheat( 
     s = workspaceObject.getString(AirTerminal_SingleDuct_VAV_ReheatFields::ZoneMinimumAirFlowInputMethod);
     if( s )
     {
-      airTerminal->setZoneMinimumAirFlowMethod(s.get());
+      airTerminal->setZoneMinimumAirFlowInputMethod(s.get());
     }
 
     // ConstantMinimumAirFlowFraction

--- a/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -335,12 +335,12 @@ namespace detail{
     return false;
   }
 
-  std::string AirTerminalSingleDuctVAVReheat_Impl::zoneMinimumAirFlowMethod()
+  std::string AirTerminalSingleDuctVAVReheat_Impl::zoneMinimumAirFlowInputMethod()
   {
     return this->getString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::ZoneMinimumAirFlowInputMethod).get();
   }
 
-  bool AirTerminalSingleDuctVAVReheat_Impl::setZoneMinimumAirFlowMethod( std::string value )
+  bool AirTerminalSingleDuctVAVReheat_Impl::setZoneMinimumAirFlowInputMethod(const std::string& value)
   {
     if( istringEqual(value,"Constant") )
     {
@@ -483,7 +483,7 @@ namespace detail{
     return this->getString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::DamperHeatingAction).get();
   }
 
-  bool AirTerminalSingleDuctVAVReheat_Impl::setDamperHeatingAction( std::string value )
+  bool AirTerminalSingleDuctVAVReheat_Impl::setDamperHeatingAction(const std::string& value)
   {
     return setString(OS_AirTerminal_SingleDuct_VAV_ReheatFields::DamperHeatingAction,value);;
   }
@@ -798,7 +798,7 @@ AirTerminalSingleDuctVAVReheat::AirTerminalSingleDuctVAVReheat( const Model& mod
 
   autosizeMaximumAirFlowRate();
 
-  setZoneMinimumAirFlowMethod("Constant");
+  setZoneMinimumAirFlowInputMethod("Constant");
 
   setConstantMinimumAirFlowFraction(0.3);
 
@@ -861,14 +861,26 @@ bool AirTerminalSingleDuctVAVReheat::isMaximumAirFlowRateAutosized() const
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->isMaximumAirFlowRateAutosized();
 }
 
-std::string AirTerminalSingleDuctVAVReheat::zoneMinimumAirFlowMethod()
+std::string AirTerminalSingleDuctVAVReheat::zoneMinimumAirFlowInputMethod()
 {
-  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->zoneMinimumAirFlowMethod();
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->zoneMinimumAirFlowInputMethod();
 }
 
-bool AirTerminalSingleDuctVAVReheat::setZoneMinimumAirFlowMethod( std::string value )
+std::string AirTerminalSingleDuctVAVReheat::zoneMinimumAirFlowMethod()
 {
-  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setZoneMinimumAirFlowMethod(value);
+  LOG(Warn,"zoneMinimumAirFlowMethod is deprecated, please use zoneMinimumAirFlowInputMethod");
+  return zoneMinimumAirFlowInputMethod();
+}
+
+bool AirTerminalSingleDuctVAVReheat::setZoneMinimumAirFlowInputMethod(const std::string& value )
+{
+  return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setZoneMinimumAirFlowInputMethod(value);
+}
+
+bool AirTerminalSingleDuctVAVReheat::setZoneMinimumAirFlowMethod(const std::string& value )
+{
+  LOG(Warn,"setZoneMinimumAirFlowMethod is deprecated, please use setZoneMinimumAirFlowInputMethod");
+  return setZoneMinimumAirFlowInputMethod(value);
 }
 
 boost::optional<double> AirTerminalSingleDuctVAVReheat::constantMinimumAirFlowFraction() const
@@ -968,7 +980,7 @@ std::string AirTerminalSingleDuctVAVReheat::damperHeatingAction()
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->damperHeatingAction();
 }
 
-bool AirTerminalSingleDuctVAVReheat::setDamperHeatingAction( std::string value )
+bool AirTerminalSingleDuctVAVReheat::setDamperHeatingAction(const std::string& value)
 {
   return getImpl<detail::AirTerminalSingleDuctVAVReheat_Impl>()->setDamperHeatingAction(value);
 }

--- a/src/model/AirTerminalSingleDuctVAVReheat.hpp
+++ b/src/model/AirTerminalSingleDuctVAVReheat.hpp
@@ -34,6 +34,7 @@
 #include "StraightComponent.hpp"
 #include "Connection.hpp"
 #include "ModelAPI.hpp"
+#include "../utilities/core/Deprecated.hpp"
 
 namespace openstudio {
 
@@ -84,12 +85,17 @@ class MODEL_API AirTerminalSingleDuctVAVReheat : public StraightComponent {
   bool isMaximumAirFlowRateAutosized() const;
 
   /** Returns the value of the MaximumAirFlowRate field. */
-  std::string zoneMinimumAirFlowMethod();
+  std::string zoneMinimumAirFlowInputMethod();
+  /** deprecated **/
+  OS_DEPRECATED std::string zoneMinimumAirFlowMethod();
 
   /** Sets the value of the MaximumAirFlowRate field.
    *  Options are FixedFlowRate and Scheduled.
    */
-  bool setZoneMinimumAirFlowMethod( std::string value );
+  bool setZoneMinimumAirFlowInputMethod(const std::string& value );
+  /** deprecated **/
+  OS_DEPRECATED bool setZoneMinimumAirFlowMethod(const std::string& value );
+
 
   /** Returns the value of the ConstantMinimumAirFlowFraction field. */
   boost::optional<double> constantMinimumAirFlowFraction() const;
@@ -154,7 +160,7 @@ class MODEL_API AirTerminalSingleDuctVAVReheat : public StraightComponent {
   /** Sets the value of the DamperHeatingAction field.
    *  Options are Normal and Reverse.
    */
-  bool setDamperHeatingAction( std::string value );
+  bool setDamperHeatingAction(const std::string& value);
 
   /** Returns the value of the MaximumFlowPerZoneFloorAreaDuringReheat field. */
   boost::optional<double> maximumFlowPerZoneFloorAreaDuringReheat();

--- a/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
+++ b/src/model/AirTerminalSingleDuctVAVReheat_Impl.hpp
@@ -97,9 +97,9 @@ namespace detail {
 
     bool isMaximumAirFlowRateAutosized() const;
 
-    std::string zoneMinimumAirFlowMethod();
+    std::string zoneMinimumAirFlowInputMethod();
 
-    bool setZoneMinimumAirFlowMethod( std::string value );
+    bool setZoneMinimumAirFlowInputMethod(const std::string& value );
 
     boost::optional<double> constantMinimumAirFlowFraction() const;
     bool isConstantMinimumAirFlowFractionAutosized() const;
@@ -135,7 +135,7 @@ namespace detail {
 
     std::string damperHeatingAction();
 
-    bool setDamperHeatingAction( std::string value );
+    bool setDamperHeatingAction(const std::string& value);
 
     boost::optional<double> maximumFlowPerZoneFloorAreaDuringReheat();
 

--- a/src/sdd/MapHVAC.cpp
+++ b/src/sdd/MapHVAC.cpp
@@ -4990,17 +4990,17 @@ boost::optional<model::ModelObject> ReverseTranslator::translateTrmlUnit(const p
     pugi::xml_node minAirFracSchRefElement = trmlUnitElement.child("MinAirFracSchRef");
     if( boost::optional<model::Schedule> minAirFracSch = model.getModelObjectByName<model::Schedule>(minAirFracSchRefElement.text().as_string()) )
     {
-      terminal.setZoneMinimumAirFlowMethod("Scheduled");
+      terminal.setZoneMinimumAirFlowInputMethod("Scheduled");
       terminal.setMinimumAirFlowFractionSchedule(minAirFracSch.get());
     }
     else if( primaryAirFlowMin )
     {
-      terminal.setZoneMinimumAirFlowMethod("FixedFlowRate");
+      terminal.setZoneMinimumAirFlowInputMethod("FixedFlowRate");
       terminal.setFixedMinimumAirFlowRate(primaryAirFlowMin.get());
     }
     else
     {
-      terminal.setZoneMinimumAirFlowMethod("Constant");
+      terminal.setZoneMinimumAirFlowInputMethod("Constant");
       terminal.setConstantMinimumAirFlowFraction(0.2);
     }
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #2977 - Make VAVReheat Method consistent with IDD and other objects
- To avoid breaking API, keeping the old name but marking as OS_DEPRECATED
- Updated entire codebase to use the new name and avoid triggering deprecation warnings.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
