### PR TITLE
Fix #1058 - remove warning when loading DDY file

### DIFF
--- a/src/utilities/idf/IdfFile.cpp
+++ b/src/utilities/idf/IdfFile.cpp
@@ -380,26 +380,28 @@ OptionalIdfFile IdfFile::load(const path& p,
   // complete path
   path wp(p);
 
-  if (iddFileType == IddFileType::OpenStudio) {
+  std::string ext = getFileExtension(p);
 
+  if (iddFileType == IddFileType::OpenStudio) {
     // can be Model or Component
-    std::string ext = getFileExtension(p);
     if (! ( openstudio::istringEqual(ext, "osm") ||
             openstudio::istringEqual(ext, "osc")) ) {
       LOG_FREE(Warn,"openstudio.setFileExtension","Path p, '" << toString(p)
                  << "', has an unexpected file extension. Was expecting 'osm' or 'osc'.");
     }
-
-    // This isn't issuing warnings because we pass false (we have to, since it can be either osm or osc)
-    // hence why we do check above
-    wp = completePathToFile(wp,path(),modelFileExtension(),false);
-    if (wp.empty()) {
-      wp = completePathToFile(wp,path(),componentFileExtension(),false);
+  } else {
+    std::string ext = getFileExtension(p);
+    if (! ( openstudio::istringEqual(ext, "idf") ||
+            openstudio::istringEqual(ext, "imf") ||
+            openstudio::istringEqual(ext, "ddy")) ) {
+      LOG_FREE(Warn,"openstudio.setFileExtension","Path p, '" << toString(p)
+                 << "', has an unexpected file extension. Was expecting 'idf', 'ddy', or 'imf'.");
     }
   }
-  else {
-    wp = completePathToFile(wp,path(),"idf",true);
-  }
+
+  // pass warnOnMisMatch as false since we warn above anyways
+  // In fact, don't pass the ext param, skip the entire call to setFileExtension which is pointless since it won't force replace it
+  wp = completePathToFile(wp,path(),"",false);
 
   // try to open file and parse
   openstudio::filesystem::ifstream inFile(wp);


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #1058 
 - warn only if the file extension isn't OSM, OSC, IDF, IMF, or DDY

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
