### PR TITLE
Implement `eql?` and `hash` for UUID in Ruby so UUID can be used as a key in a Ruby Hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ test_gems
 test_fails.txt
 # Ignore build folders (at root level only)
 /build*/
+/debug*/
+/release*/
 
 developer/msvc/Visualizers/all_concat.natvis
 .vscode/

--- a/ruby/test/UUID_Test.rb
+++ b/ruby/test/UUID_Test.rb
@@ -65,6 +65,68 @@ class UUID_Test < MiniTest::Unit::TestCase
 
     File.delete("UUIDSet.txt")
   end
+  
+  def test_uuid_hash
+    model = OpenStudio::Model::Model.new
+    space1 = OpenStudio::Model::Space.new(model)
+    space1.setName("Space 1")
+    space2 = OpenStudio::Model::Space.new(model)
+    space2.setName("Space 2")
+    
+    space1_handle1 = space1.handle
+    space1_handle2 = space1.handle
+    space2_handle1 = space2.handle
+    space2_handle2 = space2.handle
+    
+    assert(space1_handle1 == space1_handle1)
+    assert(space1_handle1 == space1_handle2)
+    assert(space1_handle1 != space2_handle1)
+    assert(space1_handle1 != space2_handle2)
+    
+    assert(space1_handle1.to_s == space1_handle1.to_s)
+    assert(space1_handle1.to_s == space1_handle2.to_s)
+    assert(space1_handle1.to_s != space2_handle1.to_s)
+    assert(space1_handle1.to_s != space2_handle2.to_s)
+    
+    assert(space1_handle1.hash == space1_handle1.hash)
+    assert(space1_handle1.hash == space1_handle2.hash)
+    assert(space1_handle1.hash != space2_handle1.hash)
+    assert(space1_handle1.hash != space2_handle2.hash)
+    
+    assert(space1_handle1.eql?(space1_handle1))
+    assert(space1_handle1.eql?(space1_handle2))
+    assert(!space1_handle1.eql?(space2_handle1))
+    assert(!space1_handle1.eql?(space2_handle2))
+    
+    assert(space1_handle1.to_s != space1_handle1)
+    assert(space1_handle1.to_s != space1_handle2)
+    assert(space1_handle1.to_s != space2_handle1)
+    assert(space1_handle1.to_s != space2_handle2)
+    
+    handle_to_space_map = {}
+    handle_to_space_map[space1_handle1] = space1
+    handle_to_space_map[space2_handle1] = space2
+    assert(handle_to_space_map[space1_handle1] == space1)
+    assert(handle_to_space_map[space1_handle2] == space1) 
+    assert(handle_to_space_map[space2_handle1] == space2)
+    assert(handle_to_space_map[space2_handle2] == space2) 
+    assert(handle_to_space_map[space1_handle1.to_s] != space1)
+    assert(handle_to_space_map[space1_handle2.to_s] != space1)
+    assert(handle_to_space_map[space2_handle1.to_s] != space2)
+    assert(handle_to_space_map[space2_handle2.to_s] != space2)
+    
+    handle_str_to_space_map = {}
+    handle_str_to_space_map[space1_handle1.to_s] = space1
+    handle_str_to_space_map[space2_handle1.to_s] = space2
+    assert(handle_str_to_space_map[space1_handle1.to_s] == space1)
+    assert(handle_str_to_space_map[space1_handle2.to_s] == space1)
+    assert(handle_str_to_space_map[space2_handle1.to_s] == space2)
+    assert(handle_str_to_space_map[space2_handle2.to_s] == space2)
+    assert(handle_str_to_space_map[space1_handle1] != space1)
+    assert(handle_str_to_space_map[space1_handle2] != space1)
+    assert(handle_str_to_space_map[space2_handle1] != space2)
+    assert(handle_str_to_space_map[space2_handle2] != space2)
+  end
 
 end
 

--- a/src/utilities/core/UUID.hpp
+++ b/src/utilities/core/UUID.hpp
@@ -74,6 +74,10 @@ namespace openstudio {
       return is_nil();
     }
 
+    bool isEqual(const UUID& other) const {
+      return (*this == other);
+    }
+
     using boost::uuids::uuid::iterator;
     using boost::uuids::uuid::const_iterator;
     using boost::uuids::uuid::begin;

--- a/src/utilities/core/UUID.i
+++ b/src/utilities/core/UUID.i
@@ -7,17 +7,21 @@
 
 %{
   #include <utilities/core/UUID.hpp>
+  #include <functional>
 %}
 
 namespace openstudio{
 
   #ifdef SWIGRUBY
     %rename("nil?") isNull();
+
+    %alias UUID::isEqual "eql?";
   #endif
 
   class UUID {
   public:
     bool isNull() const;
+    bool isEqual(const UUID& other) const;
     ~UUID();
 
   protected:
@@ -38,6 +42,14 @@ namespace openstudio{
 
     std::string __str__() const{
       return openstudio::toString(*self);
+    }
+
+    int __hash__() const{
+      return std::hash<std::string>{}(openstudio::toString(*self));
+    }
+
+    bool __eq__ (const UUID & other) const{
+        return *self == other;
     }
 
     bool operator!= ( const UUID & other ) const {


### PR DESCRIPTION
Pull request overview

Currently UUID's cannot be used as a key in a Ruby Map (they can be used if converted to strings first). This PR implements `eql?` and `hash` for UUID in Ruby so UUID can be used as a key in a Ruby Hash

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [X] All new and existing tests passes

**Labels:**

 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
