### PR TITLE
Fix #3997 - GbXMLReverseTranslator applies incorrect scaling to windows when unit isn't meter

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -285,6 +285,7 @@ SET(gbxml_resources_src
   gbxml/TwoStoryOffice_Trane.xml
   gbxml/ZNETH.xml
   gbxml/3951_Geometry_bug.xml
+  gbxml/3997_WindowScaling_bug.xml
 )
 
 # update the resources

--- a/resources/gbxml/3997_WindowScaling_bug.xml
+++ b/resources/gbxml/3997_WindowScaling_bug.xml
@@ -1,0 +1,252 @@
+<gbXML xmlns="http://www.gbxml.org/schema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.gbxml.org/schema http://gbxml.org/schema/6-01/GreenBuildingXML_Ver6.01.xsd" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" useSIUnitsForResults="true" SurfaceReferenceLocation="Centerline" temperatureUnit="F" lengthUnit="Feet" areaUnit="SquareFeet" volumeUnit="CubicFeet" version="6.01">
+  <Campus id="Facility">
+
+    <Description>A gbxml MCVE to illustrate issue 3997 where windows are incorrectly placed</Description>
+
+    <Building id="1">
+      <Area>200000</Area>
+      <BuildingStorey id="storey-1">
+        <Name>storey 1</Name>
+        <Level>0</Level>
+      </BuildingStorey>
+      <Space id="space-1" zoneIdRef="zone-1" buildingStoreyIdRef="storey-1" conditionType="HeatedAndCooled">
+        <Name>storey-1-space-1</Name>
+        <Description>internal space 1</Description>
+        <Area>11040</Area>
+        <Volume>165600</Volume>
+      </Space>
+    </Building>
+
+    <Surface surfaceType="ExteriorWall" id="surface-19">
+      <Name>storey-1-exterior-wall-1-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>303</Azimuth>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+      <Opening openingType="FixedWindow" id="opening-1">
+        <RectangularGeometry>
+          <Azimuth>303</Azimuth>
+        </RectangularGeometry>
+        <PlanarGeometry>
+          <PolyLoop>
+            <CartesianPoint>
+              <Coordinate>139.2895</Coordinate>
+              <Coordinate>-316.4557</Coordinate>
+              <Coordinate>13.2</Coordinate>
+            </CartesianPoint>
+            <CartesianPoint>
+              <Coordinate>97.7105</Coordinate>
+              <Coordinate>-316.4557</Coordinate>
+              <Coordinate>13.2</Coordinate>
+            </CartesianPoint>
+            <CartesianPoint>
+              <Coordinate>97.7105</Coordinate>
+              <Coordinate>-316.4557</Coordinate>
+              <Coordinate>1.8</Coordinate>
+            </CartesianPoint>
+            <CartesianPoint>
+              <Coordinate>139.2895</Coordinate>
+              <Coordinate>-316.4557</Coordinate>
+              <Coordinate>1.8</Coordinate>
+            </CartesianPoint>
+          </PolyLoop>
+        </PlanarGeometry>
+      </Opening>
+    </Surface>
+
+    <Surface surfaceType="Roof" id="surface-1">
+      <Name>storey-1-roof-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>90</Azimuth>
+        <Tilt>0</Tilt>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+    </Surface>
+    <Surface surfaceType="SlabOnGrade" id="surface-2">
+      <Name>storey-1-slabongrade-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>90</Azimuth>
+        <Tilt>180</Tilt>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+    </Surface>
+
+    <Surface surfaceType="ExteriorWall" id="surface-11">
+      <Name>storey-1-exterior-wall-2-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>303</Azimuth>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+    </Surface>
+
+    <Surface surfaceType="ExteriorWall" id="surface-15">
+      <Name>storey-1-exterior-wall-diagonal-1-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>307</Azimuth>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+    </Surface>
+
+    <Surface surfaceType="ExteriorWall" id="surface-16">
+      <Name>storey-1-exterior-wall-diagonal-2-space-1</Name>
+      <RectangularGeometry>
+        <Azimuth>338</Azimuth>
+      </RectangularGeometry>
+      <CADOjectId>none</CADOjectId>
+      <AdjacentSpaceId spaceIdRef="space-1"/>
+      <PlanarGeometry>
+        <PolyLoop>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>15</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-118</Coordinate>
+            <Coordinate>-276.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+          <CartesianPoint>
+            <Coordinate>-158</Coordinate>
+            <Coordinate>-316.4557</Coordinate>
+            <Coordinate>0</Coordinate>
+          </CartesianPoint>
+        </PolyLoop>
+      </PlanarGeometry>
+    </Surface>
+
+  </Campus>
+  <Zone id="zone-1">
+    <Name>storey-1-zone-1</Name>
+  </Zone>
+</gbXML>

--- a/src/gbxml/ReverseTranslator.cpp
+++ b/src/gbxml/ReverseTranslator.cpp
@@ -573,7 +573,7 @@ namespace gbxml {
       std::array<double, 3> coords{ {0.0, 0.0, 0.0} };
       size_t i{ 0 };
       for (auto &el : coordinateElements) {
-        coords[i] = m_lengthMultiplier*el.text().as_double();
+        coords[i] = m_lengthMultiplier * el.text().as_double();
         ++i;
         if (i == 3) {
           break;
@@ -987,7 +987,7 @@ namespace gbxml {
       std::array<double, 3> coords{ {0.0, 0.0, 0.0} };
       size_t i{ 0 };
       for (auto &el : coordinateElements) {
-        coords[i] = el.text().as_double();
+        coords[i] = m_lengthMultiplier * el.text().as_double();
         ++i;
         if (i == 3) {
           break;

--- a/src/gbxml/Test/ReverseTranslator_GTest.cpp
+++ b/src/gbxml/Test/ReverseTranslator_GTest.cpp
@@ -542,4 +542,74 @@ TEST_F(gbXMLFixture, ReverseTranslator_3997_WindowScaling)
   ASSERT_TRUE(ss.surface());
   Surface s = ss.surface().get();
   EXPECT_TRUE(ss.plane().equal(s.plane()));
+
+  // Might as well retest #3951 while we're at it
+  // Check all the surfaces for their surfaceTypes and boundary conditions
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-slabongrade-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("Floor", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(0u, _surf->subSurfaces().size());
+    EXPECT_EQ("Ground", _surf->outsideBoundaryCondition());
+  }
+
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-roof-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("RoofCeiling", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(0u, _surf->subSurfaces().size());
+    EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
+  }
+
+
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-exterior-wall-1-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("Wall", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(1u, _surf->subSurfaces().size());
+    EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
+  }
+
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-exterior-wall-2-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("Wall", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(0u, _surf->subSurfaces().size());
+    EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
+  }
+
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-exterior-wall-diagonal-1-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("Wall", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(0u, _surf->subSurfaces().size());
+    EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
+  }
+
+  {
+    auto _surf = _model->getModelObjectByName<Surface>("storey-1-exterior-wall-diagonal-2-space-1");
+    ASSERT_TRUE(_surf);
+    EXPECT_EQ("Wall", _surf->surfaceType());
+    auto _space = _surf->space();
+    ASSERT_TRUE(_space);
+    EXPECT_EQ("storey-1-space-1", _space->nameString());
+    EXPECT_EQ(0u, _surf->subSurfaces().size());
+    EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
+  }
+
 }

--- a/src/gbxml/Test/ReverseTranslator_GTest.cpp
+++ b/src/gbxml/Test/ReverseTranslator_GTest.cpp
@@ -59,6 +59,7 @@
 
 #include "../../utilities/idf/Workspace.hpp"
 #include "../../utilities/core/Optional.hpp"
+#include "../../utilities/geometry/Plane.hpp"
 
 #include <utilities/idd/OS_Surface_FieldEnums.hxx>
 #include <utilities/idd/OS_SubSurface_FieldEnums.hxx>
@@ -524,4 +525,21 @@ TEST_F(gbXMLFixture, ReverseTranslator_3951_Surface)
     ASSERT_TRUE(_space);
     EXPECT_EQ("storey-1-space-1", _space->nameString());
   }
+}
+
+TEST_F(gbXMLFixture, ReverseTranslator_3997_WindowScaling)
+{
+  openstudio::path inputPath = resourcesPath() / openstudio::toPath("gbxml/3997_WindowScaling_bug.xml");
+
+  openstudio::gbxml::ReverseTranslator reverseTranslator;
+  boost::optional<openstudio::model::Model> _model = reverseTranslator.loadModel(inputPath);
+  ASSERT_TRUE(_model);
+
+  // Check the SubSurface is contained on the same plane as its Surface
+  auto _subSurfaces = _model->getConcreteModelObjects<SubSurface>();
+  ASSERT_EQ(1u, _subSurfaces.size());
+  SubSurface ss = _subSurfaces[0];
+  ASSERT_TRUE(ss.surface());
+  Surface s = ss.surface().get();
+  EXPECT_TRUE(ss.plane().equal(s.plane()));
 }


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #3997
- GbXMLReverseTranslator applies incorrect scaling to windows when unit isn't meter

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] gbXML API Changes / Additions
 - [x] gbXML API methods are tested (in `src/gbxml/test`)
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
