### PR TITLE
Removes Propane warning

### DIFF
--- a/src/model/CoilHeatingGas.cpp
+++ b/src/model/CoilHeatingGas.cpp
@@ -221,9 +221,6 @@ namespace detail{
 
   bool CoilHeatingGas_Impl::setFuelType(const std::string &fuelType)
   {
-    if (fuelType == "Propane") {
-        LOG(Warn, "'Propane' is deprecated for Coil_Heating_GasFields:FuelType, use 'Propane' instead");
-    }
     return this->setString(OS_Coil_Heating_GasFields::FuelType, fuelType);
   }
 


### PR DESCRIPTION
Pull request overview
---------------------

Removes a warning message that no longer makes sense:
`'Propane' is deprecated for Coil_Heating_GasFields:FuelType, use 'Propane' instead`

It used to make sense, but then lost meaning after a [find/replace of PropaneGas -> Propane](https://github.com/NREL/OpenStudio/commit/c4979a3d1ebcce2f229b5e762b4decbe82218731#diff-c2b0c728d13d7d6bff199f68d302e27dL224-R225).

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
