### PR TITLE
remove if defaulted statements

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -183,9 +183,7 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
 
   idfObject.setString(openstudio::ZoneFields::Type,"");
 
-  if (!modelObject.isMultiplierDefaulted()){
-    idfObject.setInt(openstudio::ZoneFields::Multiplier,modelObject.multiplier());
-  }
+  idfObject.setInt(openstudio::ZoneFields::Multiplier,modelObject.multiplier());
 
   if (modelObject.ceilingHeight()){
     idfObject.setDouble(openstudio::ZoneFields::CeilingHeight,modelObject.ceilingHeight().get());
@@ -218,28 +216,18 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
   }else{
     OS_ASSERT(spaces.size() == 1);
 
-    if (!spaces[0].isDirectionofRelativeNorthDefaulted()){
-      idfObject.setDouble(openstudio::ZoneFields::DirectionofRelativeNorth, spaces[0].directionofRelativeNorth());
-    }
+    idfObject.setDouble(openstudio::ZoneFields::DirectionofRelativeNorth, spaces[0].directionofRelativeNorth());
 
-    if (!spaces[0].isXOriginDefaulted()){
-      idfObject.setDouble(openstudio::ZoneFields::XOrigin, spaces[0].xOrigin());
-    }
+    idfObject.setDouble(openstudio::ZoneFields::XOrigin, spaces[0].xOrigin());
 
-    if (!spaces[0].isYOriginDefaulted()){
-      idfObject.setDouble(openstudio::ZoneFields::YOrigin, spaces[0].yOrigin());
-    }
+    idfObject.setDouble(openstudio::ZoneFields::YOrigin, spaces[0].yOrigin());
 
-    if (!spaces[0].isZOriginDefaulted()){
-      idfObject.setDouble(openstudio::ZoneFields::ZOrigin, spaces[0].zOrigin());
-    }
+    idfObject.setDouble(openstudio::ZoneFields::ZOrigin, spaces[0].zOrigin());
 
-    if (!spaces[0].isPartofTotalFloorAreaDefaulted()){
-      if (spaces[0].partofTotalFloorArea()){
-        idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"Yes");
-      }else{
-        idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"No");
-      }
+    if (spaces[0].partofTotalFloorArea()){
+    idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"Yes");
+    }else{
+    idfObject.setString(openstudio::ZoneFields::PartofTotalFloorArea,"No");
     }
 
     // translate the space now
@@ -487,31 +475,21 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
         Daylighting_ControlsFields::GlareCalculationDaylightingReferencePointName,
         primaryReferencePoint.nameString());
 
+      daylightingControlObject.setDouble(
+        Daylighting_ControlsFields::MinimumInputPowerFractionforContinuousorContinuousOffDimmingControl,
+        primaryDaylightingControl->minimumInputPowerFractionforContinuousDimmingControl());
 
-      if (!primaryDaylightingControl->isMinimumInputPowerFractionforContinuousDimmingControlDefaulted()){
-        daylightingControlObject.setDouble(
-            Daylighting_ControlsFields::MinimumInputPowerFractionforContinuousorContinuousOffDimmingControl,
-            primaryDaylightingControl->minimumInputPowerFractionforContinuousDimmingControl());
-      }
+      daylightingControlObject.setDouble(
+        Daylighting_ControlsFields::MinimumLightOutputFractionforContinuousorContinuousOffDimmingControl,
+        primaryDaylightingControl->minimumLightOutputFractionforContinuousDimmingControl());
 
-      if (!primaryDaylightingControl->isMinimumLightOutputFractionforContinuousDimmingControlDefaulted()) {
-        daylightingControlObject.setDouble(
-            Daylighting_ControlsFields::MinimumLightOutputFractionforContinuousorContinuousOffDimmingControl,
-            primaryDaylightingControl->minimumLightOutputFractionforContinuousDimmingControl());
-      }
+      daylightingControlObject.setInt(
+        Daylighting_ControlsFields::NumberofSteppedControlSteps,
+        primaryDaylightingControl->numberofSteppedControlSteps());
 
-      if (!primaryDaylightingControl->isNumberofSteppedControlStepsDefaulted()){
-        daylightingControlObject.setInt(
-            Daylighting_ControlsFields::NumberofSteppedControlSteps,
-            primaryDaylightingControl->numberofSteppedControlSteps());
-      }
-
-      if (!primaryDaylightingControl->isProbabilityLightingwillbeResetWhenNeededinManualSteppedControlDefaulted()){
-        daylightingControlObject.setDouble(
-            Daylighting_ControlsFields::ProbabilityLightingwillbeResetWhenNeededinManualSteppedControl,
-            primaryDaylightingControl->probabilityLightingwillbeResetWhenNeededinManualSteppedControl());
-      }
-
+      daylightingControlObject.setDouble(
+        Daylighting_ControlsFields::ProbabilityLightingwillbeResetWhenNeededinManualSteppedControl,
+        primaryDaylightingControl->probabilityLightingwillbeResetWhenNeededinManualSteppedControl());
     }
 
     // translate illuminance map
@@ -676,10 +654,8 @@ boost::optional<IdfObject> ForwardTranslator::translateThermalZone( ThermalZone 
             }
 
             // Thermostat's Temperature Difference Between Cutout And Setpoint is placed here on the ZoneControl:Thermostat
-            if (!dualSetpoint.isTemperatureDifferenceBetweenCutoutAndSetpointDefaulted()) {
-              zoneControlThermostat.setDouble(ZoneControl_ThermostatFields::TemperatureDifferenceBetweenCutoutAndSetpoint,
-                                              dualSetpoint.temperatureDifferenceBetweenCutoutAndSetpoint());
-            }
+            zoneControlThermostat.setDouble(ZoneControl_ThermostatFields::TemperatureDifferenceBetweenCutoutAndSetpoint,
+                                          dualSetpoint.temperatureDifferenceBetweenCutoutAndSetpoint());
           }
         };
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #2100 (IF THIS IS A DEFECT)
 - remove if defaulted statements in ForwardTranslateThermalZone

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### mpraprost

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [X] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
