### PR TITLE
Fix #4001 - gbXML issue on ForwardTranslation - surfaceType attribute written twice for SlabOnGrade

### DIFF
--- a/src/gbxml/ForwardTranslator.cpp
+++ b/src/gbxml/ForwardTranslator.cpp
@@ -790,7 +790,7 @@ namespace gbxml {
           result.append_attribute("surfaceType") = "RaisedFloor";
         } else if (surface.isGroundSurface()) {
           checkSlabOnGrade = true;
-          result.append_attribute("surfaceType") = "UndergroundSlab"; // might be SlabOnGrade, check vertices later
+          // Can be either UndergroundSlab or SlabOnGrade, check vertices later
         } else if (istringEqual("Surface", outsideBoundaryCondition)) {
           result.append_attribute("surfaceType") = "InteriorFloor";
         } else if (istringEqual("Adiabatic", outsideBoundaryCondition)) {
@@ -847,6 +847,8 @@ namespace gbxml {
       }
       if ((maxZ <= 0.01) && (minZ >= -0.01)) {
         result.append_attribute("surfaceType") = "SlabOnGrade";
+      } else {
+        result.append_attribute("surfaceType") = "UndergroundSlab";
       }
     }
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4001
- gbXML issue on ForwardTranslation - surfaceType attribute written twice for SlabOnGrade

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
