### PR TITLE
Addresses #2895, cannot add window frame and divider to skylights

### DIFF
--- a/src/energyplus/Test/SubSurface_GTest.cpp
+++ b/src/energyplus/Test/SubSurface_GTest.cpp
@@ -38,8 +38,14 @@
 #include "../../model/SubSurface_Impl.hpp"
 #include "../../model/Surface.hpp"
 #include "../../model/Surface_Impl.hpp"
+#include "../../model/Space.hpp"
+#include "../../model/Space_Impl.hpp"
+#include "../../model/ThermalZone.hpp"
+#include "../../model/ThermalZone_Impl.hpp"
+#include "../../model/WindowPropertyFrameAndDivider.hpp"
+#include "../../model/WindowPropertyFrameAndDivider_Impl.hpp"
 
-#include <utilities/idd/Daylighting_Controls_FieldEnums.hxx>
+#include <utilities/idd/FenestrationSurface_Detailed_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 
 #include <resources.hxx>
@@ -83,6 +89,44 @@ TEST_F(EnergyPlusFixture,ReverseTranslator_GlassDoorToSubSurface) {
 TEST_F(EnergyPlusFixture,ForwardTranslator_SubSurface)
 {
   Model model;
+
+  ThermalZone thermalZone(model);
+
+  Space space(model);
+  space.setThermalZone(thermalZone);
+
+  std::vector<Point3d> vertices;
+  vertices.push_back(Point3d(0, 2, 0));
+  vertices.push_back(Point3d(0, 0, 0));
+  vertices.push_back(Point3d(2, 0, 0));
+  vertices.push_back(Point3d(2, 2, 0));
+  Surface surface(vertices, model);
+  surface.setSpace(space);
+
+  vertices.clear();
+  vertices.push_back(Point3d(0, 1, 0));
+  vertices.push_back(Point3d(0, 0, 0));
+  vertices.push_back(Point3d(1, 0, 0));
+  vertices.push_back(Point3d(1, 1, 0));
+
+  SubSurface subSurface(vertices, model);
+  subSurface.setSurface(surface);
+  subSurface.assignDefaultSubSurfaceType();
+
+  WindowPropertyFrameAndDivider frame(model);
+  subSurface.setWindowPropertyFrameAndDivider(frame);
+
+  ForwardTranslator forwardTranslator;
+  Workspace workspace = forwardTranslator.translateModel(model);
+
+  ASSERT_EQ(1u, workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed).size());
+  ASSERT_EQ(1u, workspace.getObjectsByType(IddObjectType::WindowProperty_FrameAndDivider).size());
+
+  WorkspaceObject subSurfaceObject = workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed)[0];
+  WorkspaceObject frameObject = workspace.getObjectsByType(IddObjectType::WindowProperty_FrameAndDivider)[0];
+
+  ASSERT_TRUE(subSurfaceObject.getTarget(FenestrationSurface_DetailedFields::FrameandDividerName));
+  EXPECT_EQ(frameObject.handle(), subSurfaceObject.getTarget(FenestrationSurface_DetailedFields::FrameandDividerName)->handle());
 }
 
 

--- a/src/model/SubSurface.cpp
+++ b/src/model/SubSurface.cpp
@@ -493,6 +493,7 @@ namespace detail {
     std::string subSurfaceType = this->subSurfaceType();
     if (istringEqual("FixedWindow", subSurfaceType) ||
         istringEqual("OperableWindow", subSurfaceType) ||
+        istringEqual("Skylight", subSurfaceType) ||
         istringEqual("GlassDoor", subSurfaceType))
     {
       result = true;

--- a/src/model/test/SubSurface_GTest.cpp
+++ b/src/model/test/SubSurface_GTest.cpp
@@ -38,6 +38,8 @@
 #include "../SubSurface_Impl.hpp"
 #include "../Building.hpp"
 #include "../Building_Impl.hpp"
+#include "../WindowPropertyFrameAndDivider.hpp"
+#include "../WindowPropertyFrameAndDivider_Impl.hpp"
 #include "../SimpleGlazing.hpp"
 #include "../Construction.hpp"
 #include "../DefaultSubSurfaceConstructions.hpp"
@@ -1036,6 +1038,12 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     SubSurface s(vertices, model);
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("Skylight", s.subSurfaceType());
+
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
   }
   {
     // normal 0,1,0
@@ -1048,6 +1056,12 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     SubSurface s(vertices, model);
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("FixedWindow", s.subSurfaceType());
+
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
   }
 
   // with base surface the default type is set based on base surface
@@ -1093,9 +1107,21 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("Door", s.subSurfaceType());
 
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_FALSE(s.allowWindowPropertyFrameAndDivider());
+    EXPECT_FALSE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_FALSE(s.windowPropertyFrameAndDivider());
+    ASSERT_FALSE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+
     EXPECT_TRUE(s.setSubSurfaceType("GlassDoor"));
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("GlassDoor", s.subSurfaceType());
+
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
   }
   {
     // normal 0,1,0 not on bottom edge
@@ -1110,6 +1136,12 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_EQ("FixedWindow", s.subSurfaceType());
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("FixedWindow", s.subSurfaceType());
+
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
   }
 
   // set default window construction, reproduces #1924
@@ -1143,9 +1175,21 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("Door", s.subSurfaceType());
 
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_FALSE(s.allowWindowPropertyFrameAndDivider());
+    EXPECT_FALSE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_FALSE(s.windowPropertyFrameAndDivider());
+    ASSERT_FALSE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+
     s.setConstruction(construction);
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("GlassDoor", s.subSurfaceType());
+
+    WindowPropertyFrameAndDivider frame(model);
+    EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider());
+    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
   }
 }
 

--- a/src/model/test/SubSurface_GTest.cpp
+++ b/src/model/test/SubSurface_GTest.cpp
@@ -1043,7 +1043,8 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
     ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_TRUE(s.windowPropertyFrameAndDivider());
-    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+    WindowPropertyFrameAndDivider frame2 = s.windowPropertyFrameAndDivider().get();
+    EXPECT_EQ(frame, frame2);
   }
   {
     // normal 0,1,0
@@ -1061,7 +1062,8 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
     ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_TRUE(s.windowPropertyFrameAndDivider());
-    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+    WindowPropertyFrameAndDivider frame2 = s.windowPropertyFrameAndDivider().get();
+    EXPECT_EQ(frame, frame2);
   }
 
   // with base surface the default type is set based on base surface
@@ -1111,17 +1113,16 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_FALSE(s.allowWindowPropertyFrameAndDivider());
     EXPECT_FALSE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_FALSE(s.windowPropertyFrameAndDivider());
-    ASSERT_FALSE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
 
     EXPECT_TRUE(s.setSubSurfaceType("GlassDoor"));
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("GlassDoor", s.subSurfaceType());
 
-    WindowPropertyFrameAndDivider frame(model);
     EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
     ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_TRUE(s.windowPropertyFrameAndDivider());
-    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+    WindowPropertyFrameAndDivider frame2 = s.windowPropertyFrameAndDivider().get();
+    EXPECT_EQ(frame, frame2);
   }
   {
     // normal 0,1,0 not on bottom edge
@@ -1141,7 +1142,8 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
     ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_TRUE(s.windowPropertyFrameAndDivider());
-    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+    WindowPropertyFrameAndDivider frame2 = s.windowPropertyFrameAndDivider().get();
+    EXPECT_EQ(frame, frame2);
   }
 
   // set default window construction, reproduces #1924
@@ -1179,17 +1181,16 @@ TEST_F(ModelFixture, DefaultSubSurfaceType)
     EXPECT_FALSE(s.allowWindowPropertyFrameAndDivider());
     EXPECT_FALSE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_FALSE(s.windowPropertyFrameAndDivider());
-    ASSERT_FALSE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
 
     s.setConstruction(construction);
     s.assignDefaultSubSurfaceType();
     EXPECT_EQ("GlassDoor", s.subSurfaceType());
 
-    WindowPropertyFrameAndDivider frame(model);
     EXPECT_TRUE(s.allowWindowPropertyFrameAndDivider());
     ASSERT_TRUE(s.setWindowPropertyFrameAndDivider(frame));
     ASSERT_TRUE(s.windowPropertyFrameAndDivider());
-    ASSERT_TRUE(s.windowPropertyFrameAndDivider().optionalCast<WindowPropertyFrameAndDivider>());
+    WindowPropertyFrameAndDivider frame2 = s.windowPropertyFrameAndDivider().get();
+    EXPECT_EQ(frame, frame2);
   }
 }
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #2895

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
