### PR TITLE
Addresses #2867, sum of fraction radiant, fraction lost, etc can be > 1

### DIFF
--- a/src/model/ElectricEquipmentDefinition.cpp
+++ b/src/model/ElectricEquipmentDefinition.cpp
@@ -207,6 +207,14 @@ namespace detail {
   }
 
   bool ElectricEquipmentDefinition_Impl::setFractionLatent(double fractionLatent) {
+
+    double fractionRadiantAndLost = fractionRadiant() + fractionLost();
+    if ( (fractionLatent + fractionRadiantAndLost) > 1.0) {
+      LOG(Error, "Radiant Fraction and Lost Fraction sum to " << fractionRadiantAndLost
+          << " and you supplied a Latent Fraction of " << fractionLatent
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_ElectricEquipment_DefinitionFields::FractionLatent, fractionLatent);
     return result;
   }
@@ -217,6 +225,14 @@ namespace detail {
   }
 
   bool ElectricEquipmentDefinition_Impl::setFractionRadiant(double fractionRadiant) {
+
+    double fractionLatentAndLost = fractionLatent() + fractionLost();
+    if ( (fractionRadiant + fractionLatentAndLost) > 1.0) {
+      LOG(Error, "Latent Fraction and Lost Fraction sum to " << fractionLatentAndLost
+          << " and you supplied a Radiant Fraction of " << fractionRadiant
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_ElectricEquipment_DefinitionFields::FractionRadiant, fractionRadiant);
     return result;
   }
@@ -227,6 +243,14 @@ namespace detail {
   }
 
   bool ElectricEquipmentDefinition_Impl::setFractionLost(double fractionLost) {
+
+    double fractionLatentAndRadiant = fractionLatent() + fractionRadiant();
+    if ( (fractionLost + fractionLatentAndRadiant) > 1.0) {
+      LOG(Error, "Latent Fraction and Radiant Fraction sum to " << fractionLatentAndRadiant
+          << " and you supplied a Lost Fraction of " << fractionLost
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_ElectricEquipment_DefinitionFields::FractionLost, fractionLost);
     return result;
   }

--- a/src/model/GasEquipmentDefinition.cpp
+++ b/src/model/GasEquipmentDefinition.cpp
@@ -217,6 +217,14 @@ namespace detail {
   }
 
   bool GasEquipmentDefinition_Impl::setFractionLatent(double fractionLatent) {
+
+    double fractionRadiantAndLost = fractionRadiant() + fractionLost();
+    if ( (fractionLatent + fractionRadiantAndLost) > 1.0) {
+      LOG(Error, "Radiant Fraction and Lost Fraction sum to " << fractionRadiantAndLost
+          << " and you supplied a Latent Fraction of " << fractionLatent
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_GasEquipment_DefinitionFields::FractionLatent, fractionLatent);
     return result;
   }
@@ -227,6 +235,14 @@ namespace detail {
   }
 
   bool GasEquipmentDefinition_Impl::setFractionRadiant(double fractionRadiant) {
+
+    double fractionLatentAndLost = fractionLatent() + fractionLost();
+    if ( (fractionRadiant + fractionLatentAndLost) > 1.0) {
+      LOG(Error, "Latent Fraction and Lost Fraction sum to " << fractionLatentAndLost
+          << " and you supplied a Radiant Fraction of " << fractionRadiant
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_GasEquipment_DefinitionFields::FractionRadiant, fractionRadiant);
     return result;
   }
@@ -237,6 +253,14 @@ namespace detail {
   }
 
   bool GasEquipmentDefinition_Impl::setFractionLost(double fractionLost) {
+
+    double fractionLatentAndRadiant = fractionLatent() + fractionRadiant();
+    if ( (fractionLost + fractionLatentAndRadiant) > 1.0) {
+      LOG(Error, "Latent Fraction and Radiant Fraction sum to " << fractionLatentAndRadiant
+          << " and you supplied a Lost Fraction of " << fractionLost
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_GasEquipment_DefinitionFields::FractionLost, fractionLost);
     return result;
   }

--- a/src/model/HotWaterEquipmentDefinition.cpp
+++ b/src/model/HotWaterEquipmentDefinition.cpp
@@ -209,6 +209,14 @@ namespace detail {
   }
 
   bool HotWaterEquipmentDefinition_Impl::setFractionLatent(double fractionLatent) {
+
+    double fractionRadiantAndLost = fractionRadiant() + fractionLost();
+    if ( (fractionLatent + fractionRadiantAndLost) > 1.0) {
+      LOG(Error, "Radiant Fraction and Lost Fraction sum to " << fractionRadiantAndLost
+          << " and you supplied a Latent Fraction of " << fractionLatent
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_HotWaterEquipment_DefinitionFields::FractionLatent, fractionLatent);
     return result;
   }
@@ -219,6 +227,14 @@ namespace detail {
   }
 
   bool HotWaterEquipmentDefinition_Impl::setFractionRadiant(double fractionRadiant) {
+
+    double fractionLatentAndLost = fractionLatent() + fractionLost();
+    if ( (fractionRadiant + fractionLatentAndLost) > 1.0) {
+      LOG(Error, "Latent Fraction and Lost Fraction sum to " << fractionLatentAndLost
+          << " and you supplied a Radiant Fraction of " << fractionRadiant
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_HotWaterEquipment_DefinitionFields::FractionRadiant, fractionRadiant);
     return result;
   }
@@ -229,6 +245,14 @@ namespace detail {
   }
 
   bool HotWaterEquipmentDefinition_Impl::setFractionLost(double fractionLost) {
+
+    double fractionLatentAndRadiant = fractionLatent() + fractionRadiant();
+    if ( (fractionLost + fractionLatentAndRadiant) > 1.0) {
+      LOG(Error, "Latent Fraction and Radiant Fraction sum to " << fractionLatentAndRadiant
+          << " and you supplied a Lost Fraction of " << fractionLost
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_HotWaterEquipment_DefinitionFields::FractionLost, fractionLost);
     return result;
   }

--- a/src/model/OtherEquipmentDefinition.cpp
+++ b/src/model/OtherEquipmentDefinition.cpp
@@ -175,6 +175,14 @@ namespace detail {
   }
 
   bool OtherEquipmentDefinition_Impl::setFractionLatent(double fractionLatent) {
+
+    double fractionRadiantAndLost = fractionRadiant() + fractionLost();
+    if ( (fractionLatent + fractionRadiantAndLost) > 1.0) {
+      LOG(Error, "Radiant Fraction and Lost Fraction sum to " << fractionRadiantAndLost
+          << " and you supplied a Latent Fraction of " << fractionLatent
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_OtherEquipment_DefinitionFields::FractionLatent, fractionLatent);
     return result;
   }
@@ -185,6 +193,14 @@ namespace detail {
   }
 
   bool OtherEquipmentDefinition_Impl::setFractionRadiant(double fractionRadiant) {
+
+    double fractionLatentAndLost = fractionLatent() + fractionLost();
+    if ( (fractionRadiant + fractionLatentAndLost) > 1.0) {
+      LOG(Error, "Latent Fraction and Lost Fraction sum to " << fractionLatentAndLost
+          << " and you supplied a Radiant Fraction of " << fractionRadiant
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_OtherEquipment_DefinitionFields::FractionRadiant, fractionRadiant);
     return result;
   }
@@ -195,6 +211,14 @@ namespace detail {
   }
 
   bool OtherEquipmentDefinition_Impl::setFractionLost(double fractionLost) {
+
+    double fractionLatentAndRadiant = fractionLatent() + fractionRadiant();
+    if ( (fractionLost + fractionLatentAndRadiant) > 1.0) {
+      LOG(Error, "Latent Fraction and Radiant Fraction sum to " << fractionLatentAndRadiant
+          << " and you supplied a Lost Fraction of " << fractionLost
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_OtherEquipment_DefinitionFields::FractionLost, fractionLost);
     return result;
   }

--- a/src/model/SteamEquipmentDefinition.cpp
+++ b/src/model/SteamEquipmentDefinition.cpp
@@ -177,6 +177,14 @@ namespace detail {
   }
 
   bool SteamEquipmentDefinition_Impl::setFractionLatent(double fractionLatent) {
+
+    double fractionRadiantAndLost = fractionRadiant() + fractionLost();
+    if ( (fractionLatent + fractionRadiantAndLost) > 1.0) {
+      LOG(Error, "Radiant Fraction and Lost Fraction sum to " << fractionRadiantAndLost
+          << " and you supplied a Latent Fraction of " << fractionLatent
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_SteamEquipment_DefinitionFields::FractionLatent, fractionLatent);
     return result;
   }
@@ -187,6 +195,14 @@ namespace detail {
   }
 
   bool SteamEquipmentDefinition_Impl::setFractionRadiant(double fractionRadiant) {
+
+    double fractionLatentAndLost = fractionLatent() + fractionLost();
+    if ( (fractionRadiant + fractionLatentAndLost) > 1.0) {
+      LOG(Error, "Latent Fraction and Lost Fraction sum to " << fractionLatentAndLost
+          << " and you supplied a Radiant Fraction of " << fractionRadiant
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_SteamEquipment_DefinitionFields::FractionRadiant, fractionRadiant);
     return result;
   }
@@ -197,6 +213,14 @@ namespace detail {
   }
 
   bool SteamEquipmentDefinition_Impl::setFractionLost(double fractionLost) {
+
+    double fractionLatentAndRadiant = fractionLatent() + fractionRadiant();
+    if ( (fractionLost + fractionLatentAndRadiant) > 1.0) {
+      LOG(Error, "Latent Fraction and Radiant Fraction sum to " << fractionLatentAndRadiant
+          << " and you supplied a Lost Fraction of " << fractionLost
+          << " which would result in a sum greater than 1.0");
+      return false;
+    }
     bool result = setDouble(OS_SteamEquipment_DefinitionFields::FractionLost, fractionLost);
     return result;
   }

--- a/src/model/test/ElectricEquipment_GTest.cpp
+++ b/src/model/test/ElectricEquipment_GTest.cpp
@@ -104,3 +104,16 @@ TEST_F(ModelFixture, ElectricEquipment_Cost) {
 
   EXPECT_DOUBLE_EQ(300.0, cost->totalCost());
 }
+
+/* Tests that you cannot set Fractions that sum to greater than 1 */
+TEST_F(ModelFixture, ElectricEquipment_FractionsLatentRadiantLost) {
+  Model m;
+  ElectricEquipmentDefinition definition(model);
+  ElectricEquipment electricEquipment(definition);
+
+  ASSERT_TRUE(definition.setFractionLatent(0.5));
+  ASSERT_TRUE(definition.setFractionRadiant(0.5));
+  ASSERT_FALSE(definition.setFractionLost(0.75));
+  ASSERT_FALSE(definition.setFractionLatent(0.75));
+  ASSERT_FALSE(definition.setFractionRadiant(0.75));
+}

--- a/src/model/test/ElectricEquipment_GTest.cpp
+++ b/src/model/test/ElectricEquipment_GTest.cpp
@@ -108,7 +108,7 @@ TEST_F(ModelFixture, ElectricEquipment_Cost) {
 /* Tests that you cannot set Fractions that sum to greater than 1 */
 TEST_F(ModelFixture, ElectricEquipment_FractionsLatentRadiantLost) {
   Model m;
-  ElectricEquipmentDefinition definition(model);
+  ElectricEquipmentDefinition definition(m);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/ElectricEquipment_GTest.cpp
+++ b/src/model/test/ElectricEquipment_GTest.cpp
@@ -109,7 +109,6 @@ TEST_F(ModelFixture, ElectricEquipment_Cost) {
 TEST_F(ModelFixture, ElectricEquipment_FractionsLatentRadiantLost) {
   Model m;
   ElectricEquipmentDefinition definition(model);
-  ElectricEquipment electricEquipment(definition);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/GasEquipment_GTest.cpp
+++ b/src/model/test/GasEquipment_GTest.cpp
@@ -95,7 +95,7 @@ TEST_F(ModelFixture, GasEquipment_Cost)
 /* Tests that you cannot set Fractions that sum to greater than 1 */
 TEST_F(ModelFixture, GasEquipment_FractionsLatentRadiantLost) {
   Model m;
-  GasEquipmentDefinition definition(model);
+  GasEquipmentDefinition definition(m);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/GasEquipment_GTest.cpp
+++ b/src/model/test/GasEquipment_GTest.cpp
@@ -91,3 +91,15 @@ TEST_F(ModelFixture, GasEquipment_Cost)
 
   EXPECT_DOUBLE_EQ(80.0, cost->totalCost());
 }
+
+/* Tests that you cannot set Fractions that sum to greater than 1 */
+TEST_F(ModelFixture, GasEquipment_FractionsLatentRadiantLost) {
+  Model m;
+  GasEquipmentDefinition definition(model);
+
+  ASSERT_TRUE(definition.setFractionLatent(0.5));
+  ASSERT_TRUE(definition.setFractionRadiant(0.5));
+  ASSERT_FALSE(definition.setFractionLost(0.75));
+  ASSERT_FALSE(definition.setFractionLatent(0.75));
+  ASSERT_FALSE(definition.setFractionRadiant(0.75));
+}

--- a/src/model/test/HotWaterEquipment_GTest.cpp
+++ b/src/model/test/HotWaterEquipment_GTest.cpp
@@ -53,7 +53,7 @@ TEST_F(ModelFixture, HotWaterEquipment)
 /* Tests that you cannot set Fractions that sum to greater than 1 */
 TEST_F(ModelFixture, HotWaterEquipment_FractionsLatentRadiantLost) {
   Model m;
-  HotWaterEquipmentDefinition definition(model);
+  HotWaterEquipmentDefinition definition(m);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/HotWaterEquipment_GTest.cpp
+++ b/src/model/test/HotWaterEquipment_GTest.cpp
@@ -49,3 +49,15 @@ TEST_F(ModelFixture, HotWaterEquipment)
   HotWaterEquipment hotWaterEquipment(definition);
   EXPECT_EQ(2u, model.numObjects());
 }
+
+/* Tests that you cannot set Fractions that sum to greater than 1 */
+TEST_F(ModelFixture, HotWaterEquipment_FractionsLatentRadiantLost) {
+  Model m;
+  HotWaterEquipmentDefinition definition(model);
+
+  ASSERT_TRUE(definition.setFractionLatent(0.5));
+  ASSERT_TRUE(definition.setFractionRadiant(0.5));
+  ASSERT_FALSE(definition.setFractionLost(0.75));
+  ASSERT_FALSE(definition.setFractionLatent(0.75));
+  ASSERT_FALSE(definition.setFractionRadiant(0.75));
+}

--- a/src/model/test/OtherEquipment_GTest.cpp
+++ b/src/model/test/OtherEquipment_GTest.cpp
@@ -125,3 +125,15 @@ TEST_F(ModelFixture, OtherEquipment_EndUseSubcategory)
   EXPECT_TRUE(equipment.isEndUseSubcategoryDefaulted());
 
 }
+
+/* Tests that you cannot set Fractions that sum to greater than 1 */
+TEST_F(ModelFixture, OtherEquipment_FractionsLatentRadiantLost) {
+  Model m;
+  OtherEquipmentDefinition definition(model);
+
+  ASSERT_TRUE(definition.setFractionLatent(0.5));
+  ASSERT_TRUE(definition.setFractionRadiant(0.5));
+  ASSERT_FALSE(definition.setFractionLost(0.75));
+  ASSERT_FALSE(definition.setFractionLatent(0.75));
+  ASSERT_FALSE(definition.setFractionRadiant(0.75));
+}

--- a/src/model/test/OtherEquipment_GTest.cpp
+++ b/src/model/test/OtherEquipment_GTest.cpp
@@ -129,7 +129,7 @@ TEST_F(ModelFixture, OtherEquipment_EndUseSubcategory)
 /* Tests that you cannot set Fractions that sum to greater than 1 */
 TEST_F(ModelFixture, OtherEquipment_FractionsLatentRadiantLost) {
   Model m;
-  OtherEquipmentDefinition definition(model);
+  OtherEquipmentDefinition definition(m);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/SteamEquipment_GTest.cpp
+++ b/src/model/test/SteamEquipment_GTest.cpp
@@ -87,7 +87,7 @@ TEST_F(ModelFixture, SteamEquipment_Instance)
 /* Tests that you cannot set Fractions that sum to greater than 1 */
 TEST_F(ModelFixture, SteamEquipment_FractionsLatentRadiantLost) {
   Model m;
-  SteamEquipmentDefinition definition(model);
+  SteamEquipmentDefinition definition(m);
 
   ASSERT_TRUE(definition.setFractionLatent(0.5));
   ASSERT_TRUE(definition.setFractionRadiant(0.5));

--- a/src/model/test/SteamEquipment_GTest.cpp
+++ b/src/model/test/SteamEquipment_GTest.cpp
@@ -83,3 +83,15 @@ TEST_F(ModelFixture, SteamEquipment_Instance)
   SteamEquipment instance(definition);
   EXPECT_TRUE(instance.definition().optionalCast<SteamEquipmentDefinition>());
 }
+
+/* Tests that you cannot set Fractions that sum to greater than 1 */
+TEST_F(ModelFixture, SteamEquipment_FractionsLatentRadiantLost) {
+  Model m;
+  SteamEquipmentDefinition definition(model);
+
+  ASSERT_TRUE(definition.setFractionLatent(0.5));
+  ASSERT_TRUE(definition.setFractionRadiant(0.5));
+  ASSERT_FALSE(definition.setFractionLost(0.75));
+  ASSERT_FALSE(definition.setFractionLatent(0.75));
+  ASSERT_FALSE(definition.setFractionRadiant(0.75));
+}


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #2867

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
