### PR TITLE
Revert "#4007 - Model objects returned in inconsistent order"

### DIFF
--- a/src/model/Model.hpp
+++ b/src/model/Model.hpp
@@ -302,7 +302,7 @@ class MODEL_API Model : public openstudio::Workspace {
    *  speed up the search. This method will only work for concrete model objects (leaves in the
    *  ModelObject inheritance tree), hence the name. */
   template <typename T>
-  std::vector<T> getConcreteModelObjects(bool sorted=false) const
+  std::vector<T> getConcreteModelObjects() const
   {
     std::vector<T> result;
     std::vector<WorkspaceObject> objects = this->getObjectsByType(T::iddObjectType());
@@ -310,9 +310,6 @@ class MODEL_API Model : public openstudio::Workspace {
     {
       std::shared_ptr<typename T::ImplType> p = it->getImpl<typename T::ImplType>();
       if (p) { result.push_back(T(p)); }
-    }
-    if (sorted) {
-      std::sort(result.begin(), result.end());
     }
     return result;
   }

--- a/src/model/Model_Common_Include.i
+++ b/src/model/Model_Common_Include.i
@@ -72,7 +72,7 @@
   %init %{
     rb_eval_string("OpenStudio::IdfObject.class_eval { define_method(:to_" #_name ") { OpenStudio::Model::to" #_name "(self); } }");
     rb_eval_string("OpenStudio::Model::Model.class_eval { define_method(:get" #_name ") { |handle| OpenStudio::Model::get" #_name "(self, handle); } }");
-    rb_eval_string("OpenStudio::Model::Model.class_eval { define_method(:get" #_name "s) { | sorted = false | OpenStudio::Model::get" #_name "s(self, sorted); } }");
+    rb_eval_string("OpenStudio::Model::Model.class_eval { define_method(:get" #_name "s) { OpenStudio::Model::get" #_name "s(self); } }");
     rb_eval_string("OpenStudio::Model::Model.class_eval { define_method(:get" #_name "ByName) { |name| OpenStudio::Model::get" #_name "ByName(self, name); } }");
     rb_eval_string("OpenStudio::Model::Model.class_eval { define_method(:get" #_name "sByName) { |name, exactMatch| OpenStudio::Model::get" #_name "sByName(self, name, exactMatch); } }");
   %}
@@ -202,7 +202,7 @@
 
       boost::optional<_name> to##_name(const openstudio::IdfObject& idfObject);
       boost::optional<_name> get##_name(const Model &t_model, const openstudio::Handle &t_handle);
-      std::vector<_name> get##_name##s(const Model &t_model, bool sorted);
+      std::vector<_name> get##_name##s(const Model &t_model);
       boost::optional<_name> get##_name##ByName(const Model &t_model, const std::string &t_name);
       std::vector<_name> get##_name##sByName(const Model &t_model, const std::string &t_name, bool t_exactMatch);
     }
@@ -216,11 +216,11 @@
       boost::optional<_name> get##_name(const Model &t_model, const openstudio::Handle &t_handle) {
         return t_model.getModelObject<_name>(t_handle);
       }
-      std::vector<_name> get##_name##s(const Model &t_model, bool sorted) {
+      std::vector<_name> get##_name##s(const Model &t_model) {
         %#if _isConcrete
-          return t_model.getConcreteModelObjects<_name>(sorted);
+          return t_model.getConcreteModelObjects<_name>();
         %#else
-          return t_model.getModelObjects<_name>(sorted);
+          return t_model.getModelObjects<_name>();
         %#endif
       }
       boost::optional<_name> get##_name##ByName(const Model &t_model, const std::string &t_name) {


### PR DESCRIPTION
Reverts NREL/OpenStudio#4010

Need to roll back this commit as the Windows build failed which appears to be due to csharp issue. 
See build of commit: [0607f8775e3ec1049b9b618b84ddaf0a34788011](https://github.com/NREL/OpenStudio/commit/0607f8775e3ec1049b9b618b84ddaf0a34788011)  
and the CI for this build  -  https://ci.commercialbuildings.dev/blue/organizations/jenkins/openstudio-develop-nightly/detail/openstudio-develop-nightly/554/pipeline/ 
 
The previous commit [e876c5a269c0fd7a766f4afd0fa46379bc3228e1](https://github.com/NREL/OpenStudio/commit/e876c5a269c0fd7a766f4afd0fa46379bc3228e1) 
is clean on Windows - https://ci.commercialbuildings.dev/blue/organizations/jenkins/openstudio-develop-nightly/detail/openstudio-develop-nightly/552/pipeline


