### PR TITLE
Fix #4014 download from BCL

### DIFF
--- a/src/cli/test/bundle_git/test.rb
+++ b/src/cli/test/bundle_git/test.rb
@@ -25,4 +25,4 @@ begin
 rescue LoadError
   did_fail = true
 end
-raise "Should not load openstudio-standards" unless did_fail == true
+raise "Should allow to load the embedded openstudio-standards" unless did_fail == false

--- a/src/utilities/bcl/RemoteBCL.cpp
+++ b/src/utilities/bcl/RemoteBCL.cpp
@@ -64,6 +64,9 @@ namespace openstudio{
   // as it will allow us to change http_client_config (SSL settings etc) in  only one place
   web::http::client::http_client RemoteBCL::getClient(const std::string& url) const {
     web::http::client::http_client_config config;
+    // bcl.nrel.gov can be slow to respond to client requests so bump the default of 30 seconds to 60 to account for lengthy response time.  
+    // this is timeout is for each send and receive operation on the client and not the entire client session. 
+    config.set_timeout(std::chrono::seconds(60));
     config.set_validate_certificates(false);
 
     return web::http::client::http_client(utility::conversions::to_string_t(url), config);


### PR DESCRIPTION
Fixes #4014 

Seems host `bcl.nrel.gov` can be slow to download for certain bcl components. For instance, in our unit tests, component `a10331a0-edc7-0131-840c-48e0eb16a403` can exceed the cpprestsdk default 30 sec response time which closes the client handle and results in a unit test failure.  

You can manually reproduce the slow response time by running a simple wget to the api endpoint for that component: 

`wget https://bcl.nrel.gov/api/component/download?uids=a10331a0-edc7-0131-840c-48e0eb16a403 `

This can change of course due to client/server network speeds.   

Increasing from 30 to 60 seems to fix.  

