### PR TITLE
Addresses #3578, warning message when running measure test 'Cannot find current Workflow Step'

### DIFF
--- a/src/measure/OSRunner.cpp
+++ b/src/measure/OSRunner.cpp
@@ -270,6 +270,7 @@ void OSRunner::prepareForMeasureRun(const OSMeasure& measure) {
   }
   boost::optional<WorkflowStep> currentStep = m_workflow.currentStep();
   if (!currentStep){
+    // run a measure that isn't listed in the workflow
     LOG(Info, "Cannot find current Workflow Step");
   }
 

--- a/src/measure/OSRunner.cpp
+++ b/src/measure/OSRunner.cpp
@@ -270,8 +270,7 @@ void OSRunner::prepareForMeasureRun(const OSMeasure& measure) {
   }
   boost::optional<WorkflowStep> currentStep = m_workflow.currentStep();
   if (!currentStep){
-    LOG(Error, "Cannot find current Workflow Step");
-    return;
+    LOG(Info, "Cannot find current Workflow Step");
   }
 
   m_startedStep = true;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #3578

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
