### PR TITLE
Fix #4016 - Move VT from 2.9.0 to 3.0.0 for new fields at end of the ZoneHVAC:TerminalUnit:VariableRefrigerantFlow

### DIFF
--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -4717,31 +4717,6 @@ std::string VersionTranslator::update_2_8_1_to_2_9_0(const IdfFile& idf_2_8_1, c
       m_refactored.push_back(RefactoredObjectData(object, newObject));
       ss << newObject;
 
-
-    } else if (iddname == "OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow") {
-      auto iddObject = idd_2_9_0.getObject("OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow");
-      IdfObject newObject(iddObject.get());
-
-      // Added fields at end, so copy everything existing in place
-      for (size_t i = 0; i < object.numFields(); ++i) {
-        if ((value = object.getString(i))) {
-          newObject.setString(i, value.get());
-        }
-      }
-
-      // 21 = AVM List
-      // 22 = Design Spec ZoneHVAC Sizing
-      // 23 = Supplemental Heating Coil (optional)
-      // Maximum SAT for Supplemental Heater
-      newObject.setString(24, "Autosize");
-      // Maximum OATdb for Supplemental Heater
-      newObject.setDouble(25, 21.0);
-
-      // Register refactored
-      m_refactored.push_back(RefactoredObjectData(object, newObject));
-      ss << newObject;
-
-
     // Four fields were added but only the last (End Use Subcat) was implemented, but withotu transition rules either
     } else if ((iddname == "OS:HeaderedPumps:ConstantSpeed") || (iddname == "OS:HeaderedPumps:VariableSpeed")) {
       auto iddObject = idd_2_9_0.getObject(iddname);
@@ -5223,6 +5198,31 @@ std::string VersionTranslator::update_2_9_1_to_3_0_0(const IdfFile& idf_2_9_1, c
       // Two fields were plain added to the end: Design Zone Secondary Recirculation Fraction,
       // and  Design Minimum Zone Ventilation Efficiency, but both are optional (has default) so no-op there
 
+      m_refactored.push_back(RefactoredObjectData(object, newObject));
+      ss << newObject;
+
+    } else if (iddname == "OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow") {
+      // Note #3687 was originally planned for 2.9.0 inclusion, so VT was there. But it was only merged to develop3 and hence relased in 3.0.0
+      // Moving it in the right location, as needed per #4016
+      auto iddObject = idd_3_0_0.getObject("OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow");
+      IdfObject newObject(iddObject.get());
+
+      // Added fields at end, so copy everything existing in place
+      for (size_t i = 0; i < object.numFields(); ++i) {
+        if ((value = object.getString(i))) {
+          newObject.setString(i, value.get());
+        }
+      }
+
+      // 21 = AVM List
+      // 22 = Design Spec ZoneHVAC Sizing
+      // 23 = Supplemental Heating Coil (optional)
+      // Maximum SAT for Supplemental Heater
+      newObject.setString(24, "Autosize");
+      // Maximum OATdb for Supplemental Heater
+      newObject.setDouble(25, 21.0);
+
+      // Register refactored
       m_refactored.push_back(RefactoredObjectData(object, newObject));
       ss << newObject;
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4016 
- Move VT from 2.9.0 to 3.0.0 for new fields at end of the ZoneHVAC:TerminalUnit:VariableRefrigerantFlow

**Tested via the failing component in #4016**

```
wget https://raw.githubusercontent.com/DavidGoldwasser/PAT_projects/os30_upgrade/PAT_SDDC_PrimarySchool/measures/zedgk_12_hvac_vrf_with_doas/resources/VRF_Terminal.osc
```

```
p = 'VRF_Terminal.osc'
vt = OpenStudio::OSVersion::VersionTranslator.new
new_objectComponent = vt.loadComponent(OpenStudio::Path.new(p))
object = new_objectComponent.get.primaryObject
puts object
```

Before:

```
OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
  {4e15e1b4-659e-4025-9dfa-d9886f97eced}, !- Handle
  VRF Terminal Unit,                      !- Name
  {a62ea42d-ebe7-405e-a7fd-a4a18662a939}, !- Terminal Unit Availability schedule
  ,                                       !- Terminal Unit Air Inlet Node
  ,                                       !- Terminal Unit Air Outlet Node
  0.2,                                    !- Supply Air Flow Rate During Cooling Operation {m3/s}
  autosize,                               !- Supply Air Flow Rate When No Cooling is Needed {m3/s}
  0.2,                                    !- Supply Air Flow Rate During Heating Operation {m3/s}
  autosize,                               !- Supply Air Flow Rate When No Heating is Needed {m3/s}
  autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
  autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
  autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
  {a62ea42d-ebe7-405e-a7fd-a4a18662a939}, !- Supply Air Fan Operating Mode Schedule
  ,                                       !- Supply Air Fan placement
  {2c002f23-1469-41f7-919f-735fb7091339}, !- Supply Air Fan
  ,                                       !- Outside Air Mixer
  {c25f7f69-6b16-4bbc-a394-dfe502fe30b7}, !- Cooling Coil
  {68998874-fdb3-46f0-baf4-5aa2765f1978}, !- Heating Coil
  30,                                     !- Zone Terminal Unit On Parasitic Electric Energy Use {W}
  20,                                     !- Zone Terminal Unit Off Parasitic Electric Energy Use {W}
  1,                                      !- Rated Total Heating Capacity Sizing Ratio {W/W}
  ,                                       !- Availability Manager List Name
  ,                                       !- Design Specification ZoneHVAC Sizing Object Name
  ,                                       !- Supplemental Heating Coil Name
  ,                                       !- Maximum Supply Air Temperature from Supplemental Heater {C}
  ;                                       !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
```

After:
```
OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
  {4e15e1b4-659e-4025-9dfa-d9886f97eced}, !- Handle
  VRF Terminal Unit,                      !- Name
  {a62ea42d-ebe7-405e-a7fd-a4a18662a939}, !- Terminal Unit Availability schedule
  ,                                       !- Terminal Unit Air Inlet Node
  ,                                       !- Terminal Unit Air Outlet Node
  0.2,                                    !- Supply Air Flow Rate During Cooling Operation {m3/s}
  autosize,                               !- Supply Air Flow Rate When No Cooling is Needed {m3/s}
  0.2,                                    !- Supply Air Flow Rate During Heating Operation {m3/s}
  autosize,                               !- Supply Air Flow Rate When No Heating is Needed {m3/s}
  autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
  autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
  autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
  {a62ea42d-ebe7-405e-a7fd-a4a18662a939}, !- Supply Air Fan Operating Mode Schedule
  ,                                       !- Supply Air Fan placement
  {2c002f23-1469-41f7-919f-735fb7091339}, !- Supply Air Fan
  ,                                       !- Outside Air Mixer
  {c25f7f69-6b16-4bbc-a394-dfe502fe30b7}, !- Cooling Coil
  {68998874-fdb3-46f0-baf4-5aa2765f1978}, !- Heating Coil
  30,                                     !- Zone Terminal Unit On Parasitic Electric Energy Use {W}
  20,                                     !- Zone Terminal Unit Off Parasitic Electric Energy Use {W}
  1,                                      !- Rated Total Heating Capacity Sizing Ratio {W/W}
  ,                                       !- Availability Manager List Name
  ,                                       !- Design Specification ZoneHVAC Sizing Object Name
  ,                                       !- Supplemental Heating Coil Name
  Autosize,                               !- Maximum Supply Air Temperature from Supplemental Heater {C}
  21;                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
```
### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [x] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
