### PR TITLE
Fix #4038 - Re-enable `-Wall` on Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,12 +410,10 @@ endif()
 # Compiler and system specific options
 if(UNIX)
 
-  #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -fno-strict-aliasing")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -fno-strict-aliasing")
 
   # all warnings
-  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -fno-strict-aliasing -Winvalid-pch -Wnon-virtual-dtor")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fPIC -fno-strict-aliasing -Winvalid-pch")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -fno-strict-aliasing -Winvalid-pch -Wnon-virtual-dtor")
   # Treat all warnings as errors
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   if(APPLE)

--- a/ProjectMacros.cmake
+++ b/ProjectMacros.cmake
@@ -318,7 +318,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
       # Prevent excessive warnings from generated swig files, suppress deprecated declarations
       # Suppress 'register' storage class specified warnings (coming from Ruby)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-sometimes-uninitialized")
     else()
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-conversion-null")
     endif()
@@ -517,7 +517,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES SUFFIX ".pyd")
     elseif(UNIX)
       if(APPLE AND NOT CMAKE_COMPILER_IS_GNUCXX)
-        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
       else()
         set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare")
       endif()
@@ -756,7 +756,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /wd4996") ## /wd4996 suppresses deprecated warnings
       set(final_name "${JAVA_OUTPUT_NAME}.dll")
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
     endif()
 
     target_link_libraries(${swig_target} ${PARENT_TARGET} ${JAVA_JVM_LIBRARY})
@@ -885,7 +885,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if(MSVC)
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /DBUILDING_NODE_EXTENSION /wd4996")  ## /wd4996 suppresses deprecated warnings
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
     endif()
 
     if(APPLE)

--- a/ProjectMacros.cmake
+++ b/ProjectMacros.cmake
@@ -318,7 +318,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
       # Prevent excessive warnings from generated swig files, suppress deprecated declarations
       # Suppress 'register' storage class specified warnings (coming from Ruby)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-sometimes-uninitialized")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-sometimes-uninitialized -Wno-misleading-indentation")
     else()
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-conversion-null")
     endif()
@@ -517,7 +517,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES SUFFIX ".pyd")
     elseif(UNIX)
       if(APPLE AND NOT CMAKE_COMPILER_IS_GNUCXX)
-        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
       else()
         set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare")
       endif()
@@ -756,7 +756,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /wd4996") ## /wd4996 suppresses deprecated warnings
       set(final_name "${JAVA_OUTPUT_NAME}.dll")
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
     endif()
 
     target_link_libraries(${swig_target} ${PARENT_TARGET} ${JAVA_JVM_LIBRARY})
@@ -885,7 +885,7 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if(MSVC)
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /DBUILDING_NODE_EXTENSION /wd4996")  ## /wd4996 suppresses deprecated warnings
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
     endif()
 
     if(APPLE)
@@ -1051,4 +1051,3 @@ macro(CONFIGURE_FILE_WITH_CHECKSUM INPUT_FILE OUTPUT_FILE)
     endif()
   endif()
 endmacro()
-

--- a/ProjectMacros.cmake
+++ b/ProjectMacros.cmake
@@ -318,9 +318,9 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
       # Prevent excessive warnings from generated swig files, suppress deprecated declarations
       # Suppress 'register' storage class specified warnings (coming from Ruby)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-sometimes-uninitialized -Wno-misleading-indentation")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-sometimes-uninitialized")
     else()
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-conversion-null")
+      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-register -Wno-conversion-null -Wno-misleading-indentation")
     endif()
   endif()
 
@@ -517,9 +517,9 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES SUFFIX ".pyd")
     elseif(UNIX)
       if(APPLE AND NOT CMAKE_COMPILER_IS_GNUCXX)
-        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-dynamic-class-memaccess -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
       else()
-        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-misleading-indentation")
       endif()
     endif()
 
@@ -756,7 +756,12 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /wd4996") ## /wd4996 suppresses deprecated warnings
       set(final_name "${JAVA_OUTPUT_NAME}.dll")
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
+      # If 'AppleClang' or 'Clang'
+      if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
+      else()
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-sign-compare -Wno-misleading-indentation")
+      endif()
     endif()
 
     target_link_libraries(${swig_target} ${PARENT_TARGET} ${JAVA_JVM_LIBRARY})
@@ -885,7 +890,12 @@ macro(MAKE_SWIG_TARGET NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGET PARENT_S
     if(MSVC)
       set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "/bigobj /DBUILDING_NODE_EXTENSION /wd4996")  ## /wd4996 suppresses deprecated warnings
     elseif(UNIX)
-      set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized -Wno-misleading-indentation")
+      # If 'AppleClang' or 'Clang'
+      if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clang$")
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-sometimes-uninitialized")
+      else()
+        set_target_properties(${swig_target} PROPERTIES COMPILE_FLAGS "-DBUILDING_NODE_EXTENSION -Wno-deprecated-declarations -Wno-sign-compare -Wno-misleading-indentation")
+      endif()
     endif()
 
     if(APPLE)

--- a/src/cli/RubyInterpreter.hpp
+++ b/src/cli/RubyInterpreter.hpp
@@ -693,8 +693,8 @@ class RubyInterpreter
 {
   private:
     // dummy arguments passed to ruby_options
-    int m_argc;
-    char** m_argv;
+    // int m_argc;
+    // char** m_argv;
 
     static void addIncludePath(std::vector<std::string>& includePaths, const std::string& includePath)
     {

--- a/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateTableMultiVariableLookup.cpp
@@ -64,7 +64,7 @@ boost::optional<IdfObject> ForwardTranslator::translateTableMultiVariableLookup(
   std::string interpolationMethod = modelObject.interpolationMethod();
 
   int numberofIndependentVariables = modelObject.numberofIndependentVariables();
-  int expectedNumberOfValues = 1;
+  unsigned expectedNumberOfValues = 1;
   for (int i = 0; i < numberofIndependentVariables; ++i) {
     auto xValues = modelObject.xValues(i);
     auto sizeX = xValues.size();

--- a/src/energyplus/ReverseTranslator/ReverseTranslateFanSystemModel.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateFanSystemModel.cpp
@@ -189,7 +189,7 @@ boost::optional<ModelObject> ReverseTranslator::translateFanSystemModel( const W
 
   boost::optional<int> _numberofSpeeds = workspaceObject.getInt(Fan_SystemModelFields::NumberofSpeeds);
   int nExts = extensibleGroups.size();
-  int nspeeds;
+  int nspeeds = 0;
   if (_numberofSpeeds) {
     nspeeds = _numberofSpeeds.get();
     if (nExts < nspeeds) {

--- a/src/model/FanSystemModel.cpp
+++ b/src/model/FanSystemModel.cpp
@@ -615,6 +615,7 @@ namespace detail {
 
   void FanSystemModel_Impl::resetElectricPowerFunctionofFlowFractionCurve() {
     bool result = setString(OS_Fan_SystemModelFields::ElectricPowerFunctionofFlowFractionCurveName, "");
+    OS_ASSERT(result);
   }
 
   bool FanSystemModel_Impl::setNightVentilationModePressureRise(double nightVentilationModePressureRise) {

--- a/src/model/OutputTableSummaryReports.cpp
+++ b/src/model/OutputTableSummaryReports.cpp
@@ -146,11 +146,11 @@ namespace detail {
   }
 
   bool OutputTableSummaryReports_Impl::addSummaryReports(const std::vector<std::string>& summaryReports) {
-    unsigned int num = numberofSummaryReports();
+    bool result = true;
     for (std::string summaryReport : summaryReports) {
-      addSummaryReport(summaryReport);
+      result &= addSummaryReport(summaryReport);
     }
-    return true;
+    return result;
   }
 
   boost::optional<unsigned> OutputTableSummaryReports_Impl::summaryReportIndex(const std::string& summaryReport) const {

--- a/src/model/ShadowCalculation.cpp
+++ b/src/model/ShadowCalculation.cpp
@@ -116,7 +116,6 @@ namespace detail {
   }
 
   int ShadowCalculation_Impl::shadingCalculationUpdateFrequency() const {
-    int i = OS_ShadowCalculationFields::DisableSelfShadingWithinShadingZoneGroups;
     boost::optional<int> value = getInt(OS_ShadowCalculationFields::ShadingCalculationUpdateFrequency,true);
     OS_ASSERT(value);
     return value.get();

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -4900,7 +4900,7 @@ std::string VersionTranslator::update_2_9_1_to_3_0_0(const IdfFile& idf_2_9_1, c
     return false;
   };
 
-  auto replaceForField = [&ss, &replaceFuelTypesMap](const IdfObject& object, IdfObject& newObject, int fieldIndex) -> void {
+  auto replaceForField = [&replaceFuelTypesMap](const IdfObject& object, IdfObject& newObject, int fieldIndex) -> void {
       if (boost::optional<std::string> _fuelType = object.getString(fieldIndex)) {
         auto it = replaceFuelTypesMap.find(_fuelType.get());
         if (it != replaceFuelTypesMap.end()) {

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -4892,7 +4892,7 @@ std::string VersionTranslator::update_2_9_1_to_3_0_0(const IdfFile& idf_2_9_1, c
       // {"OS:Boiler:HotWater", 2},  // Fuel Type
   });
 
-  auto checkIfReplaceNeeded = [this, replaceFuelTypesMap](const IdfObject& object, int fieldIndex) -> bool {
+  auto checkIfReplaceNeeded = [replaceFuelTypesMap](const IdfObject& object, int fieldIndex) -> bool {
     // std::map::contains() only in C++20
     if (boost::optional<std::string> _fuelType = object.getString(fieldIndex)) {
       return replaceFuelTypesMap.find(_fuelType.get()) != replaceFuelTypesMap.end();
@@ -4900,7 +4900,7 @@ std::string VersionTranslator::update_2_9_1_to_3_0_0(const IdfFile& idf_2_9_1, c
     return false;
   };
 
-  auto replaceForField = [this, &ss, &replaceFuelTypesMap](const IdfObject& object, IdfObject& newObject, int fieldIndex) -> void {
+  auto replaceForField = [&ss, &replaceFuelTypesMap](const IdfObject& object, IdfObject& newObject, int fieldIndex) -> void {
       if (boost::optional<std::string> _fuelType = object.getString(fieldIndex)) {
         auto it = replaceFuelTypesMap.find(_fuelType.get());
         if (it != replaceFuelTypesMap.end()) {

--- a/src/sdd/MapHVAC.cpp
+++ b/src/sdd/MapHVAC.cpp
@@ -5386,9 +5386,9 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateFlui
   boost::optional<model::ThermalStorageChilledWaterStratified> thermalStorage;
   std::string thermalStorageDischargePriority;
   boost::optional<model::ScheduleRuleset> tesSchedule;
-  // TODO: this variable will be used un-initialized in case the "TankSetptTemp" child key is ill-formed (not present or, doesn't cast to double)
-  // Set a default or something
-  double thermalStorageTankSetptTemp;
+  // Note: this variable will be used un-initialized in case the "TankSetptTemp" child key is ill-formed (not present or, doesn't cast to double)
+  // Setting to a default of 7.5 per E+ example 5ZoneVAV-ChilledWaterStorage-Stratified.idf
+  double thermalStorageTankSetptTemp = 7.5;
   if( auto mo = translateThrmlEngyStor(thrmlEngyStorElement, model) ) {
     thermalStorage = mo->cast<model::ThermalStorageChilledWaterStratified>();
     plantLoop.addSupplyBranchForComponent(thermalStorage.get());
@@ -5400,6 +5400,9 @@ boost::optional<openstudio::model::ModelObject> ReverseTranslator::translateFlui
     boost::optional<double> _tankSetptTemp = lexicalCastToDouble(tankSetptTempElement);
     if (_tankSetptTemp) {
       thermalStorageTankSetptTemp = unitToUnit(_tankSetptTemp.get(),"F","C").get();
+    } else {
+      LOG(Warn, "Missing TankSetptTemp (or bad cast to double) for '" << thermalStorage->briefDescription()
+             << ", defaulting to " << thermalStorageTankSetptTemp << " C.");
     }
 
     // charging scheme, which is a component setpoint scheme so we add SPMs

--- a/src/utilities/data/Attribute.cpp
+++ b/src/utilities/data/Attribute.cpp
@@ -612,7 +612,7 @@ namespace detail {
       ss << *p;
     }  else if (auto * p = std::get_if<std::string>(&m_value)) {
       ss << *p;
-    } else if (auto * p = std::get_if<std::vector<Attribute>>(&m_value)) {
+    } else if (std::get_if<std::vector<Attribute>>(&m_value)) {
       // Call toXml() and save to the stringstream
       this->toXml().save(ss, "  ");
     }

--- a/src/utilities/geometry/RoofGeometry_Details.hpp
+++ b/src/utilities/geometry/RoofGeometry_Details.hpp
@@ -28,6 +28,7 @@
 
 #include "Geometry.hpp"
 #include "Vector3d.hpp"
+#include "Point3d.hpp"
 #include <boost/optional.hpp>
 #include <boost/math/constants/constants.hpp>
 
@@ -2381,7 +2382,7 @@ static void removeEmptyLav(std::vector< std::vector< std::shared_ptr<Vertex> > >
   }
 }
 
-static std::vector< std::vector<Point3d> > doStraightSkeleton(std::vector<Point3d>& polygon, double roofPitchDegrees) {
+[[maybe_unused]] static std::vector< std::vector<Point3d> > doStraightSkeleton(std::vector<Point3d>& polygon, double roofPitchDegrees) {
 
   /* Straight skeleton algorithm implementation. Based on highly modified Petr
   * Felkel and Stepan Obdrzalek algorithm.
@@ -2716,7 +2717,7 @@ static void applyGableLogicTwoRidgesTwoOppositeAngles(std::vector< std::vector<P
 
 }
 
-static void applyGables(std::vector< std::vector<Point3d> >& surfaces) {
+[[maybe_unused]] static void applyGables(std::vector< std::vector<Point3d> >& surfaces) {
   // Convert hip roof to gable roof
 
   // Simple logic
@@ -2776,7 +2777,7 @@ static std::vector<Point3d> getShedLine(std::vector<Point3d>& polygon, double di
   return line;
 }
 
-static std::vector< std::vector<Point3d> > doShedRoof(std::vector<Point3d>& polygon, double roofPitchDegrees, double directionDegrees) {
+[[maybe_unused]] static std::vector< std::vector<Point3d> > doShedRoof(std::vector<Point3d>& polygon, double roofPitchDegrees, double directionDegrees) {
   std::vector< std::vector<Point3d> > surfaces;
 
   double zcoord = initPolygon(polygon);

--- a/src/utilities/geometry/RoofGeometry_Details.hpp
+++ b/src/utilities/geometry/RoofGeometry_Details.hpp
@@ -708,7 +708,6 @@ public:
 
 private:
   REGISTER_LOGGER("utilities.QueueEvent");
-  bool obsolete = false;
 };
 
 class Chain // Chains of queue events

--- a/src/utilities/sql/Test/SqlFile_GTest.cpp
+++ b/src/utilities/sql/Test/SqlFile_GTest.cpp
@@ -414,7 +414,7 @@ void regressionTestSqlFile(const std::string& name, double netSiteEnergy, double
   ASSERT_FALSE(availableEnvPeriods.empty());
   EXPECT_EQ(static_cast<unsigned>(3), availableEnvPeriods.size());
   std::string availableEnvPeriod;
-  for (int i = 0; i < availableEnvPeriods.size(); i++)
+  for (size_t i = 0; i < availableEnvPeriods.size(); i++)
   {
     if (availableEnvPeriods[i].find("CONDNS") == std::string::npos) {
       availableEnvPeriod = availableEnvPeriods[i];

--- a/src/utilities/units/test/OSQuantityVector_GTest.cpp
+++ b/src/utilities/units/test/OSQuantityVector_GTest.cpp
@@ -104,7 +104,7 @@ TEST_F(UnitsFixture,OSQuantityVector_MathematicalOperators) {
   ASSERT_EQ(2u,resultVec.size());
   EXPECT_EQ(resultQ,resultVec.getQuantity(0));
   EXPECT_EQ(resultQ,resultVec.getQuantity(1));
-  EXPECT_EQ(0.0,resultQ.value());
+  EXPECT_EQ(-3.5,resultQ.value());
 
   resultVec = testVec1 - testVec2;
   resultQ = testQ1 - testQ2;

--- a/src/utilities/units/test/OSQuantityVector_GTest.cpp
+++ b/src/utilities/units/test/OSQuantityVector_GTest.cpp
@@ -98,9 +98,9 @@ TEST_F(UnitsFixture,OSQuantityVector_MathematicalOperators) {
 
   // basic subtraction
   resultVec = testVec1;
-  resultVec -= resultVec;
+  resultVec -= 2*resultVec;
   resultQ = testQ1;
-  resultQ -= resultQ;
+  resultQ -= 2*resultQ;
   ASSERT_EQ(2u,resultVec.size());
   EXPECT_EQ(resultQ,resultVec.getQuantity(0));
   EXPECT_EQ(resultQ,resultVec.getQuantity(1));


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4038
- Re-enable `-Wall` on Unix

I started doing this on #4037 but I'm having some mac-specific (apple-clang) warnings, so better to separate them in two PRs.



### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
