### PR TITLE
Bump conan min version to 1.28 or sqlite3 recipe will throw an error

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -23,7 +23,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
 
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-  conan_check(VERSION 1.21.0 REQUIRED)
+  conan_check(VERSION 1.28.0 REQUIRED)
 
   message(STATUS "openstudio: RUNNING CONAN")
 


### PR DESCRIPTION
Pull request overview
---------------------

At least developpers will get a clear error indicated that they need to upgrade their conan version instead of being puzzled by this error

```
ERROR: sqlite3/3.30.1: Error in package_info() method, line 116
	self.cpp_info.filenames["cmake_find_package"] = "SQLite3"
	TypeError: '_CppInfo' object does not support item assignment
```

Here's the change in the recipe: https://github.com/conan-io/conan-center-index/pull/2350/files (merged 2 hours ago)


CI will likely need updated instances too @tijcolem. I'll launch a build to make sure