### PR TITLE
Pin the actual recipe revisions for all conan dependencies

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -37,16 +37,30 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   #conan_add_remote(NAME jmarrec
   #  URL https://api.bintray.com/conan/jmarrec/testing)
 
+  # Enable revisions in conan
+  execute_process(
+    COMMAND ${CONAN_CMD} config get general.revisions_enabled
+    OUTPUT_VARIABLE CONAN_REV_STATUS
+    ERROR_VARIABLE CONAN_REV_STATUS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  message(STATUS "Conan: config get general.revisions_enabled=${CONAN_REV_STATUS}")
+  if (NOT "${CONAN_REV_STATUS}" STREQUAL "True")
+    message(AUTHOR_WARNING "Conan: Force enabling revisions (conan config set general.revisions_enabled=True)")
+    execute_process(COMMAND ${CONAN_CMD} config set general.revisions_enabled=True)
+  endif()
+
   list(APPEND CONAN_OPTIONS "zlib:minizip=True")
   # TODO:  list(APPEND CONAN_OPTIONS "fmt:header_only=True")
 
   # You do want to rebuild packages if there's a newer recipe in the remote (which applies mostly to our own openstudio_ruby where we don't
   # bump the actual package version when we make changes) than the binaries were built with
   # 'outdated' also acts like 'missing': if no binary, will build them.
-  list(APPEND CONAN_BUILD "outdated")
+  # list(APPEND CONAN_BUILD "outdated")
+  list(APPEND CONAN_BUILD "missing")
 
   if (BUILD_TESTING)
-    set(CONAN_GTEST "gtest/1.10.0")
+    set(CONAN_GTEST "gtest/1.10.0#ef88ba8e54f5ffad7d706062d0731a40")
   else()
     set(CONAN_GTEST "")
   endif()
@@ -57,29 +71,30 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   conan_cmake_run(REQUIRES
     ${CONAN_READLINE}
     ${CONAN_QT}
-    openssl/1.1.0l # ruby 2.5.5 won't work with 1.1.1x, so use 1.1.0l here to try to force every package to align on the same as ruby
+    "openssl/1.1.0l#7f3fa5cfcfba31fffa344c71a9795176" # ruby 2.5.5 won't work with 1.1.1x, so use 1.1.0l here to try to force every package to align on the same as ruby
     # Track NREL/stable in general, on a feature branch this could be temporarily switched to NREL/testing
-    openstudio_ruby/2.5.5@nrel/stable    # TODO: Temp #@nrel/stable
-    boost/1.73.0
-    pugixml/1.10
-    jsoncpp/1.9.3
-    zlib/1.2.11
-    fmt/7.0.1
-    sqlite3/3.32.3
-    cpprestsdk/2.10.16
-    websocketpp/0.8.2
-    geographiclib/1.50.1
-    swig/4.0.2
+    "openstudio_ruby/2.5.5@nrel/stable#dcdbeda50b48bbd0b2bf3dd1612b3896"    # TODO: Temp #@nrel/stable
+    "boost/1.73.0#4129a76c9b83c300fc103e36d1908792"
+    "pugixml/1.10#64b3ebc897bb9d9854c8a2443bf112a8"
+    "jsoncpp/1.9.3#073a6d3cb40911d7c8027bddb6ae7dbf"
+    "zlib/1.2.11#0df31fd24179543f5720ec7beb2a88d7"
+    "fmt/7.0.1#0580b1492b1dddb43b1768e68f25c43c"
+    "sqlite3/3.32.3#914492672c458f8be511e3800c14c717"
+    "cpprestsdk/2.10.16#d097ff9a8719d9d0ed34293c2ebd90ed"
+    "websocketpp/0.8.2#6d77b9b8a2368fa5fd5377af0c0ca211"
+    "geographiclib/1.50.1#b1a7966385dead17ec170b25a99cf71b"
+    "swig/4.0.2#bfafb16cd2bea6af3b8003163abcbd09"
     ${CONAN_GTEST}
 
     # Override to avoid dependency mismatches
-    bzip2/1.0.8
+    #"bzip2/1.0.8#d4a5c7144832d75fc3f349c5346160b0"
+    #"libyaml/0.2.5#9e234874df88c3ba7249f6d1368fceaf"
     BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
     OPTIONS ${CONAN_OPTIONS}
     BUILD ${CONAN_BUILD}
     # Passes `-u, --update`    to conan install: Check updates exist from upstream remotes
     # That and build=outdated should ensure we track the right
-    UPDATE
+    # UPDATE
   )
 
   set(CONAN_OPENSTUDIO_ALREADY_RUN TRUE)

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -94,7 +94,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     BUILD ${CONAN_BUILD}
     # Passes `-u, --update`    to conan install: Check updates exist from upstream remotes
     # That and build=outdated should ensure we track the right
-    # UPDATE
+    UPDATE
   )
 
   set(CONAN_OPENSTUDIO_ALREADY_RUN TRUE)

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -37,7 +37,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   #conan_add_remote(NAME jmarrec
   #  URL https://api.bintray.com/conan/jmarrec/testing)
 
-  # Enable revisions in conan
+  # Enable revisions in conan: check if they are already enabled, if not do it an warn user
   execute_process(
     COMMAND ${CONAN_CMD} config get general.revisions_enabled
     OUTPUT_VARIABLE CONAN_REV_STATUS


### PR DESCRIPTION
Pro: we have zero chance of pulling something else. Fully reproducible builds


Cons: whenever we want to update a dependency, we'll have to bump the revision in OpenStudio/ConanInstall.cmake

If we do not pin dependencies, we could simply upload a new recipe revision, and delete the old one from the remote, or pass UPDATE to conan cmake run. I don't like passing UPDATE to conan_cmake_run actually  because it has to query bintray for changes everytime you run cmake (which takes time, doesn't work offline, etc)


Note: the pinning of deps really matter a lot of openstuido_ruby but not so much for the rest of the deps. Because we're unlikely going to bump a dep like boost for no reason without also bumping the version (eg boost/1.74...)