### PR TITLE
Fix #4060 Cloning a DualDuct AirLoopHVAC breaks the existing loop

### DIFF
--- a/src/model/AirLoopHVAC.cpp
+++ b/src/model/AirLoopHVAC.cpp
@@ -721,39 +721,99 @@ namespace model {
 
       airLoopClone.getImpl<detail::AirLoopHVAC_Impl>()->createTopology();
 
-      auto supplyComps = supplyComponents();
-      auto outletNodeClone = airLoopClone.supplyOutletNode();
-      std::vector<Node> supplyNodes;
+      struct HVACPath
+      {
+        HVACPath(const HVACComponent& t_originalStart, const HVACComponent& t_originalEnd, const HVACComponent& t_clonedStartOrEndOfPath,
+                 const Node& t_clonedAddNode, bool t_reverse)
+          : originalStart(t_originalStart),
+            originalEnd(t_originalEnd),
+            clonedStartOrEndOfPath(t_clonedStartOrEndOfPath),
+            clonedAddNode(t_clonedAddNode),
+            reverse(t_reverse){};
 
-      for (const auto& comp : supplyComps) {
-        if (comp.iddObjectType() == Node::iddObjectType()) {
-          supplyNodes.push_back(comp.cast<Node>());
-        } else {
-          auto compClone = comp.clone(model).cast<HVACComponent>();
-          compClone.addToNode(outletNodeClone);
-          // If the original component was also on a PlantLoop
-          if (boost::optional<HVACComponent> hvacComp = comp.optionalCast<HVACComponent>()) {
-            if (boost::optional<PlantLoop> pl = hvacComp->plantLoop()) {
-              // Connect the clone to the plantLoop too
-              pl->addDemandBranchForComponent(compClone);
+        HVACComponent originalStart;
+        HVACComponent originalEnd;
+        HVACComponent clonedStartOrEndOfPath;  // If reverse is false, it's the start, if reverse is true, it's the end
+        Node clonedAddNode;
+        bool reverse;
+      };
+
+      std::vector<HVACPath> pathsToHandle;
+
+      if (isDualDuct()) {
+        // Add the Splitter to make it a dual duct
+        auto supplyInletNodeClone = airLoopClone.supplyInletNode();
+        ConnectorSplitter supplySplitterClone(model);
+        supplySplitterClone.addToNode(supplyInletNodeClone);
+        airLoopClone.getImpl<detail::AirLoopHVAC_Impl>()->setSupplySplitter(supplySplitterClone);
+
+        auto supplyOutletNodeClones = airLoopClone.supplyOutletNodes();
+
+        auto supplySplitter = this->supplySplitter().get();
+        auto supplyInletNode = this->supplyInletNode();
+        auto supplyOutletNodes = this->supplyOutletNodes();
+
+        pathsToHandle.emplace_back(supplyInletNode, supplySplitter, supplySplitterClone, supplyInletNodeClone, true);
+        pathsToHandle.emplace_back(supplySplitter, supplyOutletNodes[0], supplySplitterClone, supplyOutletNodeClones[0], false);
+        pathsToHandle.emplace_back(supplySplitter, supplyOutletNodes[1], supplySplitterClone, supplyOutletNodeClones[1], false);
+
+      } else {
+
+        pathsToHandle.emplace_back(this->supplyInletNode(), this->supplyOutletNode(), airLoopClone.supplyInletNode(), airLoopClone.supplyOutletNode(),
+                                   false);
+      }
+
+      for (const auto& path : pathsToHandle) {
+
+        auto supplyComps = supplyComponents(path.originalStart, path.originalEnd);
+        if (path.reverse) {
+          std::reverse(supplyComps.begin(), supplyComps.end());
+        }
+        auto clonedAddNode = path.clonedAddNode;
+        std::vector<Node> supplyNodes;
+
+        for (const auto& comp : supplyComps) {
+          if (comp.iddObjectType() == Node::iddObjectType()) {
+            supplyNodes.push_back(comp.cast<Node>());
+            // Don't want to clone the splitter...
+          } else if (comp.iddObjectType() != ConnectorSplitter::iddObjectType()) {
+            auto compClone = comp.clone(model).cast<HVACComponent>();
+            compClone.addToNode(clonedAddNode);
+            // If the original component was also on a PlantLoop
+            if (boost::optional<HVACComponent> hvacComp = comp.optionalCast<HVACComponent>()) {
+              if (boost::optional<PlantLoop> pl = hvacComp->plantLoop()) {
+                // Connect the clone to the plantLoop too
+                pl->addDemandBranchForComponent(compClone);
+              }
             }
+          }
+        }
+
+        std::vector<ModelObject> supplyCompClones;
+
+        if (path.reverse) {
+          supplyCompClones = airLoopClone.supplyComponents(path.clonedAddNode, path.clonedStartOrEndOfPath);
+          std::reverse(supplyCompClones.begin(), supplyCompClones.end());
+        } else {
+          supplyCompClones = airLoopClone.supplyComponents(path.clonedStartOrEndOfPath, path.clonedAddNode);
+        }
+
+        auto supplyNodeClones = subsetCastVector<Node>(supplyCompClones);
+
+        OS_ASSERT(supplyNodes.size() == supplyNodeClones.size());
+        for (size_t i = 0; i < supplyNodes.size(); ++i) {
+          const auto node = supplyNodes[i];
+          auto cloneNode = supplyNodeClones[i];
+
+          auto spms = node.setpointManagers();
+          for (const auto& spm : spms) {
+            auto spmclone = spm.clone(model).cast<SetpointManager>();
+            spmclone.addToNode(cloneNode);
           }
         }
       }
 
-      auto supplyNodeClones = subsetCastVector<Node>(airLoopClone.supplyComponents());
-
-      OS_ASSERT(supplyNodes.size() == supplyNodeClones.size());
-      for (size_t i = 0; i < supplyNodes.size(); ++i) {
-        const auto node = supplyNodes[i];
-        auto cloneNode = supplyNodeClones[i];
-
-        auto spms = node.setpointManagers();
-        for (const auto& spm : spms) {
-          auto spmclone = spm.clone(model).cast<SetpointManager>();
-          spmclone.addToNode(cloneNode);
-        }
-      }
+      // Demand Side: same regardless of whether it's a Dual Duct or not
 
       auto terms = terminals();
       std::vector<IddObjectType> termtypes;

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -110,6 +110,8 @@
 // Casting in AVM test
 #include "../AvailabilityManagerNightCycle_Impl.hpp"
 
+#include <utilities/idd/IddEnums.hxx>
+
 using namespace openstudio::model;
 
 TEST_F(ModelFixture, AirLoopHVAC_AirLoopHVAC) {
@@ -1414,4 +1416,70 @@ TEST_F(ModelFixture, AirLoopHVAC_designReturnAirFlowFractionofSupplyAirFlow) {
   EXPECT_EQ(0.5, a.designReturnAirFlowFractionofSupplyAirFlow());
   // TODO: Not sure if we need to limit the idd to \maximum 1.0 or not
   // In theory it can be >1.0 for negative pressurization with a return fan flow that is > than supply. I can't say I've tested that use case.
+}
+
+
+TEST_F(ModelFixture,AirLoopHVAC_dualDuct_Clone)
+{
+  Model m;
+  AirLoopHVAC a(m, true);
+
+  EXPECT_TRUE(a.isDualDuct());
+
+
+  EXPECT_EQ(2u,a.supplyOutletNodes().size());
+  EXPECT_EQ(4u,a.supplyComponents().size());
+
+  EXPECT_EQ(2u,a.supplySplitterOutletNodes().size());
+  ASSERT_TRUE(a.supplySplitterInletNode());
+  EXPECT_EQ(a.supplySplitterInletNode().get(),a.supplyInletNode());
+
+  ASSERT_TRUE(a.supplySplitter());
+  EXPECT_TRUE(a.supplyComponent(a.supplySplitter()->handle()));
+  EXPECT_TRUE(a.supplyComponent(a.supplyOutletNodes().front().handle()));
+  EXPECT_TRUE(a.supplyComponent(a.supplyOutletNodes().back().handle()));
+
+  EXPECT_EQ(6u, m.getConcreteModelObjects<Node>().size());
+  EXPECT_EQ(6u, a.components(openstudio::IddObjectType::OS_Node).size());
+
+  // Clone
+  AirLoopHVAC aClone = a.clone(m).cast<AirLoopHVAC>();
+
+  EXPECT_EQ(12u, m.getConcreteModelObjects<Node>().size());
+
+  {
+    EXPECT_EQ(2u,a.supplyOutletNodes().size());
+    EXPECT_EQ(4u,a.supplyComponents().size());
+
+    EXPECT_EQ(2u,a.supplySplitterOutletNodes().size());
+
+    EXPECT_EQ(6u, a.components(openstudio::IddObjectType::OS_Node).size());
+
+    ASSERT_TRUE(a.supplySplitterInletNode());
+    EXPECT_EQ(a.supplySplitterInletNode().get(),a.supplyInletNode());
+
+    ASSERT_TRUE(a.supplySplitter());
+    EXPECT_TRUE(a.supplyComponent(a.supplySplitter()->handle()));
+    EXPECT_TRUE(a.supplyComponent(a.supplyOutletNodes().front().handle()));
+    EXPECT_TRUE(a.supplyComponent(a.supplyOutletNodes().back().handle()));
+
+  }
+
+  {
+    EXPECT_EQ(2u,aClone.supplyOutletNodes().size());
+    EXPECT_EQ(4u,aClone.supplyComponents().size());
+
+    EXPECT_EQ(2u,aClone.supplySplitterOutletNodes().size());
+
+    EXPECT_EQ(6u, aClone.components(openstudio::IddObjectType::OS_Node).size());
+
+    ASSERT_TRUE(aClone.supplySplitterInletNode());
+    EXPECT_EQ(aClone.supplySplitterInletNode().get(),aClone.supplyInletNode());
+
+    ASSERT_TRUE(aClone.supplySplitter());
+    EXPECT_TRUE(aClone.supplyComponent(aClone.supplySplitter()->handle()));
+    EXPECT_TRUE(aClone.supplyComponent(aClone.supplyOutletNodes().front().handle()));
+    EXPECT_TRUE(aClone.supplyComponent(aClone.supplyOutletNodes().back().handle()));
+  }
+
 }

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -1422,6 +1422,34 @@ TEST_F(ModelFixture, AirLoopHVAC_designReturnAirFlowFractionofSupplyAirFlow) {
   // In theory it can be >1.0 for negative pressurization with a return fan flow that is > than supply. I can't say I've tested that use case.
 }
 
+TEST_F(ModelFixture, AirLoopHVAC_singleDuct_Clone) {
+  Model m;
+  AirLoopHVAC a(m, false);
+
+  EXPECT_FALSE(a.isDualDuct());
+
+  EXPECT_EQ(1u, a.supplyOutletNodes().size());
+  EXPECT_EQ(2u, a.supplyComponents().size());
+
+  EXPECT_EQ(0u, a.supplySplitterOutletNodes().size());
+  EXPECT_FALSE(a.supplySplitterInletNode());
+  EXPECT_FALSE(a.supplySplitter());
+
+  EXPECT_EQ(5u, m.getConcreteModelObjects<Node>().size());
+  EXPECT_EQ(5u, a.components(openstudio::IddObjectType::OS_Node).size());
+
+  // Clone
+  AirLoopHVAC aClone = a.clone(m).cast<AirLoopHVAC>();
+
+  EXPECT_EQ(10u, m.getConcreteModelObjects<Node>().size());
+  EXPECT_EQ(5u, a.components(openstudio::IddObjectType::OS_Node).size());
+  EXPECT_EQ(5u, aClone.components(openstudio::IddObjectType::OS_Node).size());
+  EXPECT_EQ(1u, a.supplyOutletNodes().size());
+  EXPECT_EQ(2u, a.supplyComponents().size());
+  EXPECT_EQ(1u, aClone.supplyOutletNodes().size());
+  EXPECT_EQ(2u, aClone.supplyComponents().size());
+}
+
 TEST_F(ModelFixture, AirLoopHVAC_dualDuct_Clone) {
   // Test for #4060
   Model m;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4060
 -  Cloning a DualDuct AirLoopHVAC breaks the existing loop

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate): N/A
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
