### PR TITLE
Fix AVMList clone between different models

### DIFF
--- a/src/model/AvailabilityManagerAssignmentList.cpp
+++ b/src/model/AvailabilityManagerAssignmentList.cpp
@@ -101,11 +101,8 @@ namespace detail {
    */
   ModelObject AvailabilityManagerAssignmentList_Impl::clone(Model model) const
   {
-    boost::optional<Loop> thisLoop = loop();
-    OS_ASSERT(thisLoop);
-
     // Create a new, blank, one
-    AvailabilityManagerAssignmentList avmListClone(*thisLoop);
+    AvailabilityManagerAssignmentList avmListClone(model);
 
     // Clone all AVMs and populate the clone
     std::vector<AvailabilityManager> avmVector = availabilityManagers();
@@ -407,6 +404,12 @@ AvailabilityManagerAssignmentList::AvailabilityManagerAssignmentList(const Loop&
   OS_ASSERT(getImpl<detail::AvailabilityManagerAssignmentList_Impl>());
 
   this->setName(loop.name().get() + " AvailabilityManagerAssignmentList");
+}
+
+AvailabilityManagerAssignmentList::AvailabilityManagerAssignmentList(const Model& model)
+  : ModelObject(AvailabilityManagerAssignmentList::iddObjectType(),model)
+{
+  OS_ASSERT(getImpl<detail::AvailabilityManagerAssignmentList_Impl>());
 }
 
 IddObjectType AvailabilityManagerAssignmentList::iddObjectType() {

--- a/src/model/AvailabilityManagerAssignmentList.hpp
+++ b/src/model/AvailabilityManagerAssignmentList.hpp
@@ -60,6 +60,8 @@ class MODEL_API AvailabilityManagerAssignmentList : public ModelObject {
    */
   explicit AvailabilityManagerAssignmentList(const Loop& loop);
 
+  explicit AvailabilityManagerAssignmentList(const Model& model);
+
   virtual ~AvailabilityManagerAssignmentList() {}
 
   //@}

--- a/src/model/AvailabilityManagerAssignmentList.hpp
+++ b/src/model/AvailabilityManagerAssignmentList.hpp
@@ -39,6 +39,8 @@ namespace model {
 namespace detail {
 
   class AvailabilityManagerAssignmentList_Impl;
+  class AirLoopHVAC_Impl;
+  class PlantLoop_Impl;
 
 } // detail
 
@@ -59,8 +61,6 @@ class MODEL_API AvailabilityManagerAssignmentList : public ModelObject {
    * At least until we implement AVMLists for ZoneHVAC equipment
    */
   explicit AvailabilityManagerAssignmentList(const Loop& loop);
-
-  explicit AvailabilityManagerAssignmentList(const Model& model);
 
   virtual ~AvailabilityManagerAssignmentList() {}
 
@@ -159,11 +159,14 @@ class MODEL_API AvailabilityManagerAssignmentList : public ModelObject {
   /// @cond
   typedef detail::AvailabilityManagerAssignmentList_Impl ImplType;
 
+  explicit AvailabilityManagerAssignmentList(const Model& model);
   explicit AvailabilityManagerAssignmentList(std::shared_ptr<detail::AvailabilityManagerAssignmentList_Impl> impl);
 
   friend class detail::AvailabilityManagerAssignmentList_Impl;
   friend class Model;
   friend class IdfObject;
+  friend class detail::AirLoopHVAC_Impl;
+  friend class detail::PlantLoop_Impl;
   friend class openstudio::detail::IdfObject_Impl;
   /// @endcond
  private:

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -1178,6 +1178,11 @@ TEST_F(ModelFixture,AirLoopHVAC_AvailabilityManagers)
   AirLoopHVAC a2 = a.clone(m).cast<AirLoopHVAC>();
   ASSERT_EQ(9u, a2.availabilityManagers().size());
 
+  // Test Clone, different model
+  Model m2;
+  AirLoopHVAC a3 = a.clone(m2).cast<AirLoopHVAC>();
+  ASSERT_EQ(9u, a3.availabilityManagers().size());
+
   // reset shouldn't affect the clone
   a.resetAvailabilityManagers();
   ASSERT_EQ(0u, a.availabilityManagers().size());

--- a/src/model/test/PlantLoop_GTest.cpp
+++ b/src/model/test/PlantLoop_GTest.cpp
@@ -517,11 +517,15 @@ TEST_F(ModelFixture, PlantLoop_AvailabilityManagers) {
   PlantLoop p2 = p.clone(m).cast<PlantLoop>();
   ASSERT_EQ(6u, p2.availabilityManagers().size());
 
+  // Test Clone, different model
+  Model m2;
+  PlantLoop p3 = p.clone(m2).cast<PlantLoop>();
+  ASSERT_EQ(6u, p3.availabilityManagers().size());
+
   // reset shouldn't affect the clone
   p.resetAvailabilityManagers();
   ASSERT_EQ(0u, p.availabilityManagers().size());
   ASSERT_EQ(6u, p2.availabilityManagers().size());
-
 
   // TODO: this fails, but not my fault, it hits the PlantLoop_Impl::sizingPlant()  LOG_AND_THROW statement
   // Test Clone, other model


### PR DESCRIPTION
close #4033
close #4034

Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
