### PR TITLE
637 speedup version translation new parsing method

### DIFF
--- a/src/utilities/core/ASCIIStrings.hpp
+++ b/src/utilities/core/ASCIIStrings.hpp
@@ -1,0 +1,78 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2020, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+
+#ifndef UTILITIES_CORE_ASCIISTRINGS_HPP
+#define UTILITIES_CORE_ASCIISTRINGS_HPP
+
+#include <string>
+#include <string_view>
+
+
+namespace openstudio {
+
+inline std::string ascii_to_lower_copy(std::string_view input) {
+  std::string result{input};
+  constexpr auto to_lower_diff = 'a' - 'A';
+  for(auto &c : result) {
+    if (c >= 'A' && c <= 'Z') {
+      c += to_lower_diff;
+    }
+  }
+  return result;
+}
+
+
+
+inline std::string_view ascii_trim_left(std::string_view s) {
+  return s.substr(std::min(s.find_first_not_of(" \f\n\r\t\v"), s.size()));
+}
+
+inline std::string_view ascii_trim_right(std::string_view s) {
+  return s.substr(0, std::min(s.find_last_not_of(" \f\n\r\t\v")+1, s.size()));
+}
+
+inline std::string_view ascii_trim(std::string_view s) {
+  return ascii_trim_left(ascii_trim_right(s));
+}
+
+inline void ascii_trim(std::string &str) {
+  str = std::string(ascii_trim(std::string_view(str)));
+}
+
+}
+
+
+
+
+
+
+
+#endif
+

--- a/src/utilities/core/test/String_GTest.cpp
+++ b/src/utilities/core/test/String_GTest.cpp
@@ -32,6 +32,7 @@
 #include "../Containers.hpp"
 #include "../String.hpp"
 #include "../StringHelpers.hpp"
+#include "../ASCIIStrings.hpp"
 #include "../Path.hpp"
 
 #include <boost/regex.hpp>
@@ -400,4 +401,30 @@ TEST(String, SplitEMSLineToTokens)
   EXPECT_EQ("2", tokens[2]);
   EXPECT_EQ("Var2", tokens[3]);
 }
+
+TEST(String, ASCIIToLowerCopy)
+{
+  EXPECT_EQ("123helloworld123", openstudio::ascii_to_lower_copy("123HeLloWOrld123"));
+}
+
+TEST(String, ASCIITrimLeft)
+{
+  std::string test = "   hello world   ";
+  EXPECT_EQ("hello world   ", openstudio::ascii_trim_left(test));
+}
+
+TEST(String, ASCIITrimRight)
+{
+  std::string test = " \t hello world   ";
+  EXPECT_EQ(" \t hello world", openstudio::ascii_trim_right(test));
+}
+
+TEST(String, ASCIITrimString)
+{
+  std::string test = " \t hello world  \r";
+  openstudio::ascii_trim(test);
+  EXPECT_EQ("hello world", test);
+}
+
+
 

--- a/src/utilities/idd/IddField.cpp
+++ b/src/utilities/idd/IddField.cpp
@@ -41,6 +41,7 @@
 #include "../units/IPUnit.hpp"
 #include "../units/Quantity.hpp"
 
+#include "../core/ASCIIStrings.hpp"
 #include "../core/Assert.hpp"
 #include "../core/Containers.hpp"
 
@@ -302,10 +303,10 @@ namespace detail {
 
       // parse all the properties
       while (boost::regex_search(fieldProperties, matches, iddRegex::metaDataComment())){
-        std::string thisProperty(matches[1].first, matches[1].second); boost::trim(thisProperty);
+        std::string thisProperty(matches[1].first, matches[1].second); openstudio::ascii_trim(thisProperty);
         parseProperty(thisProperty);
 
-        fieldProperties = std::string(matches[2].first, matches[2].second); boost::trim(fieldProperties);
+        fieldProperties = std::string(matches[2].first, matches[2].second); openstudio::ascii_trim(fieldProperties);
       }
 
       if ( !( (boost::regex_match(fieldProperties, commentRegex::whitespaceOnlyBlock())) ||
@@ -356,8 +357,10 @@ namespace detail {
 
     bool notHandled=true;
     boost::smatch matches;
-    std::string lowerText = boost::algorithm::to_lower_copy(text);
-    char index = lowerText[0];
+
+    std::string lowerText = openstudio::ascii_to_lower_copy(text);
+
+    const char index = lowerText[0];
 
     //sort inside the case statements based on the probability of that value being in the string.(so we don't run 5 unlikely
     //regex tofind the likely one) Keep the case statements in aphabitical order for ease of maintance, since it doesn't
@@ -395,7 +398,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::defaultProperty()));
           std::string stringDefault(matches[1].first, matches[1].second);
-          boost::trim(stringDefault);
+          openstudio::ascii_trim(stringDefault);
           m_properties.stringDefault = stringDefault;
           notHandled=false;
           // if we are numeric type and not set to autosize, set the numeric property
@@ -426,7 +429,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::externalListProperty()));
           std::string externalList(matches[1].first, matches[1].second);
-          boost::trim(externalList);
+          openstudio::ascii_trim(externalList);
           m_properties.externalLists.push_back(externalList);
           notHandled=false;
         }
@@ -439,7 +442,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::nameProperty()));
           std::string fieldName(matches[1].first, matches[1].second);
-          boost::trim(fieldName);
+          openstudio::ascii_trim(fieldName);
           notHandled=false;
           if (!boost::equals(m_name, fieldName))
           {
@@ -455,7 +458,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::ipUnitsProperty()));
           std::string ipUnits(matches[1].first, matches[1].second);
-          boost::trim(ipUnits);
+          openstudio::ascii_trim(ipUnits);
           m_properties.ipUnits = ipUnits;
           notHandled=false;
         }
@@ -473,7 +476,7 @@ namespace detail {
           if (boost::regex_search(keyText, keyMatches, iddRegex::contentAndCommentLine()))
           {
             std::string keyName(keyMatches[1].first, keyMatches[1].second);
-            boost::trim(keyName);
+            openstudio::ascii_trim(keyName);
 
             // construct the key
             OptionalIddKey key = IddKey::load(keyName, keyText);
@@ -501,7 +504,7 @@ namespace detail {
           {
             m_properties.minBoundType = IddFieldProperties::ExclusiveBound;
             std::string minExclusive(matches[1].first, matches[1].second);
-            boost::trim(minExclusive);
+            openstudio::ascii_trim(minExclusive);
             m_properties.minBoundValue = boost::lexical_cast<double>(minExclusive);
             m_properties.minBoundText = minExclusive;
             notHandled=false;
@@ -510,7 +513,7 @@ namespace detail {
           {
             m_properties.minBoundType = IddFieldProperties::InclusiveBound;
             std::string minInclusive(matches[1].first, matches[1].second);
-            boost::trim(minInclusive);
+            openstudio::ascii_trim(minInclusive);
             m_properties.minBoundValue = boost::lexical_cast<double>(minInclusive);
             m_properties.minBoundText = minInclusive;
             notHandled=false;
@@ -522,7 +525,7 @@ namespace detail {
           {
             m_properties.maxBoundType = IddFieldProperties::ExclusiveBound;
             std::string maxExclusive(matches[1].first, matches[1].second);
-            boost::trim(maxExclusive);
+            openstudio::ascii_trim(maxExclusive);
             m_properties.maxBoundValue = boost::lexical_cast<double>(maxExclusive);
             m_properties.maxBoundText = maxExclusive;
             notHandled=false;
@@ -531,7 +534,7 @@ namespace detail {
           {
             m_properties.maxBoundType = IddFieldProperties::InclusiveBound;
             std::string maxInclusive(matches[1].first, matches[1].second);
-            boost::trim(maxInclusive);
+            openstudio::ascii_trim(maxInclusive);
             m_properties.maxBoundValue = boost::lexical_cast<double>(maxInclusive);
             m_properties.maxBoundText = maxInclusive;
             notHandled=false;
@@ -567,7 +570,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::objectListProperty()));
           std::string objectList(matches[1].first, matches[1].second);
-          boost::trim(objectList);
+          openstudio::ascii_trim(objectList);
           m_properties.objectLists.push_back(objectList);
           notHandled=false;
         }
@@ -584,7 +587,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::referenceClassNameProperty()));
           std::string reference(matches[1].first, matches[1].second);
-          boost::trim(reference);
+          openstudio::ascii_trim(reference);
           m_properties.referenceClassNames.push_back(reference);
           notHandled=false;
         }
@@ -592,7 +595,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::referenceProperty()));
           std::string reference(matches[1].first, matches[1].second);
-          boost::trim(reference);
+          openstudio::ascii_trim(reference);
           m_properties.references.push_back(reference);
           notHandled=false;
         }
@@ -610,7 +613,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::typeProperty()));
           std::string fieldType(matches[1].first, matches[1].second);
-          boost::trim(fieldType);
+          openstudio::ascii_trim(fieldType);
           m_properties.type = IddFieldType(fieldType);
           notHandled=false;
         }
@@ -628,7 +631,7 @@ namespace detail {
         {
           OS_ASSERT(boost::regex_search(text, matches, iddRegex::unitsProperty()));
           std::string units(matches[1].first, matches[1].second);
-          boost::trim(units);
+          openstudio::ascii_trim(units);
           m_properties.units = units;
           notHandled=false;
         }

--- a/src/utilities/idd/IddFile.cpp
+++ b/src/utilities/idd/IddFile.cpp
@@ -34,6 +34,7 @@
 #include "IddEnums.hpp"
 #include <utilities/idd/IddEnums.hxx>
 
+#include "../core/ASCIIStrings.hpp"
 #include "../core/PathHelpers.hpp"
 #include "../core/Assert.hpp"
 
@@ -271,7 +272,7 @@ namespace detail {
       ++lineNum;
 
       // remove whitespace
-      boost::trim(line);
+      openstudio::ascii_trim(line);
 
       if (line.empty()){
 
@@ -297,7 +298,7 @@ namespace detail {
         headerClosed = true;
 
         // get the group name
-        std::string groupName(matches[1].first, matches[1].second); boost::trim(groupName);
+        std::string groupName(matches[1].first, matches[1].second); openstudio::ascii_trim(groupName);
 
         // set the current group
         currentGroup = groupName;
@@ -316,7 +317,7 @@ namespace detail {
         // peek at the object name for indexing in map
         std::string objectName;
         if (boost::regex_search(line, matches, iddRegex::line())){
-          objectName = std::string(matches[1].first, matches[1].second); boost::trim(objectName);
+          objectName = std::string(matches[1].first, matches[1].second); openstudio::ascii_trim(objectName);
         }else{
           // can't figure out the object's name
           LOG_AND_THROW("Cannot determine object name on line " << lineNum <<
@@ -342,7 +343,7 @@ namespace detail {
           ++lineNum;
 
           // remove whitespace
-          boost::trim(line);
+          openstudio::ascii_trim(line);
 
           // found last field and this is not a field comment
           if (foundClosingLine && (!boost::regex_match(line, iddRegex::metaDataComment()))){

--- a/src/utilities/idd/IddObject.cpp
+++ b/src/utilities/idd/IddObject.cpp
@@ -38,7 +38,7 @@
 #include "CommentRegex.hpp"
 
 #include "../core/Assert.hpp"
-
+#include "../core/ASCIIStrings.hpp"
 
 #include <boost/lexical_cast.hpp>
 
@@ -48,7 +48,6 @@ using boost::regex;
 using boost::smatch;
 using boost::regex_replace;
 using boost::replace_all;
-using boost::trim;
 
 namespace openstudio {
 
@@ -543,7 +542,7 @@ namespace detail {
     for (IddField& extensibleField : m_extensibleFields){
       std::string extensibleFieldName = extensibleField.name();
       extensibleFieldName = regex_replace(extensibleFieldName, find, replace);
-      trim(extensibleFieldName);
+      openstudio::ascii_trim(extensibleFieldName);
       extensibleField.setName(extensibleFieldName);
     }
 
@@ -565,21 +564,21 @@ namespace detail {
     string objectName;
     string propertiesText;
     if (boost::regex_search(text, matches, iddRegex::line())){
-      objectName = string(matches[1].first, matches[1].second); trim(objectName);
+      objectName = string(matches[1].first, matches[1].second); openstudio::ascii_trim(objectName);
       if (!boost::equals(m_name,objectName)){
         LOG_AND_THROW("Object name '" << objectName << "' does not match expected '" << m_name << "'");
       }
 
-      propertiesText = string(matches[2].first, matches[2].second); trim(propertiesText);
+      propertiesText = string(matches[2].first, matches[2].second); openstudio::ascii_trim(propertiesText);
     }else{
       LOG_AND_THROW("Could not determine object name from text '" << text << "'");
     }
 
     while (boost::regex_search(propertiesText, matches, iddRegex::metaDataComment())){
-      string thisProperty(matches[1].first, matches[1].second); trim(thisProperty);
+      string thisProperty(matches[1].first, matches[1].second); openstudio::ascii_trim(thisProperty);
       parseProperty(thisProperty);
 
-      propertiesText = string(matches[2].first, matches[2].second); trim(propertiesText);
+      propertiesText = string(matches[2].first, matches[2].second); openstudio::ascii_trim(propertiesText);
     }
     if ( !( (boost::regex_match(propertiesText, commentRegex::whitespaceOnlyBlock())) ||
             (boost::regex_match(propertiesText, iddRegex::commentOnlyLine())) ) ){
@@ -592,7 +591,7 @@ namespace detail {
   {
     smatch matches;
     if (boost::regex_search(text, matches, iddRegex::memoProperty())){
-      string memo(matches[1].first, matches[1].second); trim(memo);
+      string memo(matches[1].first, matches[1].second); openstudio::ascii_trim(memo);
       if (m_properties.memo.empty()) { m_properties.memo = memo; }
       else { m_properties.memo += "\n" + memo; }
 
@@ -615,7 +614,7 @@ namespace detail {
       m_properties.numExtensible = boost::lexical_cast<unsigned>(numExtensible);
 
     }else if (boost::regex_search(text, matches, iddRegex::formatProperty())){
-      string format(matches[1].first, matches[1].second); trim(format);
+      string format(matches[1].first, matches[1].second); openstudio::ascii_trim(format);
       m_properties.format = format;
 
     }else if (boost::regex_search(text, matches, iddRegex::minFieldsProperty())){
@@ -667,11 +666,11 @@ namespace detail {
       // peak ahead to find the field name for indexing in map
       smatch nameMatches;
       if (boost::regex_search(fieldText, nameMatches, iddRegex::name())){
-        fieldName = string(nameMatches[1].first, nameMatches[1].second); trim(fieldName);
+        fieldName = string(nameMatches[1].first, nameMatches[1].second); openstudio::ascii_trim(fieldName);
       }else if(boost::regex_search(fieldText, nameMatches, iddRegex::field())){
         // if no explicit field name, use the type and number
-        string fieldTypeChar(nameMatches[1].first, nameMatches[1].second); trim(fieldTypeChar);
-        string fieldTypeNumber(nameMatches[2].first, nameMatches[2].second); trim(fieldTypeNumber);
+        string fieldTypeChar(nameMatches[1].first, nameMatches[1].second); openstudio::ascii_trim(fieldTypeChar);
+        string fieldTypeNumber(nameMatches[2].first, nameMatches[2].second); openstudio::ascii_trim(fieldTypeNumber);
         fieldName = fieldTypeChar + fieldTypeNumber;
       }else{
         // cannot find the field name


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #637
 - Improves IDD parsing performance by about 3x

* Invert logic for parsing of ParseFields function to avoid very expensive regex
* Reduce cost of `trim` and `to_lower_copy` by only using ascii-safe functions
