### PR TITLE
OutputControlFiles and ShadingControl updates

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -30983,11 +30983,6 @@ OS:OutputControl:Files,
        \key Yes
        \key No
        \required-field
-  A17, \field Output END
-       \type choice
-       \key Yes
-       \key No
-       \required-field
   A18, \field Output SHD
        \type choice
        \key Yes

--- a/src/energyplus/ForwardTranslator.cpp
+++ b/src/energyplus/ForwardTranslator.cpp
@@ -448,7 +448,7 @@ Workspace ForwardTranslator::translateModelPrivate( model::Model & model, bool f
   // TODO: Is this still needed?
   // ensure shading controls only reference windows in a single zone and determine control sequence number
   // DLM: ideally E+ would not need to know the zone, shading controls could work across zones
-  std::vector<ShadingControl> shadingControls = model.getConcreteModelObjects<ShadingControl>();
+  /*std::vector<ShadingControl> shadingControls = model.getConcreteModelObjects<ShadingControl>();
   std::sort(shadingControls.begin(), shadingControls.end(), WorkspaceObjectNameLess());
   std::map<Handle, ShadingControlVector> zoneHandleToShadingControlVectorMap;
   for (auto& shadingControl : shadingControls) {
@@ -495,7 +495,7 @@ Workspace ForwardTranslator::translateModelPrivate( model::Model & model, bool f
         LOG(Warn, "Cannot find Space for " << subSurface.briefDescription() << " referencing " << shadingControl.briefDescription());
       }
     }
-  }
+  }*/
 
   if (!m_keepRunControlSpecialDays){
     LOG(Warn, "You have manually choosen to not translate the RunPeriodControlSpecialDays, ignoring them.");

--- a/src/energyplus/ForwardTranslator.cpp
+++ b/src/energyplus/ForwardTranslator.cpp
@@ -445,10 +445,9 @@ Workspace ForwardTranslator::translateModelPrivate( model::Model & model, bool f
     }
   }
 
-  // TODO: Is this still needed?
   // ensure shading controls only reference windows in a single zone and determine control sequence number
   // DLM: ideally E+ would not need to know the zone, shading controls could work across zones
-  /*std::vector<ShadingControl> shadingControls = model.getConcreteModelObjects<ShadingControl>();
+  std::vector<ShadingControl> shadingControls = model.getConcreteModelObjects<ShadingControl>();
   std::sort(shadingControls.begin(), shadingControls.end(), WorkspaceObjectNameLess());
   std::map<Handle, ShadingControlVector> zoneHandleToShadingControlVectorMap;
   for (auto& shadingControl : shadingControls) {
@@ -495,7 +494,7 @@ Workspace ForwardTranslator::translateModelPrivate( model::Model & model, bool f
         LOG(Warn, "Cannot find Space for " << subSurface.briefDescription() << " referencing " << shadingControl.briefDescription());
       }
     }
-  }*/
+  }
 
   if (!m_keepRunControlSpecialDays){
     LOG(Warn, "You have manually choosen to not translate the RunPeriodControlSpecialDays, ignoring them.");

--- a/src/energyplus/ForwardTranslator/ForwardTranslateOutputControlFiles.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateOutputControlFiles.cpp
@@ -137,11 +137,7 @@ boost::optional<IdfObject> ForwardTranslator::translateOutputControlFiles( Outpu
     idfObject.setString(OutputControl_FilesFields::OutputMTD, "No");
   }
 
-  if (modelObject.outputEND()) {
-    idfObject.setString(OutputControl_FilesFields::OutputEND, "Yes");
-  } else {
-    idfObject.setString(OutputControl_FilesFields::OutputEND, "No");
-  }
+  idfObject.setString(OutputControl_FilesFields::OutputEND, "Yes");
 
   if (modelObject.outputSHD()) {
     idfObject.setString(OutputControl_FilesFields::OutputSHD, "Yes");

--- a/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -134,8 +134,7 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl(model::Sha
     LOG(Error, "Cannot find ThermalZone for " << modelObject.briefDescription());
   }
 
-  //boost::optional<int> sequenceNumber = modelObject.additionalProperties().getFeatureAsInteger("Shading Control Sequence Number");
-  boost::optional<int> sequenceNumber = 1;
+  boost::optional<int> sequenceNumber = modelObject.additionalProperties().getFeatureAsInteger("Shading Control Sequence Number");
   if (sequenceNumber) {
     idfObject.setInt(WindowShadingControlFields::ShadingControlSequenceNumber, *sequenceNumber);
   } else {

--- a/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateShadingControl.cpp
@@ -134,7 +134,8 @@ boost::optional<IdfObject> ForwardTranslator::translateShadingControl(model::Sha
     LOG(Error, "Cannot find ThermalZone for " << modelObject.briefDescription());
   }
 
-  boost::optional<int> sequenceNumber = modelObject.additionalProperties().getFeatureAsInteger("Shading Control Sequence Number");
+  //boost::optional<int> sequenceNumber = modelObject.additionalProperties().getFeatureAsInteger("Shading Control Sequence Number");
+  boost::optional<int> sequenceNumber = 1;
   if (sequenceNumber) {
     idfObject.setInt(WindowShadingControlFields::ShadingControlSequenceNumber, *sequenceNumber);
   } else {

--- a/src/energyplus/ReverseTranslator/ReverseTranslateOutputControlFiles.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateOutputControlFiles.cpp
@@ -168,8 +168,6 @@ boost::optional<ModelObject> ReverseTranslator::translateOutputControlFiles( con
     }
   }
 
-  modelObject.setString(16, "Yes"); // Output END
-
   if (boost::optional<std::string> _outputSHD = workspaceObject.getString(OutputControl_FilesFields::OutputSHD, true)) {
     if(istringEqual("Yes", _outputSHD.get())) {
       modelObject.setOutputSHD(true);

--- a/src/energyplus/ReverseTranslator/ReverseTranslateOutputControlFiles.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateOutputControlFiles.cpp
@@ -168,13 +168,7 @@ boost::optional<ModelObject> ReverseTranslator::translateOutputControlFiles( con
     }
   }
 
-  if (boost::optional<std::string> _outputEND = workspaceObject.getString(OutputControl_FilesFields::OutputEND, true)) {
-    if(istringEqual("Yes", _outputEND.get())) {
-      modelObject.setOutputEND(true);
-    } else {
-      modelObject.setOutputEND(false);
-    }
-  }
+  modelObject.setString(16, "Yes"); // Output END
 
   if (boost::optional<std::string> _outputSHD = workspaceObject.getString(OutputControl_FilesFields::OutputSHD, true)) {
     if(istringEqual("Yes", _outputSHD.get())) {

--- a/src/energyplus/Test/OutputControlFiles_GTest.cpp
+++ b/src/energyplus/Test/OutputControlFiles_GTest.cpp
@@ -80,7 +80,6 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_OutputControlFiles) {
     EXPECT_TRUE(outputControlFiles.setOutputRDD(status[12]));
     EXPECT_TRUE(outputControlFiles.setOutputMDD(status[13]));
     EXPECT_TRUE(outputControlFiles.setOutputMTD(status[14]));
-    EXPECT_TRUE(outputControlFiles.setOutputEND(status[15]));
     EXPECT_TRUE(outputControlFiles.setOutputSHD(status[16]));
     EXPECT_TRUE(outputControlFiles.setOutputDFS(status[17]));
     EXPECT_TRUE(outputControlFiles.setOutputGLHE(status[18]));
@@ -118,7 +117,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_OutputControlFiles) {
     EXPECT_EQ(boolToString(status[12]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputRDD).get());
     EXPECT_EQ(boolToString(status[13]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputMDD).get());
     EXPECT_EQ(boolToString(status[14]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputMTD).get());
-    EXPECT_EQ(boolToString(status[15]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputEND).get());
+    EXPECT_EQ(boolToString(true), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputEND).get());
     EXPECT_EQ(boolToString(status[16]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputSHD).get());
     EXPECT_EQ(boolToString(status[17]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputDFS).get());
     EXPECT_EQ(boolToString(status[18]), idf_outputControlFiles.getString(OutputControl_FilesFields::OutputGLHE).get());
@@ -207,7 +206,7 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_OutputControlFiles) {
     EXPECT_EQ(status[12], outputControlFiles.outputRDD());
     EXPECT_EQ(status[13], outputControlFiles.outputMDD());
     EXPECT_EQ(status[14], outputControlFiles.outputMTD());
-    EXPECT_EQ(status[15], outputControlFiles.outputEND());
+    EXPECT_EQ(true, outputControlFiles.outputEND());
     EXPECT_EQ(status[16], outputControlFiles.outputSHD());
     EXPECT_EQ(status[17], outputControlFiles.outputDFS());
     EXPECT_EQ(status[18], outputControlFiles.outputGLHE());

--- a/src/energyplus/Test/OutputControlFiles_GTest.cpp
+++ b/src/energyplus/Test/OutputControlFiles_GTest.cpp
@@ -206,7 +206,6 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_OutputControlFiles) {
     EXPECT_EQ(status[12], outputControlFiles.outputRDD());
     EXPECT_EQ(status[13], outputControlFiles.outputMDD());
     EXPECT_EQ(status[14], outputControlFiles.outputMTD());
-    EXPECT_EQ(true, outputControlFiles.outputEND());
     EXPECT_EQ(status[16], outputControlFiles.outputSHD());
     EXPECT_EQ(status[17], outputControlFiles.outputDFS());
     EXPECT_EQ(status[18], outputControlFiles.outputGLHE());

--- a/src/energyplus/Test/ShadingControl_GTest.cpp
+++ b/src/energyplus/Test/ShadingControl_GTest.cpp
@@ -86,9 +86,12 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
   Model model;
 
   ThermalZone thermalZone(model);
+  ThermalZone thermalZone2(model);
 
   Space space(model);
+  Space space2(model);
   space.setThermalZone(thermalZone);
+  space2.setThermalZone(thermalZone2);
 
   std::vector<Point3d> vertices;
   vertices.push_back(Point3d(0, 2, 0));
@@ -96,7 +99,9 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
   vertices.push_back(Point3d(2, 0, 0));
   vertices.push_back(Point3d(2, 2, 0));
   Surface surface(vertices, model);
+  Surface surface2(vertices, model);
   surface.setSpace(space);
+  surface2.setSpace(space2);
 
   // Here's the position of the two subSurfaces onto the base Surface
   // 2 _____________
@@ -130,6 +135,18 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
   subSurfaceB.setSurface(surface);
   subSurfaceB.assignDefaultSubSurfaceType();
 
+  // C
+  vertices.clear();
+  vertices.push_back(Point3d(1, 2, 0));
+  vertices.push_back(Point3d(1, 1, 0));
+  vertices.push_back(Point3d(2, 1, 0));
+  vertices.push_back(Point3d(2, 2, 0));
+
+  SubSurface subSurfaceC(vertices, model);
+  subSurfaceC.setName("SubSurface C");
+  subSurfaceC.setSurface(surface2);
+  subSurfaceC.assignDefaultSubSurfaceType();
+
   Blind blind1(model);
   ShadingControl shadingControl1(blind1);
   EXPECT_TRUE(shadingControl1.setShadingType("ExteriorBlind"));
@@ -147,6 +164,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
   EXPECT_TRUE(shadingControl1.setGlareControlIsActive(true));
   EXPECT_TRUE(shadingControl1.setMultipleSurfaceControlType("Sequential"));
   EXPECT_TRUE(shadingControl1.addSubSurface(subSurfaceA));
+  EXPECT_FALSE(shadingControl1.addSubSurface(subSurfaceC));
   // Convenience method that calls ShadingControl::addSubSurface()
   EXPECT_TRUE(subSurfaceB.addShadingControl(shadingControl1));
   ASSERT_EQ(2u, shadingControl1.subSurfaces().size());
@@ -167,7 +185,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
   {
     Workspace workspace = forwardTranslator.translateModel(model);
 
-    EXPECT_EQ(2u, workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed).size());
+    EXPECT_EQ(3u, workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed).size());
     ASSERT_EQ(2u, workspace.getObjectsByType(IddObjectType::WindowShadingControl).size());
 
     // Test ShadingControl1: it has all the fields set. We also check that it's control sequence number is 1.
@@ -246,7 +264,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ShadingControls)
 
     Workspace workspace = forwardTranslator.translateModel(model);
 
-    EXPECT_EQ(2u, workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed).size());
+    EXPECT_EQ(3u, workspace.getObjectsByType(IddObjectType::FenestrationSurface_Detailed).size());
 
     std::vector<WorkspaceObject> objVector(workspace.getObjectsByType(IddObjectType::WindowShadingControl));
     EXPECT_EQ(1u, objVector.size());

--- a/src/model/OutputControlFiles.cpp
+++ b/src/model/OutputControlFiles.cpp
@@ -136,10 +136,6 @@ namespace detail {
     return getBooleanFieldValue(OS_OutputControl_FilesFields::OutputMTD);
   }
 
-  bool OutputControlFiles_Impl::outputEND() const {
-    return getBooleanFieldValue(OS_OutputControl_FilesFields::OutputEND);
-  }
-
   bool OutputControlFiles_Impl::outputSHD() const {
     return getBooleanFieldValue(OS_OutputControl_FilesFields::OutputSHD);
   }
@@ -258,10 +254,6 @@ namespace detail {
 
   bool OutputControlFiles_Impl::setOutputMTD(bool outputMTD) {
     return setBooleanFieldValue(OS_OutputControl_FilesFields::OutputMTD, outputMTD);
-  }
-
-  bool OutputControlFiles_Impl::setOutputEND(bool outputEND) {
-    return setBooleanFieldValue(OS_OutputControl_FilesFields::OutputEND, outputEND);
   }
 
   bool OutputControlFiles_Impl::setOutputSHD(bool outputSHD) {
@@ -390,10 +382,6 @@ bool OutputControlFiles::outputMTD() const {
   return getImpl<detail::OutputControlFiles_Impl>()->outputMTD();
 }
 
-bool OutputControlFiles::outputEND() const {
-  return getImpl<detail::OutputControlFiles_Impl>()->outputEND();
-}
-
 bool OutputControlFiles::outputSHD() const {
   return getImpl<detail::OutputControlFiles_Impl>()->outputSHD();
 }
@@ -514,10 +502,6 @@ bool OutputControlFiles::setOutputMTD(bool outputMTD) {
   return getImpl<detail::OutputControlFiles_Impl>()->setOutputMTD(outputMTD);
 }
 
-bool OutputControlFiles::setOutputEND(bool outputEND) {
-  return getImpl<detail::OutputControlFiles_Impl>()->setOutputEND(outputEND);
-}
-
 bool OutputControlFiles::setOutputSHD(bool outputSHD) {
   return getImpl<detail::OutputControlFiles_Impl>()->setOutputSHD(outputSHD);
 }
@@ -602,7 +586,6 @@ OutputControlFiles::OutputControlFiles(Model& model)
   setOutputRDD(true);
   setOutputMDD(true);
   setOutputMTD(true);
-  setOutputEND(true);
   setOutputSHD(true);
   setOutputDFS(true);
   setOutputGLHE(true);

--- a/src/model/OutputControlFiles.hpp
+++ b/src/model/OutputControlFiles.hpp
@@ -153,8 +153,6 @@ class MODEL_API OutputControlFiles : public ModelObject {
 
   bool setOutputMTD(bool outputMTD);
 
-  bool setOutputEND(bool outputEND);
-
   bool setOutputSHD(bool outputSHD);
 
   bool setOutputDFS(bool outputDFS);
@@ -205,6 +203,8 @@ class MODEL_API OutputControlFiles : public ModelObject {
   /// @endcond
  private:
   REGISTER_LOGGER("openstudio.model.OutputControlFiles");
+
+  bool setOutputEND(bool outputEND);
 };
 
 /** \relates OutputControlFiles*/

--- a/src/model/OutputControlFiles.hpp
+++ b/src/model/OutputControlFiles.hpp
@@ -87,8 +87,6 @@ class MODEL_API OutputControlFiles : public ModelObject {
 
   bool outputMTD() const;
 
-  bool outputEND() const;
-
   bool outputSHD() const;
 
   bool outputDFS() const;
@@ -203,8 +201,6 @@ class MODEL_API OutputControlFiles : public ModelObject {
   /// @endcond
  private:
   REGISTER_LOGGER("openstudio.model.OutputControlFiles");
-
-  bool setOutputEND(bool outputEND);
 };
 
 /** \relates OutputControlFiles*/

--- a/src/model/OutputControlFiles_Impl.hpp
+++ b/src/model/OutputControlFiles_Impl.hpp
@@ -102,8 +102,6 @@ namespace detail {
 
     bool outputMTD() const;
 
-    bool outputEND() const;
-
     bool outputSHD() const;
 
     bool outputDFS() const;
@@ -167,8 +165,6 @@ namespace detail {
     bool setOutputMDD(bool outputMDD);
 
     bool setOutputMTD(bool outputMTD);
-
-    bool setOutputEND(bool outputEND);
 
     bool setOutputSHD(bool outputSHD);
 

--- a/src/model/ShadingControl.cpp
+++ b/src/model/ShadingControl.cpp
@@ -45,6 +45,10 @@
 #include "Schedule_Impl.hpp"
 #include "SubSurface.hpp"
 #include "SubSurface_Impl.hpp"
+#include "Space.hpp"
+#include "Space_Impl.hpp"
+#include "ThermalZone.hpp"
+#include "ThermalZone_Impl.hpp"
 #include "Model.hpp"
 #include "Model_Impl.hpp"
 #include "ModelExtensibleGroup.hpp"
@@ -549,6 +553,29 @@ namespace detail {
     if (_existingIndex) {
       LOG(Warn, "For " << briefDescription() << ", SubSurface already exists.");
       return true;
+    }
+
+    // Check if zone of subSurface not zone of existing subSurfaces
+    bool ok = true;
+    boost::optional<Space> space = subSurface.space();
+    if (space) {
+      boost::optional<ThermalZone> thermalZone = space->thermalZone();
+      if (thermalZone) {
+        for (auto& subSurface2 : subSurfaces()) {
+          boost::optional<Space> space2 = subSurface2.space();
+          if (space2) {
+            boost::optional<ThermalZone> thermalZone2 = space2->thermalZone();
+            if (thermalZone2) {
+              if (thermalZone->handle() != thermalZone2->handle()) {
+                ok = false;
+              }
+            }
+          }
+        }
+      }
+    }
+    if (!ok) {
+      return false;
     }
 
     bool result;

--- a/src/model/test/OutputControlFiles_GTest.cpp
+++ b/src/model/test/OutputControlFiles_GTest.cpp
@@ -130,8 +130,6 @@ TEST_F(ModelFixture,OutputControlFiles_GettersSetters) {
   EXPECT_TRUE(outputControlFiles.setOutputMTD(true));
   EXPECT_TRUE(outputControlFiles.outputMTD());
 
-  EXPECT_TRUE(outputControlFiles.outputEND());
-
   EXPECT_TRUE(outputControlFiles.outputSHD());
   EXPECT_TRUE(outputControlFiles.setOutputSHD(false));
   EXPECT_FALSE(outputControlFiles.outputSHD());

--- a/src/model/test/OutputControlFiles_GTest.cpp
+++ b/src/model/test/OutputControlFiles_GTest.cpp
@@ -131,10 +131,6 @@ TEST_F(ModelFixture,OutputControlFiles_GettersSetters) {
   EXPECT_TRUE(outputControlFiles.outputMTD());
 
   EXPECT_TRUE(outputControlFiles.outputEND());
-  EXPECT_TRUE(outputControlFiles.setOutputEND(false));
-  EXPECT_FALSE(outputControlFiles.outputEND());
-  EXPECT_TRUE(outputControlFiles.setOutputEND(true));
-  EXPECT_TRUE(outputControlFiles.outputEND());
 
   EXPECT_TRUE(outputControlFiles.outputSHD());
   EXPECT_TRUE(outputControlFiles.setOutputSHD(false));


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)
 - DESCRIBE PURPOSE OF THIS PULL REQUEST

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
