### PR TITLE
Fix #4113 - Provide `openstudio --version` to conform with common CLI conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 
 # TODO: Modify the more specific variables as needed to indicate prerelease, etc
 # Keep in beta in-between release cycles. Set to empty string (or comment out) for official)
-set(PROJECT_VERSION_PRERELEASE "alpha")
+set(PROJECT_VERSION_PRERELEASE "rc1")
 
 # OpenStudio version: Only include Major.Minor.Patch, eg "3.0.0", even if you have a prerelease tag
 set(OPENSTUDIO_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

--- a/src/cli/openstudio_cli.rb
+++ b/src/cli/openstudio_cli.rb
@@ -293,7 +293,7 @@ end
 # parse the main args, those that come before the sub command
 def parse_main_args(main_args)
 
-  # Unset RUBY ENVs if previously set (e.g. rvm sets these in shell) 
+  # Unset RUBY ENVs if previously set (e.g. rvm sets these in shell)
 
   ENV.delete('GEM_HOME') if ENV['GEM_HOME']
   ENV.delete('GEM_PATH') if ENV['GEM_PATH']
@@ -711,6 +711,14 @@ class CLI
       # Help is next in short-circuiting everything. Print
       # the help and exit.
       help
+      return 0
+    end
+
+    if $main_args.include?('--version')
+      # Version is next in short-circuiting everything. Print it and exit.
+      # This is to have the same behavior as pretty much every CLI, you expect
+      # `<cli> --version` to return the version
+      safe_puts OpenStudio.openStudioLongVersion
       return 0
     end
 

--- a/src/energyplus/Test/EMS_GTest.cpp
+++ b/src/energyplus/Test/EMS_GTest.cpp
@@ -633,7 +633,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuatorSpaceLoad_Space_EMS) {
   space.setGasEquipmentPower(10, gasEquip);
 
   // add actuator
-  std::string ControlType = "Gas Power Level";
+  std::string ControlType = "NaturalGas Rate";
   std::string ComponentType = "GasEquipment";
   EnergyManagementSystemActuator fanActuator(gasEquip, ComponentType, ControlType);
   std::string actName = "Gas Equip Actuator";
@@ -682,7 +682,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuatorSpaceLoad_SpaceType_EMS) {
   gasEquip.setSpaceType(spaceType);
 
   // add actuator
-  std::string ControlType = "Gas Power Level";
+  std::string ControlType = "NaturalGas Rate";
   std::string ComponentType = "GasEquipment";
   EnergyManagementSystemActuator fanActuator(gasEquip, ComponentType, ControlType);
   std::string actName = "Gas Equip Actuator";
@@ -824,7 +824,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuatorSpaceLoad3_EMS) {
   //space.setGasEquipmentPower(10, gasEquip);
 
   // add actuator
-  std::string ControlType = "Gas Power Level";
+  std::string ControlType = "NaturalGas Rate";
   std::string ComponentType = "GasEquipment";
   EnergyManagementSystemActuator fanActuator(gasEquip, ComponentType, ControlType);
   std::string actName = "Gas Equip Actuator";
@@ -1892,15 +1892,15 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuator_exampleModel_Lights_EMS) {
   //This is the EDD file for the spaceload actuators for this model so far
   /*
   EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 PEOPLE 1,People,Number of People,[each]
-  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 LIGHTS 1,Lights,Electric Power Level,[W]
-  EnergyManagementSystem:Actuator Available,PRINTER,ElectricEquipment,Electric Power Level,[W]
-  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 ELECTRIC EQUIPMENT 1,ElectricEquipment,Electric Power Level,[W]
+  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 LIGHTS 1,Lights,Electricity Rate,[W]
+  EnergyManagementSystem:Actuator Available,PRINTER,ElectricEquipment,Electricity Rate,[W]
+  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 ELECTRIC EQUIPMENT 1,ElectricEquipment,Electricity Rate,[W]
   */
 
   //actuator settings
   //std::string ComponentType = "ElectricEquipment";
   std::string ComponentType = "Lights";
-  std::string ControlType = "Electric Power Level";
+  std::string ControlType = "Electricity Rate";
   EnergyManagementSystemActuator lightsActuator(lights[0], ComponentType, ControlType, space4.get());
   EXPECT_EQ(space4.get().thermalZone().get().handle(), lightsActuator.zoneName().get().handle());
 
@@ -1946,14 +1946,14 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuator_exampleModel_Electric_EMS) {
   //This is the EDD file for the spaceload actuators for this model so far
   /*
   EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 PEOPLE 1,People,Number of People,[each]
-  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 LIGHTS 1,Lights,Electric Power Level,[W]
-  EnergyManagementSystem:Actuator Available,PRINTER,ElectricEquipment,Electric Power Level,[W]
-  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 ELECTRIC EQUIPMENT 1,ElectricEquipment,Electric Power Level,[W]
+  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 LIGHTS 1,Lights,Electricity Rate,[W]
+  EnergyManagementSystem:Actuator Available,PRINTER,ElectricEquipment,Electricity Rate,[W]
+  EnergyManagementSystem:Actuator Available,THERMAL ZONE 1 ELECTRIC EQUIPMENT 1,ElectricEquipment,Electricity Rate,[W]
   */
 
   //actuator settings
   std::string ComponentType = "ElectricEquipment";
-  std::string ControlType = "Electric Power Level";
+  std::string ControlType = "Electricity Rate";
   //actuator on first electricEquipment object
   EnergyManagementSystemActuator electricActuator0(electricEquipment[0], ComponentType, ControlType);
   //actuator on second electricEquipment object
@@ -2009,20 +2009,20 @@ EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 PEOPLE 1, People, Nu
 EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 PEOPLE 1, People, Number of People, [each]
 EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 PEOPLE 1, People, Number of People, [each]
 EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 PEOPLE 1, People, Number of People, [each]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
 */
 
 //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights[0], lightsComponentType, lightsControlType, spaces[2]);
   //EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());
@@ -2090,20 +2090,20 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuator_API2_EMS) {
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 PEOPLE 1, People, Number of People, [each]
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 PEOPLE 1, People, Number of People, [each]
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 PEOPLE 1, People, Number of People, [each]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
   */
 
   //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights[0], lightsComponentType, lightsControlType, thermalZone2);
   //EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());
@@ -2172,20 +2172,20 @@ TEST_F(EnergyPlusFixture, ForwardTranslatorActuator_API3_EMS) {
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 PEOPLE 1, People, Number of People, [each]
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 PEOPLE 1, People, Number of People, [each]
   EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 PEOPLE 1, People, Number of People, [each]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
-  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electric Power Level, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 LIGHTS 1, Lights, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, PRINTER, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 1 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 2 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 3 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
+  EnergyManagementSystem : Actuator Available, THERMAL ZONE 4 ELECTRIC EQUIPMENT 1, ElectricEquipment, Electricity Rate, [W]
   */
 
   //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights[0], lightsComponentType, lightsControlType, thermalZone2);
   //EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());

--- a/src/model/ElectricEquipment.cpp
+++ b/src/model/ElectricEquipment.cpp
@@ -369,7 +369,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> ElectricEquipment_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "ElectricEquipment", "Electric Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "ElectricEquipment", "Electricity Rate" } };
     return actuators;
   }
 

--- a/src/model/ElectricEquipmentDefinition.cpp
+++ b/src/model/ElectricEquipmentDefinition.cpp
@@ -349,7 +349,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> ElectricEquipmentDefinition_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "ElectricEquipment", "Electric Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "ElectricEquipment", "Electricity Rate" } };
     return actuators;
   }
 

--- a/src/model/GasEquipment.cpp
+++ b/src/model/GasEquipment.cpp
@@ -355,7 +355,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> GasEquipment_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "GasEquipment", "Gas Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "GasEquipment", "NaturalGas Rate" } };
     return actuators;
   }
 

--- a/src/model/GasEquipmentDefinition.cpp
+++ b/src/model/GasEquipmentDefinition.cpp
@@ -369,7 +369,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> GasEquipmentDefinition_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "GasEquipment", "Gas Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "GasEquipment", "NaturalGas Rate" } };
     return actuators;
   }
 

--- a/src/model/Lights.cpp
+++ b/src/model/Lights.cpp
@@ -374,7 +374,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> Lights_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "Lights", "Electric Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "Lights", "Electricity Rate" } };
     return actuators;
   }
 

--- a/src/model/LightsDefinition.cpp
+++ b/src/model/LightsDefinition.cpp
@@ -392,7 +392,7 @@ namespace detail {
   }
 
   std::vector<EMSActuatorNames> LightsDefinition_Impl::emsActuatorNames() const {
-    std::vector<EMSActuatorNames> actuators{ { "Lights", "Electric Power Level" } };
+    std::vector<EMSActuatorNames> actuators{ { "Lights", "Electricity Rate" } };
     return actuators;
   }
 

--- a/src/model/test/EnergyManagementSystemActuator_GTest.cpp
+++ b/src/model/test/EnergyManagementSystemActuator_GTest.cpp
@@ -104,7 +104,7 @@ TEST_F(ModelFixture, EMSActuator_EMSActuator)
   ElectricEquipmentDefinition definition(model);
   ElectricEquipment electricEquipment(definition);
   ComponentType = "ElectricEquipment";
-  std::string equipControlType = "Electric Power Level";
+  std::string equipControlType = "Electricity Rate";
   EnergyManagementSystemActuator equipActuator(electricEquipment, ComponentType, equipControlType);
   EXPECT_EQ(equipControlType, equipActuator.actuatedComponentControlType());
   EXPECT_EQ(ComponentType, equipActuator.actuatedComponentType());
@@ -155,7 +155,7 @@ TEST_F(ModelFixture, EMSActuator_newEMSActuator)
 
   //actuator settings
   std::string elecComponentType = "ElectricEquipment";
-  std::string elecControlType = "Electric Power Level";
+  std::string elecControlType = "Electricity Rate";
   //create actuator
   EnergyManagementSystemActuator elecActuator(electricEquipment, elecComponentType, elecControlType, zone1);
   EXPECT_EQ(elecControlType, elecActuator.actuatedComponentControlType());
@@ -171,7 +171,7 @@ TEST_F(ModelFixture, EMSActuator_newEMSActuator)
 
   //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights, lightsComponentType, lightsControlType, zone2);
   EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());
@@ -213,7 +213,7 @@ TEST_F(ModelFixture, EMSActuator_newEMSActuator2)
 
   //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights, lightsComponentType, lightsControlType, zone2);
   EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());
@@ -257,7 +257,7 @@ TEST_F(ModelFixture, EMSActuator_newEMSActuator3)
 
   //actuator settings
   std::string lightsComponentType = "Lights";
-  std::string lightsControlType = "Electric Power Level";
+  std::string lightsControlType = "Electricity Rate";
   //create actuator zone2
   EnergyManagementSystemActuator lightsActuator2(lights, lightsComponentType, lightsControlType, space2);
   EXPECT_EQ(lightsControlType, lightsActuator2.actuatedComponentControlType());

--- a/src/model/test/ExternalInterfaceActuator_GTest.cpp
+++ b/src/model/test/ExternalInterfaceActuator_GTest.cpp
@@ -94,7 +94,7 @@ TEST_F(ModelFixture, ExternalInterfaceActuator) {
   ElectricEquipmentDefinition definition(model);
   ElectricEquipment electricEquipment(definition);
   ComponentType = "ElectricEquipment";
-  std::string equipControlType = "Electric Power Level";
+  std::string equipControlType = "Electricity Rate";
   ExternalInterfaceActuator equipActuator(electricEquipment, ComponentType, equipControlType);
   EXPECT_EQ(equipControlType, equipActuator.actuatedComponentControlType());
   EXPECT_EQ(ComponentType, equipActuator.actuatedComponentType());

--- a/src/model/test/ExternalInterfaceFunctionalMockupUnitExportToActuator_GTest.cpp
+++ b/src/model/test/ExternalInterfaceFunctionalMockupUnitExportToActuator_GTest.cpp
@@ -100,7 +100,7 @@ TEST_F(ModelFixture, ExternalInterfaceFunctionalMockupUnitExportToActuator) {
   ElectricEquipmentDefinition definition(model);
   ElectricEquipment electricEquipment(definition);
   ComponentType = "ElectricEquipment";
-  std::string equipControlType = "Electric Power Level";
+  std::string equipControlType = "Electricity Rate";
   ExternalInterfaceFunctionalMockupUnitExportToActuator equipActuator(electricEquipment, ComponentType, equipControlType, "electric FMU", 1);
   EXPECT_EQ(equipControlType, equipActuator.actuatedComponentControlType());
   EXPECT_EQ(ComponentType, equipActuator.actuatedComponentType());

--- a/src/model/test/ExternalInterfaceFunctionalMockupUnitImportToActuator_GTest.cpp
+++ b/src/model/test/ExternalInterfaceFunctionalMockupUnitImportToActuator_GTest.cpp
@@ -114,7 +114,7 @@ TEST_F(ModelFixture, ExternalInterfaceFunctionalMockupUnitImportToActuator) {
   ElectricEquipmentDefinition definition(model);
   ElectricEquipment electricEquipment(definition);
   ComponentType = "ElectricEquipment";
-  std::string equipControlType = "Electric Power Level";
+  std::string equipControlType = "Electricity Rate";
   ExternalInterfaceFunctionalMockupUnitImportToActuator equipActuator(electricEquipment, ComponentType, equipControlType, eifmui, "FMU", "electric FMU", 1);
   EXPECT_EQ(equipControlType, equipActuator.actuatedComponentControlType());
   EXPECT_EQ(ComponentType, equipActuator.actuatedComponentType());


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4113
 - Provide `openstudio --version` to confirm with common CLI conventions

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
