### PR TITLE
V3.1.0 fixed sqlite3 linkage

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(
 target_link_libraries(
  openstudiolib
  INTERFACE
- CONAN_PKG::sqlite3
  CONAN_PKG::boost
  CONAN_PKG::jsoncpp
  CONAN_PKG::cpprestsdk

--- a/src/utilities/UtilitiesSql.i
+++ b/src/utilities/UtilitiesSql.i
@@ -42,31 +42,4 @@
 // order that these are loaded matters, e.g TimeSeries in data needs to know about DateTime in time
 %include <utilities/sql/SqlFile.i>
 
-%{
-  struct ManageSQLite3Initialization {
-    ManageSQLite3Initialization() {
-      // Notes:
-      // * this is a no-op if sqlite3 is already initialized.
-      // * generally we don't need to call sqlite3_shutdown.
-      // * sqlite3 should be self initializing, if *not* compiled with
-      //   SQLITE_OMIT_AUTOINIT.
-      //
-      // However, it is possible when sqlite3 is called from different DLL's on Windows
-      // (which have different views of globals per DLL's) that we will need to manually 
-      // call this.
-      //
-      // This situation occurs when we use system ruby on load OpenStudioRuby DLL's on
-      // Windows.
-      //
-      // related SWIG Doc for why this is a static object http://www.swig.org/Doc4.0/SWIG.html#SWIG_nn44
-      // why we are not worried about sqlite3_shutdown http://sqlite.1065341.n5.nabble.com/Q-When-to-use-sqlite3-shutdown-td67987.html
-      // notes on initializing sqlite3 http://sqlite.org/c3ref/initialize.html
-      // similar issue found with Python on Windows https://stackoverflow.com/questions/24253406/access-violation-on-sqlite3-mutex-enter-why
-      sqlite3_initialize();
-    }
-  };
-  
-  static ManageSQLite3Initialization sqlite3initializerobjectforswigbindings;
-%}
-
 #endif // UTILITIES_UTILITIESSQL_I

--- a/src/utilities/sql/CMakeLists.txt
+++ b/src/utilities/sql/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sql_src
   sql/SqlFileTimeSeriesQuery.hpp
   sql/SqlFileTimeSeriesQuery.cpp
   sql/PreparedStatement.hpp
+  sql/PreparedStatement.cpp
 )
 
 set(sql_test_src

--- a/src/utilities/sql/PreparedStatement.cpp
+++ b/src/utilities/sql/PreparedStatement.cpp
@@ -1,0 +1,230 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2020, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include "PreparedStatement.hpp"
+#include <sqlite3.h>
+
+namespace openstudio {
+  PreparedStatement::~PreparedStatement() {
+    if (m_statement) {
+      sqlite3_finalize(m_statement);
+    }
+
+    if (m_transaction) {
+      sqlite3_exec(m_db, "COMMIT", nullptr, nullptr, nullptr);
+    }
+  }
+
+  bool PreparedStatement::bind(int position, const std::string &t_str) {
+    if (sqlite3_bind_text(m_statement, position, t_str.c_str(), t_str.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+      return false;
+    }
+    return true;
+  }
+
+  bool PreparedStatement::bind(int position, int val) {
+    if (sqlite3_bind_int(m_statement, position, val) != SQLITE_OK) {
+      return false;
+    }
+    return true;
+  }
+
+  bool PreparedStatement::bind(int position, unsigned int val) {
+    if (sqlite3_bind_int(m_statement, position, static_cast<int>(val)) != SQLITE_OK) {
+      return false;
+    }
+    return true;
+  }
+
+
+  bool PreparedStatement::bind(int position, double val) {
+    if (sqlite3_bind_double(m_statement, position, val) != SQLITE_OK) {
+      return false;
+    }
+    return true;
+  }
+
+  int PreparedStatement::execute() {
+    int code = sqlite3_step(m_statement);
+    sqlite3_reset(m_statement);
+    return code;
+  }
+
+  boost::optional<double> PreparedStatement::execAndReturnFirstDouble() const {
+    boost::optional<double> value;
+    if (m_db)
+    {
+      int code = sqlite3_step(m_statement);
+      if (code == SQLITE_ROW)
+      {
+        value = sqlite3_column_double(m_statement, 0);
+      }
+    }
+    return value;
+  }
+
+  boost::optional<int> PreparedStatement::execAndReturnFirstInt() const {
+    boost::optional<int> value;
+    if (m_db)
+    {
+      int code = sqlite3_step(m_statement);
+      if (code == SQLITE_ROW)
+      {
+        value = sqlite3_column_int(m_statement, 0);
+      }
+    }
+    return value;
+  }
+
+  boost::optional<std::string> PreparedStatement::execAndReturnFirstString() const {
+    boost::optional<std::string> value;
+    if (m_db)
+    {
+      int code = sqlite3_step(m_statement);
+      if (code == SQLITE_ROW)
+      {
+        value = columnText(sqlite3_column_text(m_statement, 0));
+      }
+    }
+    return value;
+  }
+
+  boost::optional<std::vector<double> > PreparedStatement::execAndReturnVectorOfDouble() const {
+
+    boost::optional<double> value;
+    boost::optional<std::vector<double> > valueVector;
+    if (m_db)
+    {
+      int code = SQLITE_OK;
+
+      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY) && (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
+      {
+        if (!valueVector){
+          valueVector = std::vector<double>();
+        }
+
+        code = sqlite3_step(m_statement);
+        if (code == SQLITE_ROW)
+        {
+          value = sqlite3_column_double(m_statement, 0);
+          valueVector->push_back(*value);
+        }
+        else  // i didn't get a row.  something is wrong so set the exit condition.
+        {     // should never get here since i test for all documented return states above
+          code = SQLITE_DONE;
+        }
+
+      }// end loop
+    }
+
+    return valueVector;
+  }
+
+  boost::optional<std::vector<int> > PreparedStatement::execAndReturnVectorOfInt() const {
+    boost::optional<int> value;
+    boost::optional<std::vector<int> > valueVector;
+    if (m_db)
+    {
+      int code = SQLITE_OK;
+
+      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY)&& (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
+      {
+        if (!valueVector){
+          valueVector = std::vector<int>();
+        }
+
+        code = sqlite3_step(m_statement);
+        if (code == SQLITE_ROW)
+        {
+          value = sqlite3_column_int(m_statement, 0);
+          valueVector->push_back(*value);
+        }
+        else  // i didn't get a row.  something is wrong so set the exit condition.
+        {     // should never get here since i test for all documented return states above
+          code = SQLITE_DONE;
+        }
+
+      }// end loop
+    }
+
+    return valueVector;
+  }
+
+  boost::optional<std::vector<std::string> > PreparedStatement::execAndReturnVectorOfString() const {
+    boost::optional<std::string> value;
+    boost::optional<std::vector<std::string> > valueVector;
+    if (m_db)
+    {
+      int code = SQLITE_OK;
+
+      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY)&& (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
+      {
+        if (!valueVector){
+          valueVector = std::vector<std::string>();
+        }
+
+        code = sqlite3_step(m_statement);
+        if (code == SQLITE_ROW)
+        {
+          value = columnText(sqlite3_column_text(m_statement, 0));
+          valueVector->push_back(*value);
+        }
+        else  // i didn't get a row.  something is wrong so set the exit condition.
+        {     // should never get here since i test for all documented return states above
+          code = SQLITE_DONE;
+        }
+
+      }// end loop
+    }
+    return valueVector;
+  }
+
+  PreparedStatement::PreparedStatement(PreparedStatement::InternalConstructor, const std::string &t_stmt, sqlite3 *t_db,
+                                       bool t_transaction)
+          : m_db(t_db), m_statement(nullptr), m_transaction(t_transaction) {
+    if (m_transaction) {
+      sqlite3_exec(m_db, "BEGIN", nullptr, nullptr, nullptr);
+    }
+
+    int code = sqlite3_prepare_v2(m_db, t_stmt.c_str(), t_stmt.size(), &m_statement, nullptr);
+
+    if (!m_statement) {
+      int extendedErrorCode = sqlite3_extended_errcode(m_db);
+      const char *err = sqlite3_errmsg(m_db);
+      std::string errMsg = err;
+      throw std::runtime_error(
+              "Error creating prepared statement: " + t_stmt + " with error code " + std::to_string(code)
+              + ", extended code " + std::to_string(extendedErrorCode) + ", errmsg: " + errMsg);
+    }
+  }
+
+  int PreparedStatement::get_sqlite3_bind_parameter_count(sqlite3_stmt *statement) {
+    return sqlite3_bind_parameter_count(statement);
+  }
+}

--- a/src/utilities/sql/PreparedStatement.hpp
+++ b/src/utilities/sql/PreparedStatement.hpp
@@ -44,7 +44,7 @@ struct sqlite3_stmt;
 
 namespace openstudio {
 
-struct PreparedStatement
+class UTILITIES_API PreparedStatement
 {
 private:
   sqlite3 *m_db;

--- a/src/utilities/sql/PreparedStatement.hpp
+++ b/src/utilities/sql/PreparedStatement.hpp
@@ -33,114 +33,61 @@
 #include "../UtilitiesAPI.hpp"
 #include "../core/String.hpp"
 
-#include <sqlite3.h>
 #include <boost/optional.hpp>
 
 #include <stdexcept>
 #include <string>
 #include <vector>
 
+struct sqlite3;
+struct sqlite3_stmt;
+
 namespace openstudio {
 
 struct PreparedStatement
 {
+private:
   sqlite3 *m_db;
   sqlite3_stmt *m_statement;
   bool m_transaction;
 
-  PreparedStatement & operator=(const PreparedStatement&) = delete;
-  PreparedStatement(const PreparedStatement&) = delete;
+  struct InternalConstructor { };
+
+  // a helper constructor to delegate to. It has the first parameter as
+  // InternalConstructor so it's distinguishable from the on with the defaulted
+  // t_transaction
+  PreparedStatement(InternalConstructor, const std::string &t_stmt, sqlite3 *t_db, bool t_transaction);
+
+
+
+public:
+  PreparedStatement &operator=(const PreparedStatement &) = delete;
+  PreparedStatement(const PreparedStatement &) = delete;
 
   PreparedStatement(const std::string &t_stmt, sqlite3 *t_db, bool t_transaction = false)
-  : m_db(t_db), m_statement(nullptr), m_transaction(t_transaction)
+  : PreparedStatement(InternalConstructor{}, t_stmt, t_db, t_transaction)
   {
-    if (m_transaction)
-    {
-      sqlite3_exec(m_db, "BEGIN", nullptr, nullptr, nullptr);
-    }
 
-    int code = sqlite3_prepare_v2(m_db, t_stmt.c_str(), t_stmt.size(), &m_statement, nullptr);
-
-    if (!m_statement)
-    {
-      int extendedErrorCode = sqlite3_extended_errcode(m_db);
-      const char * err = sqlite3_errmsg(m_db);
-      std::string errMsg = err;
-      throw std::runtime_error("Error creating prepared statement: " + t_stmt + " with error code " + std::to_string(code)
-          + ", extended code " + std::to_string(extendedErrorCode) + ", errmsg: " + errMsg);
-    }
   }
 
   template<typename... Args>
   PreparedStatement(const std::string &t_stmt, sqlite3 *t_db, bool t_transaction, Args&&... args)
-  : m_db(t_db), m_statement(nullptr), m_transaction(t_transaction)
+  : PreparedStatement(InternalConstructor{}, t_stmt, t_db, t_transaction)
   {
-    if (m_transaction)
-    {
-      sqlite3_exec(m_db, "BEGIN", nullptr, nullptr, nullptr);
-    }
-
-    int code = sqlite3_prepare_v2(m_db, t_stmt.c_str(), t_stmt.size(), &m_statement, nullptr);
-
-    if (!m_statement)
-    {
-      int extendedErrorCode = sqlite3_extended_errcode(m_db);
-      const char * err = sqlite3_errmsg(m_db);
-      std::string errMsg = err;
-      throw std::runtime_error("Error creating prepared statement: " + t_stmt + " with error code " + std::to_string(code)
-          + ", extended code " + std::to_string(extendedErrorCode) + ", errmsg: " + errMsg);
-    }
-
     if (!bindAll(args...)) {
       throw std::runtime_error("Error bindings args with statement: " + t_stmt);
     }
   }
 
-  ~PreparedStatement()
-  {
-    if (m_statement)
-    {
-      sqlite3_finalize(m_statement);
-    }
+  ~PreparedStatement();
 
-    if (m_transaction)
-    {
-      sqlite3_exec(m_db, "COMMIT", nullptr, nullptr, nullptr);
-    }
-  }
+  bool bind(int position, const std::string &t_str);
 
-  bool bind(int position, const std::string &t_str)
-  {
-    if (sqlite3_bind_text(m_statement, position, t_str.c_str(), t_str.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
-      return false;
-    }
-    return true;
-  }
+  bool bind(int position, int val);
 
-  bool bind(int position, int val)
-  {
-    if (sqlite3_bind_int(m_statement, position, val) != SQLITE_OK) {
-      return false;
-    }
-    return true;
-  }
+  bool bind(int position, unsigned int val);
 
-  bool bind(int position, unsigned int val)
-  {
-    if (sqlite3_bind_int(m_statement, position, val) != SQLITE_OK) {
-      return false;
-    }
-    return true;
-  }
-
-
-  bool bind(int position, double val)
-  {
-    if (sqlite3_bind_double(m_statement, position, val) != SQLITE_OK) {
-      return false;
-    }
-    return true;
-  }
+  bool bind(int position, double val);
 
   // Makes no sense
   bool bind(int position, char val) = delete;
@@ -165,13 +112,14 @@ struct PreparedStatement
     return bind(position, static_cast<int>(val));
   }
 
+  [[nodiscard]] static int get_sqlite3_bind_parameter_count(sqlite3_stmt *statement);
+
   template<typename... Args>
   bool bindAll(Args&&... args) {
     const std::size_t size = sizeof...(Args);
-    int nPlaceholders = sqlite3_bind_parameter_count(m_statement);
+    int nPlaceholders = get_sqlite3_bind_parameter_count(m_statement);
     if (nPlaceholders != size) {
       throw std::runtime_error("Wrong number of placeholders [" + std::to_string(nPlaceholders) + "] versus bindArgs [" + std::to_string(size) + "].");
-      return false;
     } else {
       int i = 1;
       // Call bind(i++, args[i]) until any returns false
@@ -183,6 +131,8 @@ struct PreparedStatement
   // Executes a **SINGLE** statement
   void execAndThrowOnError() {
     int code = execute();
+    // copied in here to avoid including sqlite3 header everywhere
+    constexpr auto SQLITE_DONE = 101;
     if (code != SQLITE_DONE)
     {
       throw std::runtime_error("Error executing SQL statement step");
@@ -190,147 +140,26 @@ struct PreparedStatement
   }
 
   // Executes a **SINGLE** statement
-  int execute() {
-    int code = sqlite3_step(m_statement);
-    sqlite3_reset(m_statement);
-    return code;
-  }
+  int execute();
 
-  boost::optional<double> execAndReturnFirstDouble() const {
-    boost::optional<double> value;
-    if (m_db)
-    {
-      int code = sqlite3_step(m_statement);
-      if (code == SQLITE_ROW)
-      {
-        value = sqlite3_column_double(m_statement, 0);
-      }
-    }
-    return value;
-  }
+  [[nodiscard]] boost::optional<double> execAndReturnFirstDouble() const;
 
-  boost::optional<int> execAndReturnFirstInt() const {
-    boost::optional<int> value;
-    if (m_db)
-    {
-      int code = sqlite3_step(m_statement);
-      if (code == SQLITE_ROW)
-      {
-        value = sqlite3_column_int(m_statement, 0);
-      }
-    }
-    return value;
-  }
+  [[nodiscard]] boost::optional<int> execAndReturnFirstInt() const;
 
-  std::string columnText(const unsigned char* column) const {
+  static std::string columnText(const unsigned char* column) {
     return std::string(reinterpret_cast<const char*>(column));
   }
 
-  boost::optional<std::string> execAndReturnFirstString() const {
-    boost::optional<std::string> value;
-    if (m_db)
-    {
-      int code = sqlite3_step(m_statement);
-      if (code == SQLITE_ROW)
-      {
-        value = columnText(sqlite3_column_text(m_statement, 0));
-      }
-    }
-    return value;
-  }
+  [[nodiscard]] boost::optional<std::string> execAndReturnFirstString() const;
 
   /// execute a statement and return the results (if any) in a vector of double
-  boost::optional<std::vector<double> > execAndReturnVectorOfDouble() const {
-
-    boost::optional<double> value;
-    boost::optional<std::vector<double> > valueVector;
-    if (m_db)
-    {
-      int code = SQLITE_OK;
-
-      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY)&& (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
-      {
-        if (!valueVector){
-          valueVector = std::vector<double>();
-        }
-
-        code = sqlite3_step(m_statement);
-        if (code == SQLITE_ROW)
-        {
-          value = sqlite3_column_double(m_statement, 0);
-          valueVector->push_back(*value);
-        }
-        else  // i didn't get a row.  something is wrong so set the exit condition.
-        {     // should never get here since i test for all documented return states above
-          code = SQLITE_DONE;
-        }
-
-      }// end loop
-    }
-
-    return valueVector;
-  }
+  [[nodiscard]] boost::optional<std::vector<double> > execAndReturnVectorOfDouble() const;
 
   /// execute a statement and return the results (if any) in a vector of int
-  boost::optional<std::vector<int> > execAndReturnVectorOfInt() const {
-    boost::optional<int> value;
-    boost::optional<std::vector<int> > valueVector;
-    if (m_db)
-    {
-      int code = SQLITE_OK;
-
-      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY)&& (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
-      {
-        if (!valueVector){
-          valueVector = std::vector<int>();
-        }
-
-        code = sqlite3_step(m_statement);
-        if (code == SQLITE_ROW)
-        {
-          value = sqlite3_column_int(m_statement, 0);
-          valueVector->push_back(*value);
-        }
-        else  // i didn't get a row.  something is wrong so set the exit condition.
-        {     // should never get here since i test for all documented return states above
-          code = SQLITE_DONE;
-        }
-
-      }// end loop
-    }
-
-    return valueVector;
-  }
+  [[nodiscard]] boost::optional<std::vector<int> > execAndReturnVectorOfInt() const;
 
   /// execute a statement and return the results (if any) in a vector of string
-  boost::optional<std::vector<std::string> > execAndReturnVectorOfString() const {
-    boost::optional<std::string> value;
-    boost::optional<std::vector<std::string> > valueVector;
-    if (m_db)
-    {
-      int code = SQLITE_OK;
-
-      while ((code != SQLITE_DONE) && (code != SQLITE_BUSY)&& (code != SQLITE_ERROR) && (code != SQLITE_MISUSE)  )//loop until SQLITE_DONE
-      {
-        if (!valueVector){
-          valueVector = std::vector<std::string>();
-        }
-
-        code = sqlite3_step(m_statement);
-        if (code == SQLITE_ROW)
-        {
-          value = columnText(sqlite3_column_text(m_statement, 0));
-          valueVector->push_back(*value);
-        }
-        else  // i didn't get a row.  something is wrong so set the exit condition.
-        {     // should never get here since i test for all documented return states above
-          code = SQLITE_DONE;
-        }
-
-      }// end loop
-    }
-    return valueVector;
-  }
+  [[nodiscard]] boost::optional<std::vector<std::string> > execAndReturnVectorOfString() const;
 
 };
 

--- a/src/utilities/sql/SqlFile_Impl.hpp
+++ b/src/utilities/sql/SqlFile_Impl.hpp
@@ -811,7 +811,9 @@ namespace openstudio{
       // Variadic arguments are the bind arguments if any, to replace '?' placeholders in the statement string
       template<typename... Args>
       int execute(const std::string& statement, Args&& ... args) const {
-        int code = SQLITE_ERROR;
+        // copied in here to avoid including sqlite3 header everywhere
+        constexpr auto SQLITE_ERROR = 1;
+        auto code = SQLITE_ERROR;
         if (m_db) {
           PreparedStatement stmt(statement, m_db, false, args...);
           code = stmt.execute();


### PR DESCRIPTION
Addresses #4126 

 - Move implementation of PreparedStatement into .cpp file
 - Remove hack for previous ruby fix
 - Remove now unnecessary extra linkage to sqlite3

Note: this has been tested to make sure the previous Ruby / Sqlite bug had not regressed.