### PR TITLE
include pyenergyplus directory from the installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1228,6 +1228,7 @@ install(PROGRAMS ${ENERGYPLUS_FILES} DESTINATION ./EnergyPlus/ COMPONENT EnergyP
 install(PROGRAMS ${ENERGYPLUS_LIB_FILES} DESTINATION ./EnergyPlus/ COMPONENT EnergyPlus)
 install(PROGRAMS "${EXPAND_OBJECTS}" DESTINATION ./EnergyPlus/ COMPONENT EnergyPlus)
 install(DIRECTORY "${ENERGYPLUS_DIR}/python_standard_lib" DESTINATION ./EnergyPlus/ COMPONENT EnergyPlus)
+install(DIRECTORY "${ENERGYPLUS_DIR}/pyenergyplus" DESTINATION ./EnergyPlus/ COMPONENT EnergyPlus)
 
 if(APPLE)
   install(PROGRAMS "${ENERGYPLUS_DIR}/libgfortran.5.dylib" DESTINATION ./EnergyPlus/ COMPONENT EnergyPlus)


### PR DESCRIPTION
avoid this error:
```
** Severe  ** Failed to import module "<Module Name>"
**   ~~~   ** Python error description follows: 
**   ~~~   ** ModuleNotFoundError("No module named 'pyenergyplus'")
```
when trying to run pyems via openstudio.