### PR TITLE
fix issue_4132 - hande lower case window drive letters

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -16,7 +16,7 @@ module OpenStudio
       absolute_path = File.expand_path p2
 
       # strip Windows drive letters
-      if /[A-Z]\:/.match(absolute_path)
+      if /[A-Za-z]\:/.match(absolute_path)
         absolute_path = absolute_path[2..-1]
       end
       absolute_path = ':' + absolute_path

--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -16,7 +16,7 @@ module OpenStudio
       absolute_path = File.expand_path p2
 
       # strip Windows drive letters
-      if /[A-Za-z]\:/.match(absolute_path)
+      if /^[A-Za-z]\:/.match(absolute_path.strip)
         absolute_path = absolute_path[2..-1]
       end
       absolute_path = ':' + absolute_path


### PR DESCRIPTION
fix #4132   Add to the existing regex to match for lower and upper case letters 

