### PR TITLE
Updating the docs for building and testing for 3.x.x series. 

### DIFF
--- a/developer/doc/Building and Testing OpenStudio.md
+++ b/developer/doc/Building and Testing OpenStudio.md
@@ -1,480 +1,135 @@
-Process of Building and Testing OpenStudio for Release
+Process of Building and Testing OpenStudio
 ======================================================
-Configured build environments: https://github.com/NREL/OpenStudio/wiki/Configuring-OpenStudio-Build-Environments
+# Contents
+- [Windows](#Windows%20Build%20Environment)
+- [Linux](#Linux%20Build%20Environment)
+- [Mac](#Mac%20Build%20Environment)
+- [Unit Testing](#Unit%20Testing)
+- [Regression Testing](#Regression%20Testing)
 
-- 64-bit Windows environment
-- 64-bit Ubuntu environment
-- 64-bit OS X environment
-- Git
-- VMWare
-- IncrediBuild
-- S3
-- MarkdownPad 2
+## Windows Build Environment
+64-bit Windows 7 – 10
+ 
+**Required**
+* [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) (Community versions is free)
+* [CMake](https://cmake.org/download/)(v3.15 or newer)
+* [conan](https://conan.io/) (v1.28 or newer)  You need to install Python first, and once that is installed, open a terminal and run `pip install conan` to install for that user, or `sudo pip install conan` to install globally for all users.  Verify conan has been installed by running `conan -v` 
 
+**Optional**
+* [nuget.exe](https://www.nuget.org/downloads) This is for creating nuget packages. You can skip this if you are not planning on building this component. It is disabled by default 
+* [QtIFW](https://download.qt.io/official_releases/qt-installer-framework/3.2.2/QtInstallerFramework-win-x86.exe) This for creating binary installer packages. 
+* [Doxygen v1.8.8](http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.8-setup.exe) For building docs. 
 
-Release Notes
-=============
-If this is a major release, release notes must be written.
+For installed dependencies such as (e.g. cmake, nuget, QtIFW) be sure to include these to your PATH. Usually this is done automatically via installer but not always. 
 
-- Contact each OpenStudio developer and get from them a list of features and bug fixes which they feel should be highlighted.
-- In the folder doc\ReleaseNotes copy the most recent release notes, and update the name to reflect the correct version, and date.
-- Incorporate the developers notes previously obtained.
-- Have the release notes reviewed for accuracy.
-- Generate a PDF from the word doc.
-- Update openstudiocore\cmakelists.txt to package the latest release notes pdf.
-- With Git, commit above files (Commit Message = `Updating release notes X.Y.Z`) to the develop branch
-- Generate a markdown document from the word doc.
+When installing Visual Studio Community 2019, you will be prompted to select which components to install. Below is a link to the `.vsconfig` that we use on the OpenStudio CI build agents. This is using Visual Studio 2019 Community Edition v16.7.1
 
+Download VS Config: [vsconfig](https://openstudio-dependencies.s3.amazonaws.com/visual-studio-2019/install-options/config/.vsconfig) 
 
-Updating HVAC lib
-=================
-If this is a major release, the HVAC library must be updated.
+You can import this file using the VS Installer:  
 
-Run `developer/ruby/UpdateHVACLibrary.rb` (ruby -I E:\Git\OS1\build\Products\ruby\Release UpdateHVACLibrary.rb)
+![vs-2019-installer](https://openstudio-dependencies.s3.amazonaws.com/visual-studio-2019/install-options/img/vsinstaller.png)
 
-Commit the updated files to develop.
+Once all the dependencies are installed, set up the build using CMake. The example below is for a headless build using PowerShell. You can also use Visual Studio and select new CMake project and navigate to the root of the openStudio clone repo. 
 
+This setting below is for a `Release` build of OpenStudio.  Note, you can customize the build options by toggling the ON/OFF cmake settings that you do not need. Here is an example of a CMake setup that builds openstudio, csharp, documentation, testing and creates installer packages. 
 
-Updating EnergyPlus
-===================
+Make sure you create a `build` directory in the base repo before running these cmake configure commands. 
 
-If a new version of EnergyPlus is to be incorporated into OpenStudio
-- Upload the 3 versions (Windows 64, Ubuntu, and Linux) to S3's folder `openstudio-resources/dependencies`
-- In the ./openstudiocore folder, update `CMakeLists.txt` following
-    - ENERGYPLUS_VERSION_MAJOR
-    - ENERGYPLUS_VERSION_MINOR
-    - ENERGYPLUS_VERSION_PATCH
-    - ENERGYPLUS_BUILD_SHA
-    - ENERGYPLUS_RELEASE_NAME
-    - ENERGYPLUS_EXPECTED_HASH (In 3 places: Win 32, Win 64, Darwin, and Linux)
+`cmake -G "Visual Studio 16 2019" -A x64 -DBUILD_CSHARP_BINDINGS=ON -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=ON -DBUILD_PACKAGE=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_BINARY_IFW=ON -DCPACK_BINARY_TGZ=ON ../`
 
-Note: use HashTab, or similar, to determine the MD5 hash value for each file referenced above.
+Here is an example of a debug build with the same settings as above. This is useful if using the Visual Studio debugger tools.   
 
+`cmake -G "Visual Studio 16 2019" -A x64 -DBUILD_CSHARP_BINDINGS=ON -DBUILD_DOCUMENTATION=ON -DBUILD_TESTING=ON -DBUILD_PACKAGE=OFF -DCMAKE_BUILD_TYPE=Debug ../`
 
-Updating OpenStudio Server used by PAT
-======================================
+Once the CMake configure step completes, you can build your target. For example, you can build the target `package` which builds and then uses QTIFW to create the binary installer packages.  
 
-If there is a new server build, bump the server SHA (both for Mac and Windows) in manifest.json in the root folder of PAT.
+`$ cmake --build . --config Release --target package`
+
+If you want to skip the installer, you can also just build openstudio.
+
+`$ cmake --build . --config Release --target openstudio`
 
 
-Updating PAT
-==========================
+## Linux Build Environment
+Ubuntu 18.04
 
-Bump the PAT SHA in OpenStudio's openstudiocore/pat/CMakeLists.txt.
+**Required**
+
+```shell
+ sudo apt install build-essential git cmake-curses-gui cmake-gui libssl-dev libxt-dev \
+    libncurses5-dev libgl1-mesa-dev autoconf libexpat1-dev libpng-dev libfreetype6-dev \
+    libdbus-glib-1-dev libglib2.0-dev libfontconfig1-dev libxi-dev libxrender-dev \
+    libgeographic-dev libicu-dev chrpath bison libffi-dev libgdbm-dev libqdbm-dev \
+    libreadline-dev libyaml-dev libharfbuzz-dev libgmp-dev patchelf python-pip
+```
+* [conan](https://conan.io/) (v1.28 or newer)  You need to install Python first, and once that is installed, open a terminal and run `pip install conan` to install for that user, or `sudo pip install conan` to install globally for all users.  Verify conan has been installed by running `conan -v`
+Other dependencies: 
+
+* cmake - The cmake version that ships via apt package manager for Ubuntu 18.04 is < 3.15, so run the commands below to build and install cmake for newer versions. 
+
+```shell
+CMAKE_VERSION=3.15.0 # Update with latest by checking https://cmake.org/download/
+wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz
+tar xfz cmake-$CMAKE_VERSION.tar.gz
+cd cmake-$CMAKE_VERSION
+./configure
+make -j$(nproc)
+sudo make install
+```
+  
+**Optional**
+* [QtIFW](https://download.qt.io/official_releases/qt-installer-framework/3.2.2/QtInstallerFramework-linux-x64.run)
 
 
-Initial Steps
-=============
-If internal to NREL, connect to developer VPN (avoids certificate warnings, increases speed of uploads).
+After you install the required dependencies, you can clone the repository and run cmake setup and build a target. Below is an example of cloning the repo at develop branch and running a basic cmake config and building the target package. 
 
-- With Git, merge `develop` into `iteration`.
+```shell
+git clone https://github.com/NREL/OpenStudio  
+cd OpenStudio  
+mkdir build 
+cd build  
+cmake -DBUILD_TESTING=ON -DBUILD_PACKAGE=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_BINARY_DEB=ON -DCPACK_BINARY_TGZ=ON -DCPACK_BINARY_TZ=OFF ../  
+make -j $(nproc) package
+``` 
+## Mac Build Environment
+#### 10.14 and higher are supported
 
-If this is a major release
+**Required**
+* [Xcode](https://developer.apple.com/support/xcode/)
+* [CMake](https://cmake.org/download/)
+* [conan](https://conan.io/) (version 1.28 or newer)  You need to install python (install version 3 or greater) and then in a terminal run `pip install conan` or `sudo pip install conan`, and make sure that your python bin dir is in your path. After that the rest of it should be automatic.
 
-- With Git, merge `develop` into `master`.
+***Optional***
+* [QtIFW](https://download.qt.io/official_releases/qt-installer-framework/3.2.2/QtInstallerFramework-mac-x64.dmg)
+* [Doxygen v1.8.8](http://ftp.stack.nl/pub/users/dimitri/Doxygen-1.8.8.dmg)
 
+After you install the required dependencies, you can clone the repository and run cmake setup and build a target. Below is an example of cloning the repo at develop branch and running a basic cmake config and building the target package. 
 
-DView Builds
-======
-
-Ubuntu
-------
-With Git, pull `iteration` branch.
-
-Ensure the correct version of wxWidgets is installed (currently 3.1.0, us "apt-get install libwxgtk3.0-dev")
-
-In a command window:
-
-    cd openstudio/buildMeta
-    ccmake ../
-
-In CMake check the following:
-
-- BUILD\_DVIEW
-- CMAKE\_BUILD\_TYPE = Release
-
-In CMake type the following:
-
-    c
-    g
-
-In a command window:
-
-    make DView
-
-Compress folder DView-install with DView, and upload to S3 (tar -zcvf DView-osx.tar.gz DView-install).
-
-Windows 64-bit
---------------
-With Git, pull `iteration` branch.
-
-Ensure the correct version of wxWidgets is installed (currently 3.1.0)
-
-In CMake, select current 64-bit compiler
-
-Point CMake to the top folder for source, and buildMeta folder for binaries
-
-In CMake check the following:
-
-- BUILD\_DVIEW
-
-Press `Configure` and `Generate` in CMake
-
-In Visual Studio:
-
-- Open OpenStudioMeta.sln
-- Select **Release** Solution Configuration
-
-Compress folder DView-install with DView, and upload to S3.
-
-Mac
----
-With Git, pull `iteration` branch.
-
-Ensure the correct version of wxWidgets is installed (currently 3.1.0)
-
-In a command window:
-
-    cd openstudio/buildMeta
-    ccmake ../
-
-In CMake check the following:
-
-- BUILD\_DVIEW
-- CMAKE\_BUILD\_TYPE = Release
-
-In CMake type the following:
-
-    c
-    g
-
-In a command window:
-```bash
-make DView –j16
-# When done:
-⌘ + q (to quit a Mac app)
+```shell
+git clone https://github.com/NREL/OpenStudio
+cd OpenStudio
+mkdir build 
+cd build  
+cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DBUILD_TESTING=ON -DBUILD_PACKAGE=ON -DCMAKE_BUILD_TYPE=Release  -DCPACK_BINARY_IFW=ON ../
+make -j $(nproc) package
 ```
 
-Locate the folder DView-install, right click and use Mac's compression algorithm. Upload to S3.
+## Unit Testing
 
-Update all DView MD5 values in openstudiocore/cmakelists.txt and upload to OpenStusio's GitHub repository.
+Provided you set the cmake option `-DBUILD_TESTING=ON` during your cmake config (see examples above),  you can use `ctest` to run the unit test suites.  This works on all platforms. Below are some examples of how to use ctest. 
 
-OpenStudio 2 Builds
-======
+`ctest -T test --no-compress-output` 
 
-Note: If the desire is to build OpenStudio 1.x, refer to the earlier version of this document dated 12/9/2016.
+You can also filter by type of tests you want to run (e.g.) 
 
-Ubuntu
-------
-With Git, pull `iteration` branch.
+`ctest -T test --no-compress-output -R IddFixture*` 
 
-In a command window:
+You can also speed up the unit tests by running in parallel by using the `-j` flag for num cores
 
-    cd openstudio/build
-    ccmake ../openstudiocore
+e.g. on a 4 core system
+`ctest -T test -j 4 --no-compress-output` 
 
-In CMake check the following:
+## Regression Testing
 
-- BUILD\_DVIEW
-- BUILD\_OS\_APP
-- BUILD\_PACKAGE
-- CMAKE\_BUILD\_TYPE = Release
-
-In CMake **uncheck** the following:
-
-- CPACK_BINARY_FOO (uncheck all)
-- CPACK_SOURCE_FOO (uncheck all)
-
-In CMake **check** the following:
-
-- CPACK\_BINARY\_DEB
-
-In CMake type the following:
-
-    c
-    g
-
-In a command window:
-
-    make –j16 package
-
-Copy .deb package from VM to Windows
-
-Windows 64-bit
---------------
-With Git, pull `iteration` branch.
-
-In CMake, select current 64-bit compiler
-
-Point CMake to the openstudiocore folder for source, and build folder for binaries
-
-In CMake check the following:
-
-- BUILD\_CSHARP\_BINDINGS
-- BUILD\_DOCUMENTATION
-- BUILD\_DVIEW
-- BUILD\_OS\_APP
-- BUILD\_PACKAGE
-- BUILD\_PAT
-- BUILD\_TESTING
-
-In CMake **uncheck** the following:
-
-- CPACK_BINARY_FOO (uncheck all)
-- CPACK_SOURCE_FOO (uncheck all)
-
-In CMake **check** the following:
-
-- CPACK\_BINARY\_IFW
-
-Press `Configure` and `Generate` in CMake
-
-In Visual Studio:
-
-- Open OpenStudio.sln
-- Select **Release** Solution Configuration
-- Build ALL_BUILD with IncrediBuild
-- Build PACKAGE
-
-Mac
----
-With Git, pull `iteration` branch.
-
-In a command window:
-
-    cd openstudio/build
-    ccmake ../openstudiocore
-
-In CMake check the following:
-
-- BUILD\_DVIEW
-- BUILD\_OS\_APP
-- BUILD\_PACKAGE
-- BUILD\_PAT
-- CMAKE\_BUILD\_TYPE = Release
-
-In CMake **uncheck** the following:
-
-- CPACK_BINARY_FOO (uncheck all)
-- CPACK_SOURCE_FOO (uncheck all)
-
-In CMake **check** the following:
-
-- CPACK\_BINARY\_IFW
-
-
-In CMake type the following:
-
-    c
-    g
-
-In a command window:
-
-```bash
-make -j16 package
-# When done:
-⌘ + q (to quit a Mac app)
-```
-
-Locate the package, right click and use Mac's compression algorithm.
-
-Copy build to VM's share folder
-
-**Note:** The package will appear to be an empty folder in the build directory, when in fact the package is in OpenStudio/build/_CPack_Packages/Darwin/IFW and it's file name will have no file type extension.
-
-**Note:** Making a build while on NREL's network (even the Dev VPN) and using a VMWare Mac VM will often fail when cmake attempts to download from GitHub the PAT SHA-specific zip file, meaning the developer will need to do this step manually. Example: https://github.com/NREL/OpenStudio-PAT/archive/f942affb1897678c4dc17a137fcf338e00da2cfb.zip. The contents off the above zip file's parent directory will need to be deleted prior to attempting again to build the package.
-
-OSVersion Testing
-=================
-
-In folder `build\Products\Release`
-
-- Open cmd prompt
-- Drag and drop `openstudio_osversion_tests.exe` onto the prompt, then run
-- Make sure everything passes
-
-Sanity Testing Release Builds
-=============================
-
-### Ubuntu
-- On a clean Ubuntu VM, install the current version of OpenStudio
-- Locate OpenStudioApp with "which OpenStudioApp", and navigate to its folder
-- ./OpenStudioApp, and make a model
-
-### Mac
-- On a clean Mac VM, install the current version of SketchUp and OpenStudio
-- Open SketchUp, and make and save a model.  Ensure that plug-in loads with Extensions Policy = "Identified Extensions Only".
-- Open OpenStudio, and open the model above
-- Open PAT, make a project, and select the model above as your baseline model
-
-### 64-bit Windows
-- On a clean Windows VM, install the current 64-bit version of SketchUp and the current 64-bit version of OpenStudio
-- Open SketchUp, and make and save a model.  Ensure that plug-in loads with Extensions Policy = "Identified Extensions Only".
-- Open OpenStudio, and open the model above
-- Open PAT, make a project, and select the model above as your baseline model
-
-### Tests to run
-- Test prior version of OpenStudio model
-- Test prior version of PAT project
-- Use SketchUp to make a model on Windows 64 bit, and Mac
-- Test running PAT on the cloud on at least one platform
-- Test BCL downloads
-- Test user scripts in SketchUp
-- Test Apply Measures Now
-- Run simulation in OpenStudio
-- Run simulation in PAT
-- Test opening results in ResultsViewer
-
-
-GitHub Releases
-===============
-https://github.com/NREL/OpenStudio/releases
-
-- Select "Draft a new release"
-- Set tag version = vX.Y.Z
-- If this is a major release
-    - Set Target = `master`
-- Else If this is an iteration build
-    - Set Target = `iteration`
-- Set Release title = OpenStudio vX.Y.Z
-- Check "This is a pre-release" for an iteration build
-- Select "Save draft"
-- Publish release
-- Attach binaries by drag and drop (tip: Save draft after each binary successfully added)
-- Select "Publish release"
-
-OpenStudio.net
-==============
-In S3:
-
-- In `openstudio-builds` bucket, make directory for new builds (X.Y.Z)
-- Drag and drop the builds into above bucket
-- Right-click on the newly uploaded files, and `Generate Web URLs`
-
-On [OpenStudio.net](https://www.openstudio.net/):
-
-Your account must have admin privileges in order to perform the following actions.
-- Select `Edit OpenStudio Release Links` in the gray menu bar at the top
-    - Update `Current Release Version` or `Develop Release Version` (depending on whether a major or iteration build is being done)
-    - Replace the S3 build URLs with those generated above
-- Click on `Add Announcement` and/or `Add Developer News Item` in the gray menu bar at the top to add a release announcement.  Announcements are featured on the `Home` page, while Developer news items are featured on the `Developers` tab.
-    
-In openstudio-web repo, master branch:
-
-- Update the `docroot\update.html` file with the new OpenStudio release information (version, date, release notes URL) in both the <release> tag and in the [CDATA] section. 
-- Commit to both the NREL repo and the Acquia repo (you will need to get access and to add a remote to commit to the Acquia repo).
-- Deploy the changes to production via the Acquia Insight
-
-
-Verification of Posted Software
-===============================
-
-Download all posted software from both GitHub and S3. Verify that each downloaded files' MD5 hash matches their respective MD5 hash of the original, tested files from the build machines.
-
-
-Documentation
-=============
-
-In Visual Studio:
-
-- Open OpenStudioCore.sln
-- **Without** IncrediBuild, build ALL\_DOXYGEN
-
-Ruby documentation (ALL\_RDOC) is no longer being built
-
-In folder `build\OSCore-prefix\src\OSCore-build\doc`
-
-- Extract zip OpenStudio-X.Y.Z-doc.zip to a similarly named directory
-
-In S3:
-
-- Drag extracted directory into S3 directory `openstudio-sdk-documentation/cpp`
-
-For major releases, delete the content of `openstudio-sdk-documentation/cpp/latest` and drag in the contents of `build\OSCore-prefix\src\OSCore-build\doc\OpenStudio-X.Y.Z-doc`
-
-- From `openstudio-sdk-documentation` bucket, download index.html and edit to new release numbers
-- Test at https://openstudio-sdk-documentation.s3.amazonaws.com/index.html
-
-
-OpenStudio News Update
-======================
-
-If this is a major release, a news update must be written
-
-- At https://www.openstudio.net/ click "Add Announcement" and publish a release note.
-
-OpenStudio-Web Update
-=====================
-
-If this is a major release, OpenStudio-web must be updated
-
-In the docroot folder\
-
-- open update.html and update its build version, sha, and date (2 places)
-
-
-Final Steps
-=============
-- With Git, switch to `develop`.
-
-
-Update CHANGELOG.md
-=================
-
-### Set the desired stats date range
-In folder `developer\ruby`
-- Open GitHubIssueStats.rb, and adjust date range
-
-### Get the stats
-In folder `developer\ruby`, open Git Bash and type the following
-
-    gem install github_api
-    ruby GitHubIssueStats.rb
-    ruby GitHubIssueStats.rb > out.txt
-
-Open out.txt, and paste data into CHANGELOG.md
-
-Commit GitHubIssueStats.rb and CHANGELOG.md to the develop branch
-
-
-Version Update
-==============
-
-The current version (X.Y.Z) being built, and the updated version (X.Y.Z+1) for the upcoming iteration need to be correctly incorporated into their respective documents.
-
-- In the top level of your OpenStudio folder, update `CMakeLists.txt` version to X.Y.Z+1 (3 lines), e.g. `set(CMAKE_VERSION_MAJOR 2)`, `set(CMAKE_VERSION_MINOR 0)`, `set(CMAKE_VERSION_PATCH 1)`
-- In the openstudiocore level of your OpenStudio folder, update `CMakeLists.txt` version to X.Y.Z+1 (1 line), e.g. `project(OpenStudio VERSION 2.0.1)`
-- Copy file `openstudiocore\resources\model\OpenStudio.idd` to `openstudiocore\src\utilities\idd\versions\x_Y_Z` (new folder)
-- In `openstudiocore\resources\model` update `OpenStudio.idd` version to X.Y.Z+1 (1 line)
-- In `openstudiocore\src\osversion` update `VersionTranslator.cpp` version to X.Y.Z+1 in first location, and X.Y.Z in second location
-
-At https://github.com/NREL/OpenStudio/blob/develop/openstudiocore/src/osversion/VersionTranslator.cpp
-
-- Select "History", see edits if needed (usually use `defaultUpdate` in first location, 1 line for each of 2 locations)
-
-With Git, commit above files (Commit Message = `Update version to X.Y.Z+1`) to the develop branch
-
-AMI BUILD
-=========
-TBD
-
-Compatibility Matrix
-====================
-On https://github.com/NREL/OpenStudio/wiki/OpenStudio-SDK-Version-Compatibility-Matrix
-
-- Select `Edit` and add a new row of information
-
-
-Docker Image
-============
-
-In the top level of your docker-openstudio folder, modify `Dockerfile`
-
-- Update OPENSTUDIO_VERSION with current version (X.Y.Z)
-- Update OPENSTUDIO_SHA with current SHA
-
-With Git, create feature branch "release-X.Y.Z" and commit Dockerfile (Commit Message = Bump OpenStudio version to OS.x.y.z.sha), 
-
-Travis CI will build, test, and deploy the container. If there is an issue, the committer will receive an email with the error.
-
-There is no need to tag releases anymore.
+Please consult https://github.com/NREL/OpenStudio-resources for all SDK regression testing. 


### PR DESCRIPTION
resolves #4058 

Removed SketchUp references in building and testing docs and updates info the current workflow that supports 3.x.x series. We should create a separate page for OpenStudio release process as it was previously included in this document. 

