### PR TITLE
Fix issue with the test portion of the python bindings workflow (no +1 for version)

### DIFF
--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -252,7 +252,7 @@ jobs:
           set -x
           python -m pip install --upgrade pip
           pip install requests packaging
-          bindings_v=$(python ./python/find_pypi_tag.py)
+          bindings_v=$(python ./python/find_pypi_tag.py --current)
           pip install -i https://test.pypi.org/simple/ openstudio==$bindings_v
 
     - name: Test the bindings

--- a/python/find_pypi_tag.py
+++ b/python/find_pypi_tag.py
@@ -51,6 +51,10 @@ if __name__ == '__main__':
                         action='store_true',
                         help="Check pypi instead of testpypi")
 
+    parser.add_argument("--current", default=False,
+                        action='store_true',
+                        help="Check current version instead of incrementing by one")
+
     args = parser.parse_args()
     current_v = parse_cmake_version_info()
     releases = parse_pypi_version(pypi=args.pypi)
@@ -63,7 +67,10 @@ if __name__ == '__main__':
         max_v = max(matched_releases)
         if max_v.pre:
             pre_iden, pre_v = max_v.pre
-            new_v += f"{pre_iden}{pre_v + 1}"
+            if args.current:
+                new_v += f"{pre_iden}{pre_v}"
+            else:
+                new_v += f"{pre_iden}{pre_v + 1}"
         else:
             new_v += ".post1"
     else:


### PR DESCRIPTION
https://github.com/NREL/OpenStudio/runs/1764809039?check_suite_focus=true#step:4:41

The script to parse the available version from testpypi increments +1 by default, but for testing we shouldn't do that obviously.