### PR TITLE
Hotfix: Add missing \ip-units following #4157

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -18947,6 +18947,7 @@ OS:Coil:Cooling:Water:Panel:Radiant,
        \autosizable
        \type real
        \units m3/s
+       \ip-units gal/min
   A6 , \field Control Type
        \note Temperature on which unit is controlled
        \required-field


### PR DESCRIPTION
Add missing \ip-units following #4157

```diff
OS:Coil:Cooling:Water:Panel:Radiant,
 
  N7 , \field Maximum Chilled Water Flow Rate
       \required-field
       \autosizable
       \type real
       \units m3/s
+       \ip-units gal/min
```