### PR TITLE
Fix #4205 - WorkspaceObject::setString allows setting invalid names for ModelObjects

### DIFF
--- a/src/utilities/idf/IdfObject.cpp
+++ b/src/utilities/idf/IdfObject.cpp
@@ -440,7 +440,7 @@ namespace detail {
   bool IdfObject_Impl::setString(unsigned index, const std::string& _value, bool checkValidity) {
     std::string value = encodeString(_value);
 
-    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex())) {
+    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex().get())) {
       return IdfObject_Impl::setName(value, checkValidity).has_value();
     }
 
@@ -579,7 +579,7 @@ namespace detail {
   bool IdfObject_Impl::pushString(const std::string& value, bool checkValidity) {
     // get new index
     unsigned index = m_fields.size();
-    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex())) {
+    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex().get())) {
       return IdfObject_Impl::setName(value, checkValidity).has_value();
     }
 

--- a/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
+++ b/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
@@ -571,11 +571,12 @@ TEST_F(IdfFixture, WorkspaceObject_setString) {
   ASSERT_TRUE(space1.getString(nameIndex));
   EXPECT_EQ("Space 1", space1.getString(nameIndex).get());
 
-  EXPECT_FALSE(space2.setString(nameIndex, "Space 1"));
+  EXPECT_TRUE(space2.setString(nameIndex, "Space 1"));   // Setting works, but it should modify it
   ASSERT_TRUE(space2.getString(nameIndex));
   EXPECT_NE("Space 1", space2.getString(nameIndex).get());
 
-  EXPECT_FALSE(space2.setString(nameIndex, ""));
+  // That portion is accepted because the level is Draft, not Final
+  EXPECT_TRUE(space2.setString(nameIndex, ""));
   ASSERT_TRUE(space2.getString(nameIndex));
-  EXPECT_NE("", space2.getString(nameIndex).get());
+  EXPECT_EQ("", space2.getString(nameIndex).get());
 }

--- a/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
+++ b/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
@@ -557,3 +557,25 @@ TEST_F(IdfFixture, WorkspaceObject_SetDouble_NaN_and_Inf) {
   EXPECT_FALSE(object2.pushExtensibleGroup(group).empty());
   EXPECT_EQ(2u, object2.numExtensibleGroups());
 }
+
+TEST_F(IdfFixture, WorkspaceObject_setString) {
+
+  // Test for #4205 - setString on a WorkspaceObject should prevent duplicate names
+  Workspace ws(StrictnessLevel::Draft, IddFileType::OpenStudio);
+  WorkspaceObject space1 = ws.addObject(IdfObject(IddObjectType::OS_Space)).get();
+
+  WorkspaceObject space2 = ws.addObject(IdfObject(IddObjectType::OS_Space)).get();
+
+  unsigned nameIndex = 1;
+  EXPECT_TRUE(space1.setString(nameIndex, "Space 1"));
+  ASSERT_TRUE(space1.getString(nameIndex));
+  EXPECT_EQ("Space 1", space1.getString(nameIndex).get());
+
+  EXPECT_FALSE(space2.setString(nameIndex, "Space 1"));
+  ASSERT_TRUE(space2.getString(nameIndex));
+  EXPECT_NE("Space 1", space2.getString(nameIndex).get());
+
+  EXPECT_FALSE(space2.setString(nameIndex, ""));
+  ASSERT_TRUE(space2.getString(nameIndex));
+  EXPECT_NE("", space2.getString(nameIndex).get());
+}

--- a/src/utilities/idf/WorkspaceObject.cpp
+++ b/src/utilities/idf/WorkspaceObject.cpp
@@ -431,7 +431,7 @@ namespace detail {
     }
 
     // regular field -- name or data
-    if ((iddObject().hasNameField()) && (index == m_iddObject.nameFieldIndex())) {
+    if ((iddObject().hasNameField()) && (index == iddObject().nameFieldIndex().get())) {
       return setName(value, checkValidity).has_value();
     }  // name
 

--- a/src/utilities/idf/WorkspaceObject.cpp
+++ b/src/utilities/idf/WorkspaceObject.cpp
@@ -431,7 +431,7 @@ namespace detail {
     }
 
     // regular field -- name or data
-    if ((index == 0) && (iddObject().hasNameField())) {
+    if ((iddObject().hasNameField()) && (index == m_iddObject.nameFieldIndex())) {
       return setName(value, checkValidity).has_value();
     }  // name
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4205
 -  WorkspaceObject::setString allows setting invalid names for ModelObjects


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
