### PR TITLE
Fix set string index 1 for ModelObjects

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -31937,7 +31937,6 @@ OS:Output:Meter,
   A2, \field Name
        \note Form is EnergyUseType:..., e.g. Electricity:* for all Electricity meters
        \note or EndUse:..., e.g. GeneralLights:* for all General Lights
-       \required-field
        \type alpha
        \memo type external-list
        \memo external-list autoRDDmeter

--- a/src/model/test/ModelObject_GTest.cpp
+++ b/src/model/test/ModelObject_GTest.cpp
@@ -38,6 +38,8 @@
 #include "../Surface_Impl.hpp"
 #include "../Construction.hpp"
 #include "../Construction_Impl.hpp"
+#include "../Space.hpp"
+#include "../Space_Impl.hpp"
 #include "../StandardsInformationConstruction.hpp"
 #include "../StandardsInformationConstruction_Impl.hpp"
 #include "../StandardOpaqueMaterial.hpp"
@@ -124,4 +126,26 @@ TEST_F(ModelFixture, ModelObject_Clone_DifferentModel) {
   EXPECT_FALSE(anotherNewSurface.construction().get().standardsInformation() == newSurface.construction().get().standardsInformation());
   EXPECT_TRUE(anotherNewSurface.construction().get().cast<LayeredConstruction>().layers()
               == newSurface.construction().get().cast<LayeredConstruction>().layers());
+}
+
+TEST_F(ModelFixture, ModelObject_SetString) {
+  Model model;
+  Space space1(model);
+  Space space2(model);
+  unsigned nameIndex = 1;
+
+  EXPECT_TRUE(space1.setString(nameIndex, "Space 1"));
+  ASSERT_TRUE(space1.getString(nameIndex));
+  EXPECT_EQ("Space 1", space1.getString(nameIndex).get());
+
+  // Set string will return true but the string will not be "Space 1"
+  EXPECT_TRUE(space2.setString(nameIndex, "Space 1"));
+  ASSERT_TRUE(space2.getString(nameIndex));
+  EXPECT_NE("Space 1", space2.getString(nameIndex).get());
+  EXPECT_EQ("Space 2", space2.getString(nameIndex).get());
+
+  EXPECT_FALSE(space2.setString(nameIndex, ""));
+  ASSERT_TRUE(space2.getString(nameIndex));
+  EXPECT_NE("", space2.getString(nameIndex).get());
+  EXPECT_EQ("Space 2", space2.getString(nameIndex).get());
 }

--- a/src/model/test/OutputMeter_GTest.cpp
+++ b/src/model/test/OutputMeter_GTest.cpp
@@ -202,6 +202,11 @@ TEST_F(ModelFixture, MeterConstructor) {
   // check order of operations
   // this is a corner case of EnergyPlus, there is no 'Heating:NaturalGas:Facility', it is just 'Heating:NaturalGas'
   meter = OutputMeter(model);
+  EXPECT_FALSE(meter.specificEndUse());
+  EXPECT_FALSE(meter.endUseType());
+  EXPECT_FALSE(meter.fuelType());
+  EXPECT_FALSE(meter.installLocationType());
+  EXPECT_FALSE(meter.specificInstallLocation());
   EXPECT_TRUE(meter.setFuelType(FuelType::Gas));
   EXPECT_TRUE(meter.setInstallLocationType(InstallLocationType::Facility));
   EXPECT_TRUE(meter.setEndUseType(EndUseType::Heating));
@@ -212,6 +217,11 @@ TEST_F(ModelFixture, MeterConstructor) {
   EXPECT_EQ(EndUseType::Heating, meter.endUseType().get().value());
 
   meter = OutputMeter(model);
+  EXPECT_FALSE(meter.specificEndUse());
+  EXPECT_FALSE(meter.endUseType());
+  EXPECT_FALSE(meter.fuelType());
+  EXPECT_FALSE(meter.installLocationType());
+  EXPECT_FALSE(meter.specificInstallLocation());
   EXPECT_TRUE(meter.setInstallLocationType(InstallLocationType::Facility));
   EXPECT_TRUE(meter.setFuelType(FuelType::Gas));
   EXPECT_TRUE(meter.setEndUseType(EndUseType::Heating));
@@ -222,6 +232,11 @@ TEST_F(ModelFixture, MeterConstructor) {
   EXPECT_EQ(EndUseType::Heating, meter.endUseType().get().value());
 
   meter = OutputMeter(model);
+  EXPECT_FALSE(meter.specificEndUse());
+  EXPECT_FALSE(meter.endUseType());
+  EXPECT_FALSE(meter.fuelType());
+  EXPECT_FALSE(meter.installLocationType());
+  EXPECT_FALSE(meter.specificInstallLocation());
   EXPECT_TRUE(meter.setEndUseType(EndUseType::Heating));
   EXPECT_TRUE(meter.setInstallLocationType(InstallLocationType::Facility));
   EXPECT_TRUE(meter.setFuelType(FuelType::Gas));
@@ -233,6 +248,11 @@ TEST_F(ModelFixture, MeterConstructor) {
 
   // make sure we don't mix up gasoline with gas
   meter = OutputMeter(model);
+  EXPECT_FALSE(meter.specificEndUse());
+  EXPECT_FALSE(meter.endUseType());
+  EXPECT_FALSE(meter.fuelType());
+  EXPECT_FALSE(meter.installLocationType());
+  EXPECT_FALSE(meter.specificInstallLocation());
   EXPECT_TRUE(meter.setFuelType(FuelType::Gasoline));
   EXPECT_TRUE(meter.setInstallLocationType(InstallLocationType::Facility));
   ASSERT_TRUE(meter.fuelType());
@@ -242,6 +262,11 @@ TEST_F(ModelFixture, MeterConstructor) {
 
   // make sure we can get FuelOil1
   meter = OutputMeter(model);
+  EXPECT_FALSE(meter.specificEndUse());
+  EXPECT_FALSE(meter.endUseType());
+  EXPECT_FALSE(meter.fuelType());
+  EXPECT_FALSE(meter.installLocationType());
+  EXPECT_FALSE(meter.specificInstallLocation());
   EXPECT_TRUE(meter.setFuelType(FuelType::FuelOil_1));
   EXPECT_TRUE(meter.setInstallLocationType(InstallLocationType::Facility));
   ASSERT_TRUE(meter.fuelType());

--- a/src/model/test/SwimmingPoolIndoor_GTest.cpp
+++ b/src/model/test/SwimmingPoolIndoor_GTest.cpp
@@ -87,7 +87,7 @@ TEST_F(ModelFixture, SwimmingPoolIndoor_GettersSetters) {
   boost::optional<Space> space2 = Space::fromFloorPrint(floorPrint, 3, m);
   ASSERT_TRUE(space2);
   auto surfaces2 = space2->surfaces();
-  auto floorSurfaceIt2 = std::find_if(std::begin(surfaces), std::end(surfaces), [](const auto& surface) { return surface.surfaceType() == "Floor"; });
+  auto floorSurfaceIt2 = std::find_if(std::begin(surfaces2), std::end(surfaces2), [](const auto& surface) { return surface.surfaceType() == "Floor"; });
   ASSERT_NE(floorSurfaceIt2, std::end(surfaces2));
   Surface floorSurface2 = *floorSurfaceIt2;
   EXPECT_TRUE(swimmingPoolIndoor.setSurface(floorSurface2));

--- a/src/model/test/WindowPropertyFrameAndDivider_GTest.cpp
+++ b/src/model/test/WindowPropertyFrameAndDivider_GTest.cpp
@@ -77,13 +77,13 @@ TEST_F(ModelFixture, WindowPropertyFrameAndDivider_Name) {
   ASSERT_TRUE(frameAndDivider2.name());
   EXPECT_EQ("Window Property Frame And Divider 2", frameAndDivider2.name().get());
 
-  // setName api protects against empty names that are equal
-  EXPECT_TRUE(frameAndDivider1.setName(""));
-  EXPECT_TRUE(frameAndDivider2.setName(""));
+  // setName api protects against empty names
+  EXPECT_FALSE(frameAndDivider1.setName(""));
+  EXPECT_FALSE(frameAndDivider2.setName(""));
   ASSERT_TRUE(frameAndDivider1.name());
-  EXPECT_EQ("", frameAndDivider1.name().get());
+  EXPECT_EQ("Window Property Frame And Divider 1", frameAndDivider1.name().get());
   ASSERT_TRUE(frameAndDivider2.name());
-  EXPECT_EQ(" 1", frameAndDivider2.name().get());
+  EXPECT_EQ("Window Property Frame And Divider 2", frameAndDivider2.name().get());
 
   // setName api protects against non-empty names that are equal
   EXPECT_TRUE(frameAndDivider1.setName("Frame"));
@@ -93,19 +93,19 @@ TEST_F(ModelFixture, WindowPropertyFrameAndDivider_Name) {
   ASSERT_TRUE(frameAndDivider2.name());
   EXPECT_EQ("Frame 1", frameAndDivider2.name().get());
 
-  // setString api does not protect against non-empty names that are equal
+  // setString api protects against non-empty names that are equal
   EXPECT_TRUE(frameAndDivider1.setString(OS_WindowProperty_FrameAndDividerFields::Name, "Divider"));
   EXPECT_TRUE(frameAndDivider2.setString(OS_WindowProperty_FrameAndDividerFields::Name, "Divider"));
   ASSERT_TRUE(frameAndDivider1.name());
   EXPECT_EQ("Divider", frameAndDivider1.name().get());
   ASSERT_TRUE(frameAndDivider2.name());
-  EXPECT_EQ("Divider", frameAndDivider2.name().get());
+  EXPECT_EQ("Divider 1", frameAndDivider2.name().get());
 
-  // setString api does not protect against empty names that are equal
-  EXPECT_TRUE(frameAndDivider1.setString(OS_WindowProperty_FrameAndDividerFields::Name, ""));
-  EXPECT_TRUE(frameAndDivider2.setString(OS_WindowProperty_FrameAndDividerFields::Name, ""));
+  // setString api protects against empty names that are equal
+  EXPECT_FALSE(frameAndDivider1.setString(OS_WindowProperty_FrameAndDividerFields::Name, ""));
+  EXPECT_FALSE(frameAndDivider2.setString(OS_WindowProperty_FrameAndDividerFields::Name, ""));
   ASSERT_TRUE(frameAndDivider1.name());
-  EXPECT_EQ("", frameAndDivider1.name().get());
+  EXPECT_EQ("Divider", frameAndDivider1.name().get());
   ASSERT_TRUE(frameAndDivider2.name());
-  EXPECT_EQ("", frameAndDivider2.name().get());
+  EXPECT_EQ("Divider 1", frameAndDivider2.name().get());
 }

--- a/src/utilities/idf/IdfObject.cpp
+++ b/src/utilities/idf/IdfObject.cpp
@@ -437,7 +437,7 @@ namespace detail {
   bool IdfObject_Impl::setString(unsigned index, const std::string& _value, bool checkValidity) {
     std::string value = encodeString(_value);
 
-    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex())) {
+    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex().get())) {
       return IdfObject_Impl::setName(value, checkValidity).has_value();
     }
 
@@ -576,7 +576,7 @@ namespace detail {
   bool IdfObject_Impl::pushString(const std::string& value, bool checkValidity) {
     // get new index
     unsigned index = m_fields.size();
-    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex())) {
+    if (m_iddObject.hasNameField() && (index == m_iddObject.nameFieldIndex().get())) {
       return IdfObject_Impl::setName(value, checkValidity).has_value();
     }
 

--- a/src/utilities/idf/Test/WorkspaceObjectWatcher_GTest.cpp
+++ b/src/utilities/idf/Test/WorkspaceObjectWatcher_GTest.cpp
@@ -85,13 +85,13 @@ TEST_F(IdfFixture, WorkspaceObjectWatcher_DataFieldChanges) {
   WorkspaceObjectWatcher watcher(lights);
   EXPECT_FALSE(watcher.dirty());
 
-  EXPECT_TRUE(lights.setName(""));
+  EXPECT_TRUE(lights.setName("Lights"));
   EXPECT_TRUE(watcher.dirty());
   EXPECT_FALSE(watcher.dataChanged());
   EXPECT_TRUE(watcher.nameChanged());
   EXPECT_FALSE(watcher.relationshipChanged());
   watcher.clearState();
-  EXPECT_TRUE(lights.createName(false));
+  EXPECT_TRUE(lights.createName(true));
   EXPECT_TRUE(watcher.dirty());
   EXPECT_FALSE(watcher.dataChanged());
   EXPECT_TRUE(watcher.nameChanged());

--- a/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
+++ b/src/utilities/idf/Test/WorkspaceObject_GTest.cpp
@@ -234,7 +234,7 @@ TEST_F(IdfFixture, WorkspaceObject_Lights_Strictness_Draft) {
   ASSERT_TRUE(light);
 
   // certain things we can't invalidate
-  EXPECT_TRUE(light->setString(LightsFields::Name, ""));
+  EXPECT_FALSE(light->setString(LightsFields::Name, ""));
   EXPECT_TRUE(light->setDouble(LightsFields::Name, 0));
 
   EXPECT_TRUE(light->setString(LightsFields::ZoneorZoneListName, ""));         // PointerType error

--- a/src/utilities/idf/WorkspaceObject.cpp
+++ b/src/utilities/idf/WorkspaceObject.cpp
@@ -359,7 +359,7 @@ namespace detail {
     if (checkValidity && (level > StrictnessLevel::None)) {
 
       // do not set if would violate field NullAndRequired
-      if ((level > StrictnessLevel::Draft) && newName.empty() && iddObject().isRequiredField(*index)) {
+      if ((level >= StrictnessLevel::Draft) && newName.empty() && iddObject().isRequiredField(*index)) {
         return boost::none;
       }
 
@@ -370,7 +370,7 @@ namespace detail {
       }
 
       // check collection NameConflict
-      if (!uniquelyIdentifiableByName()) {
+      if (!newName.empty() && iddObject().isRequiredField(*index) && !uniquelyIdentifiableByName()) {
         result = IdfObject_Impl::setName(workspace().nextName(*result, false));
         OS_ASSERT(result);
       }
@@ -431,8 +431,11 @@ namespace detail {
     }
 
     // regular field -- name or data
-    if ((index == 0) && (iddObject().hasNameField())) {
-      return setName(value, checkValidity).has_value();
+    if (iddObject().hasNameField()) {
+      boost::optional<unsigned> nameIndex = iddObject().nameFieldIndex(); 
+      if (nameIndex && (*nameIndex == index)) {
+        return setName(value, checkValidity).has_value();
+      }
     }  // name
 
     // record diffs at start


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4205  - WorkspaceObject::setString allows setting invalid names for ModelObjects

Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [x] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
