### PR TITLE
Fix #4226 - add int argument for ScheduleFile.setMinutesperItem method

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -5200,6 +5200,7 @@ OS:Schedule:File,
        \default No
   N4;  \field Minutes per Item
        \type choice
+       \default 60
        \key 1
        \key 2
        \key 3

--- a/src/energyplus/ReverseTranslator/ReverseTranslateScheduleFile.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateScheduleFile.cpp
@@ -86,19 +86,13 @@ namespace energyplus {
 
     OptionalString os = workspaceObject.getString(Schedule_FileFields::InterpolatetoTimestep);
     if (os) {
-      std::string temp = *os;
-      boost::to_lower(temp);
-      if (temp == "yes") {
+      if (openstudio::istringEqual("Yes", os.get())) {
         scheduleFile.setInterpolatetoTimestep(true);
       }
     }
 
     if (OptionalInt oi = workspaceObject.getInt(Schedule_FileFields::MinutesperItem)) {
-      double result = 60.0 / (double)oi.get();
-      if (trunc(result) == result) {
-        scheduleFile.setMinutesperItem(std::to_string((int)result));
-      }
-      // Throw?
+      scheduleFile.setMinutesperItem(oi.get());
     }
 
     return scheduleFile;

--- a/src/model/ScheduleFile.cpp
+++ b/src/model/ScheduleFile.cpp
@@ -213,7 +213,6 @@ namespace model {
       bool result = setInt(OS_Schedule_FileFields::MinutesperItem, minutesperItem);
       if (!result) {
         LOG(Warn, "Invalid 'Minutes per Item' (=" << minutesperItem << ") supplied for " << briefDescription());
-
       }
       return result;
     }

--- a/src/model/ScheduleFile.cpp
+++ b/src/model/ScheduleFile.cpp
@@ -105,8 +105,10 @@ namespace model {
       return value.get();
     }
 
-    boost::optional<int> ScheduleFile_Impl::numberofHoursofData() const {
-      return getInt(OS_Schedule_FileFields::NumberofHoursofData, true);
+    int ScheduleFile_Impl::numberofHoursofData() const {
+      boost::optional<int> value = getInt(OS_Schedule_FileFields::NumberofHoursofData, true);
+      OS_ASSERT(value);
+      return value.get();
     }
 
     bool ScheduleFile_Impl::isNumberofHoursofDataDefaulted() const {
@@ -145,8 +147,10 @@ namespace model {
       return isEmpty(OS_Schedule_FileFields::InterpolatetoTimestep);
     }
 
-    boost::optional<std::string> ScheduleFile_Impl::minutesperItem() const {
-      return getString(OS_Schedule_FileFields::MinutesperItem, true);
+    int ScheduleFile_Impl::minutesperItem() const {
+      boost::optional<int> value = getInt(OS_Schedule_FileFields::MinutesperItem, true);
+      OS_ASSERT(value);
+      return value.get();
     }
 
     bool ScheduleFile_Impl::isMinutesperItemDefaulted() const {
@@ -205,8 +209,12 @@ namespace model {
       OS_ASSERT(result);
     }
 
-    bool ScheduleFile_Impl::setMinutesperItem(const std::string& minutesperItem) {
-      bool result = setString(OS_Schedule_FileFields::MinutesperItem, minutesperItem);
+    bool ScheduleFile_Impl::setMinutesperItem(int minutesperItem) {
+      bool result = setInt(OS_Schedule_FileFields::MinutesperItem, minutesperItem);
+      if (!result) {
+        LOG(Warn, "Invalid 'Minutes per Item' (=" << minutesperItem << ") supplied for " << briefDescription());
+
+      }
       return result;
     }
 
@@ -224,14 +232,14 @@ namespace model {
 
     /* FIXME!
   openstudio::TimeSeries ScheduleFile_Impl::timeSeries(unsigned columnIndex) const
-  { 
+  {
     // need to catch integers less than or equal to 0
     // need to ensure that first column is dateTimes
-    
+
     boost::optional<CSVFile> csvFile;
     ExternalFile externalFile = this->externalFile();
-    csvFile = CSVFile::load(externalFile.filePath());    
-    
+    csvFile = CSVFile::load(externalFile.filePath());
+
     std::vector<DateTime> dateTimes = csvFile->getColumnAsDateTimes(0);
     std::vector<double> values = csvFile->getColumnAsDoubleVector(columnIndex);
     Vector vectorValues(values.size());
@@ -428,7 +436,7 @@ namespace model {
   }
 
   boost::optional<std::string> ScheduleFile::minutesperItem() const {
-    return getImpl<detail::ScheduleFile_Impl>()->minutesperItem();
+    return std::to_string(getImpl<detail::ScheduleFile_Impl>()->minutesperItem());
   }
 
   bool ScheduleFile::isMinutesperItemDefaulted() const {
@@ -488,6 +496,15 @@ unsigned ScheduleFile::addTimeSeries(const openstudio::TimeSeries& timeSeries) {
   }
 
   bool ScheduleFile::setMinutesperItem(const std::string& minutesperItem) {
+    LOG(Warn, "ScheduleFile::setMinutesperItem(const std::string&) is deprecated, use the ScheduleFile::setMinutesperItem(int) instead");
+    try {
+      return getImpl<detail::ScheduleFile_Impl>()->setMinutesperItem(std::stoi(minutesperItem));
+    } catch (...) {
+      return false;
+    }
+  }
+
+  bool ScheduleFile::setMinutesperItem(int minutesperItem) {
     return getImpl<detail::ScheduleFile_Impl>()->setMinutesperItem(minutesperItem);
   }
 

--- a/src/model/ScheduleFile.hpp
+++ b/src/model/ScheduleFile.hpp
@@ -34,11 +34,12 @@
 #include "ScheduleInterval.hpp"
 #include "../utilities/filetypes/CSVFile.hpp"
 
+#include "../utilities/core/Deprecated.hpp"
+
 namespace openstudio {
 
 namespace model {
 
-  // TODO: Check the following class names against object getters and setters.
   class ScheduleTypeLimits;
   class ExternalFile;
 
@@ -68,7 +69,6 @@ namespace model {
     /** @name Getters */
     //@{
 
-    // TODO: Check return type. From object lists, some candidates are: ScheduleTypeLimits.
     boost::optional<ScheduleTypeLimits> scheduleTypeLimits() const;
 
     ExternalFile externalFile() const;
@@ -77,6 +77,7 @@ namespace model {
 
     int rowstoSkipatTop() const;
 
+    // This should be returning `int` as it has a default
     boost::optional<int> numberofHoursofData() const;
 
     bool isNumberofHoursofDataDefaulted() const;
@@ -89,6 +90,7 @@ namespace model {
 
     bool isInterpolatetoTimestepDefaulted() const;
 
+    // This should be returning `int` instead of boost::optional<std::string>...
     boost::optional<std::string> minutesperItem() const;
 
     bool isMinutesperItemDefaulted() const;
@@ -101,7 +103,6 @@ namespace model {
     /** @name Setters */
     //@{
 
-    // TODO: Check argument type. From object lists, some candidates are: ScheduleTypeLimits.
     bool setScheduleTypeLimits(const ScheduleTypeLimits& scheduleTypeLimits);
 
     bool resetScheduleTypeLimits();
@@ -120,7 +121,9 @@ namespace model {
 
     void resetInterpolatetoTimestep();
 
-    bool setMinutesperItem(const std::string& minutesperItem);
+    OS_DEPRECATED bool setMinutesperItem(const std::string& minutesperItem);
+
+    bool setMinutesperItem(int minutesperItem);
 
     void resetMinutesperItem();
 

--- a/src/model/ScheduleFile_Impl.hpp
+++ b/src/model/ScheduleFile_Impl.hpp
@@ -38,7 +38,6 @@ namespace openstudio {
 
 namespace model {
 
-  // TODO: Check the following class names against object getters and setters.
   class ScheduleTypeLimits;
   class ExternalFile;
 
@@ -85,7 +84,7 @@ namespace model {
 
       int rowstoSkipatTop() const;
 
-      boost::optional<int> numberofHoursofData() const;
+      int numberofHoursofData() const;
 
       bool isNumberofHoursofDataDefaulted() const;
 
@@ -99,7 +98,7 @@ namespace model {
 
       bool isInterpolatetoTimestepDefaulted() const;
 
-      boost::optional<std::string> minutesperItem() const;
+      int minutesperItem() const;
 
       bool isMinutesperItemDefaulted() const;
 
@@ -127,7 +126,7 @@ namespace model {
 
       void resetInterpolatetoTimestep();
 
-      bool setMinutesperItem(const std::string& minutesperItem);
+      bool setMinutesperItem(int minutesperItem);
 
       void resetMinutesperItem();
 

--- a/src/model/test/ScheduleInterval_GTest.cpp
+++ b/src/model/test/ScheduleInterval_GTest.cpp
@@ -315,6 +315,19 @@ TEST_F(ModelFixture, ScheduleFile) {
   //EXPECT_EQ("Tab", externalfile.columnSeparator().get());
   //EXPECT_EQ("Comma", externalfile.columnSeparator().get());
 
+  // The API is kinda broken on this one, but preserving it...
+  EXPECT_TRUE(schedule3.isMinutesperItemDefaulted());
+  ASSERT_TRUE(schedule3.minutesperItem());
+  EXPECT_EQ("60", schedule3.minutesperItem().get());
+  EXPECT_TRUE(schedule3.setMinutesperItem(5)); // This is a valid choice
+  EXPECT_EQ("5", schedule3.minutesperItem().get());
+  EXPECT_FALSE(schedule3.setMinutesperItem(7)); // This is not a valid choice
+  EXPECT_EQ("5", schedule3.minutesperItem().get());
+  schedule3.resetMinutesperItem();
+  EXPECT_TRUE(schedule3.isMinutesperItemDefaulted());
+  ASSERT_TRUE(schedule3.minutesperItem());
+  EXPECT_EQ("60", schedule3.minutesperItem().get());
+
   // shouldn't create a new object
   boost::optional<ExternalFile> externalfile2 = ExternalFile::getExternalFile(model, openstudio::toString(p));
   ASSERT_TRUE(externalfile2);

--- a/src/model/test/ScheduleInterval_GTest.cpp
+++ b/src/model/test/ScheduleInterval_GTest.cpp
@@ -319,9 +319,9 @@ TEST_F(ModelFixture, ScheduleFile) {
   EXPECT_TRUE(schedule3.isMinutesperItemDefaulted());
   ASSERT_TRUE(schedule3.minutesperItem());
   EXPECT_EQ("60", schedule3.minutesperItem().get());
-  EXPECT_TRUE(schedule3.setMinutesperItem(5)); // This is a valid choice
+  EXPECT_TRUE(schedule3.setMinutesperItem(5));  // This is a valid choice
   EXPECT_EQ("5", schedule3.minutesperItem().get());
-  EXPECT_FALSE(schedule3.setMinutesperItem(7)); // This is not a valid choice
+  EXPECT_FALSE(schedule3.setMinutesperItem(7));  // This is not a valid choice
   EXPECT_EQ("5", schedule3.minutesperItem().get());
   schedule3.resetMinutesperItem();
   EXPECT_TRUE(schedule3.isMinutesperItemDefaulted());


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4226 - add int argument for ScheduleFile.setMinutesperItem method

I changed the API in Impl only, preferring to preserve backward compat in Public API.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] All new and existing tests passes
 - [x] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
