### PR TITLE
Fix #4240 (and more): add missing `\ip-units gal/min` via a script

### DIFF
--- a/developer/ruby/FindAndAddMissingIPUnits.rb
+++ b/developer/ruby/FindAndAddMissingIPUnits.rb
@@ -1,4 +1,4 @@
-require '/home/julien/Software/Others/OS-build/Products/ruby/openstudio'
+require 'openstudio'
 require 'optparse'
 
 # define the input parameters

--- a/developer/ruby/FindAndAddMissingIPUnits.rb
+++ b/developer/ruby/FindAndAddMissingIPUnits.rb
@@ -1,0 +1,99 @@
+require '/home/julien/Software/Others/OS-build/Products/ruby/openstudio'
+require 'optparse'
+
+# define the input parameters
+options = Hash.new
+
+optparse = OptionParser.new do |opts|
+
+  opts.on("-f", "--[no-]fix", "Add the missing ipUnits to the OpenSutdio.idd (note: LOTS of whitespace changes...)") do |fix|
+    options[:fix] = fix
+  end
+
+  opts.on( '-i', '--idd-path IDD_PATH',
+          String,
+          "Path to the OpenStudio.idd") do |iddPath|
+    options[:iddPath] = iddPath
+  end
+
+end
+
+# parse the input parameters
+optparse.parse!
+
+puts options
+
+
+iddWrapper = nil
+if options[:iddPath]
+  IDD_PATH = options[:iddPath]
+else
+  IDD_PATH = File.absolute_path(File.join(File.dirname(__FILE__), "../../resources/model/OpenStudio.idd"))
+  #iddWrapper = OpenStudio::IddFileAndFactoryWrapper.new("OpenStudio".to_IddFileType)
+end
+
+if !File.exist?(IDD_PATH)
+  puts "The OpenStudio.idd at '#{IDD_PATH}' does not exist. Pass it via `-i PATH`"
+  puts ""
+  puts optparse.help
+  exit 1
+end
+
+oIddFile = OpenStudio::IddFile::load(OpenStudio::toPath(IDD_PATH))
+raise "Couldn't load #{IDD_PATH}" if oIddFile.empty?
+iddWrapper = oIddFile.get
+
+def apply_water_flow_rate(iddWrapper)
+
+  puts "Looking for missing gal/min in Water Flow Rate fields"
+  include_words = ['water', 'flow', 'rate']
+  exclude_words = ['ratio', 'fraction', 'curve', 'length', 'mass']
+
+
+  n_missing = 0
+
+  iddWrapper.objects.each do |iddObject|
+    num_fields = iddObject.numFields
+    for i in 0..num_fields-1
+      f = iddObject.getField(i).get
+      f_name = f.name
+      props = f.properties
+      siUnits = props.units
+      ipUnits = props.ipUnits
+      if include_words.all? { |w| f_name.downcase.include?(w) } and exclude_words.none? { |w| f_name.downcase.include?(w) }
+        if siUnits.empty?
+          puts "#{iddObject.name} is missing units in field '#{f_name}'"
+        elsif siUnits.get != "m3/s"
+          puts "#{iddObject.name} has wrong units=#{siUnits.get} in field '#{f_name}'"
+        elsif ipUnits.empty?
+          puts "#{iddObject.name} is missing ipUnits in field '#{f_name}'"
+          props.ipUnits = OpenStudio::OptionalString.new('gal/min')
+          n_missing += 1
+        elsif ipUnits.get != "gal/min"
+          puts "#{iddObject.name} has wrong ipUnits=#{ipUnits.get} in field '#{f_name}'"
+          props.ipUnits = OpenStudio::OptionalString.new('gal/min')
+          n_missing += 1
+        end
+      end
+    end
+  end
+
+  return n_missing
+end
+
+n_missing = 0
+n_missing += apply_water_flow_rate(iddWrapper)
+
+if options[:fix]
+  puts "Fixing in place at #{IDD_PATH}"
+  # LOTS of whitespace changes
+  iddWrapper.save(OpenStudio::toPath(IDD_PATH), true)
+else
+  puts "Not fixing in place"
+end
+
+if n_missing > 0
+  exit 1
+else
+  exit 0
+end

--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -8176,12 +8176,14 @@ OS:Refrigeration:Condenser:WaterCooled,
   N5,   \field Water Design Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0.0
         \note Note required units must be converted from L/s as specified in ARI 450-2007
         \note Applicable only when loop flow type is Constant Flow.
   N6,   \field Water Maximum Flow Rate
         \type real
         \units m3/s
+        \ip-units gal/min
         \minimum> 0.0
   N7,   \field Water Maximum Water Outlet Temperature
         \type real
@@ -10406,6 +10408,7 @@ OS:AirLoopHVAC:UnitaryHeatPump:AirToAir:MultiSpeed,
         \note If non-zero, then the heat recovery inlet and outlet node names must be entered.
         \note Used for heat recovery to an EnergyPlus plant loop.
         \units m3/s
+        \ip-units gal/min
         \minimum 0.0
         \required-field
    N7,  \field Maximum Temperature for Heat Recovery
@@ -11183,6 +11186,7 @@ OS:AirLoopHVAC:UnitarySystem,
   N25, \field Design Heat Recovery Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \default 0.0
        \note If non-zero, then the heat recovery inlet and outlet node names must be entered.
@@ -11810,6 +11814,7 @@ OS:AirTerminal:SingleDuct:ConstantVolume:CooledBeam,
   N2, \field Maximum Total Chilled Water Volumetric Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum 0.0
        \autosizable
        \default autosize
@@ -17686,6 +17691,7 @@ OS:Coil:WaterHeating:Desuperheater,
        \required-field
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \note The operating water flow rate.
   N7,  \field Water Pump Power
@@ -18023,6 +18029,7 @@ OS:Coil:Heating:Water:Baseboard:Radiant,
       \autosizable
       \type real
       \units m3/s
+      \ip-units gal/min
   N7; \field Convergence Tolerance
       \required-field
       \type real
@@ -18593,6 +18600,7 @@ OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N4,  \field Rated Water Flow Rate At Selected Nominal Speed Level
         \units m3/s
+        \ip-units gal/min
         \type real
         \autosizable
         \required-field
@@ -18633,6 +18641,7 @@ OS:Coil:Heating:WaterToAirHeatPump:VariableSpeedEquationFit:SpeedData,
         \required-field
    N4,  \field Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
         \required-field
@@ -18720,6 +18729,7 @@ OS:Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit,
         \required-field
    N4,  \field Rated Water Flow Rate At Selected Nominal Speed Level
         \units m3/s
+        \ip-units gal/min
         \type real
         \autosizable
         \required-field
@@ -18780,6 +18790,7 @@ OS:Coil:Cooling:WaterToAirHeatPump:VariableSpeedEquationFit:SpeedData,
         \required-field
    N5,  \field Reference Unit Rated Water Flow Rate
         \units m3/s
+        \ip-units gal/min
         \type real
         \minimum 0
         \required-field
@@ -27701,6 +27712,7 @@ OS:Coil:WaterHeating:AirToWaterHeatPump,
   N8 , \field Rated Condenser Water Flow Rate
        \type real
        \units m3/s
+       \ip-units gal/min
        \minimum> 0
        \autosizable
        \required-field


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4240 (and more): add missing `\ip-units gal/min` via a script

Perhaps we should call the script on one of the CI runners @tijcolem ?

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
