### PR TITLE
Fix #4166 - Merging FloorSpaceJS can delete unique model Objects such as Facility, Building, Site (and children)

### DIFF
--- a/src/model/ModelMerger.cpp
+++ b/src/model/ModelMerger.cpp
@@ -89,9 +89,13 @@ namespace model {
 
   ModelMerger::ModelMerger() {
     // DLM: TODO expose this to user to give more control over merging?
+
+    // Unique Objects
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_Site);
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_Facility);
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_Building);
+
+    // Non unique Objects
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_Space);
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_ShadingSurfaceGroup);
     m_iddObjectTypesToMerge.push_back(IddObjectType::OS_ThermalZone);
@@ -1012,12 +1016,18 @@ namespace model {
     for (const auto& iddObjectType : iddObjectTypesToMerge()) {
       for (auto& currenObject : currentModel.getObjectsByType(iddObjectType)) {
         if (m_currentToNewHandleMapping.find(currenObject.handle()) == m_currentToNewHandleMapping.end()) {
-          currenObject.remove();
+          if ((iddObjectType == IddObjectType::OS_Site) || (iddObjectType == IddObjectType::OS_Facility)
+              || (iddObjectType == IddObjectType::OS_Building)) {
+            // These are unique objects, so no need to delete them
+            continue;
+          } else {
+            currenObject.remove();
+          }
         }
       }
     }
 
-    //** Merge objects from new model into curret model **//
+    //** Merge objects from new model into current model **//
     for (const auto& iddObjectType : iddObjectTypesToMerge()) {
       for (auto& newObject : newModel.getObjectsByType(iddObjectType)) {
         getCurrentModelObject(newObject);


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4166 - Merging FloorSpaceJS strips out climate zone assignment.

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
