### PR TITLE
Fix #3905 - Allow ZoneHVAC:TerminalUnit:VariableRefrigerantFlow to connect to AirLoopHVAC

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -26403,7 +26403,6 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \note This field is also ignored if VRF terminal unit is used on main AirloopHVAC branch
         \note and terminal unit has no fan.
   A8 ,  \field Supply Air Fan
-        \required-field
         \type object-list
         \object-list FansCVandOnOffandVAV
         \object-list FansSystemModel
@@ -26469,13 +26468,19 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \autosizable
         \required-field
         \note Supply air temperature from the supplemental heater will not exceed this value.
-  N12;  \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
+  N12,  \field Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation
         \type real
         \maximum 21.0
         \units C
         \required-field
         \note Supplemental heater will not operate when outdoor temperature exceeds this value.
-
+  A15; \field Controlling Zone or Thermostat Location
+       \type object-list
+       \object-list ThermalZoneNames
+       \note Used only for AirloopHVAC equipment on a main branch and defines zone name where thermostat is located.
+       \note Not required for zone equipment. Leave blank if terminal unit is used in AirLoopHVAC:OutdoorAirSystem:EquipmentList.
+       \note Required when terminal unit is used on main AirloopHVAC branch and coils are not set point controlled.
+       \note When terminal unit is used in air loop and is load controlled, this zone's thermostat will control operation.
 
 OS:ZoneHVAC:WaterToAirHeatPump,
         \min-fields 25

--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -26392,7 +26392,7 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \object-list ScheduleNames
         \note Required for zone equipment. Leave blank if terminal unit is used in AirLoopHVAC:OutdoorAirSystem:EquipmentList.
         \note Also leave blank if terminal unit is used on main AirloopHVAC branch and terminal unit has no fan.
-  A7 ,  \field Supply Air Fan placement
+  A7 ,  \field Supply Air Fan Placement
         \required-field
         \type choice
         \key BlowThrough

--- a/src/energyplus/ForwardTranslator.cpp
+++ b/src/energyplus/ForwardTranslator.cpp
@@ -3183,9 +3183,10 @@ namespace energyplus {
     // Equipments should be responsible for translating their fans
     // result.push_back(IddObjectType::OS_Fan_Variable);
     // result.push_back(IddObjectType::OS_Fan_ConstantVolume);
-    // TODO: JM 2019-07-11 These two should also be commented out. Fan_ZoneExhaust will be translated by ZoneHVACEquipmentList
-    result.push_back(IddObjectType::OS_Fan_OnOff);
-    result.push_back(IddObjectType::OS_Fan_ZoneExhaust);
+    // JM 2019-07-11 These two should also be commented out. Fan_ZoneExhaust will be translated by ZoneHVACEquipmentList. Fan_OnOff by its containing
+    // HVACComponent
+    // result.push_back(IddObjectType::OS_Fan_OnOff);
+    // result.push_back(IddObjectType::OS_Fan_ZoneExhaust);
 
     result.push_back(IddObjectType::OS_Node);
     result.push_back(IddObjectType::OS_PlantLoop);

--- a/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
@@ -82,6 +82,8 @@
 #include "../../model/AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed_Impl.hpp"
 #include "../../model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass.hpp"
 #include "../../model/AirLoopHVACUnitaryHeatCoolVAVChangeoverBypass_Impl.hpp"
+#include "../../model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp"
+#include "../../model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp"
 
 #include "../../utilities/idf/IdfExtensibleGroup.hpp"
 #include <utilities/idd/AirLoopHVAC_FieldEnums.hxx>
@@ -152,6 +154,13 @@ namespace energyplus {
         auto airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed = subsetCastVector<AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed>(supplyComponents);
         if (!airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.empty()) {
           fanOrUnitary = airLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.back();
+        }
+      }
+
+      if (!fanOrUnitary) {
+        auto zoneHVACTerminalUnitVariableRefrigerantFlow = subsetCastVector<ZoneHVACTerminalUnitVariableRefrigerantFlow>(supplyComponents);
+        if (!zoneHVACTerminalUnitVariableRefrigerantFlow.empty()) {
+          fanOrUnitary = zoneHVACTerminalUnitVariableRefrigerantFlow.back();
         }
       }
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -413,6 +413,18 @@ namespace energyplus {
     idfObject.setDouble(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation,
                         modelObject.maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation());
 
+    // ControllingZoneorThermostatLocation
+    if (boost::optional<ThermalZone> tz = modelObject.controllingZoneorThermostatLocation()) {
+      idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation, tz->name().get());
+    } else if (auto airLoop = modelObject.airLoopHVAC()) {
+      auto zones = airLoop->thermalZones();
+      if (zones.size() == 1u) {
+        if (auto zone = translateAndMapModelObject(zones.front())) {
+          idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation, zone->name().get());
+        }
+      }
+    }
+
     return idfObject;
   }
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -218,8 +218,7 @@ namespace energyplus {
     idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::TerminalUnitAirOutletNodeName, outletNodeName);
 
     auto translateMixer = [&]() {
-      auto t_airLoopHVAC = modelObject.airLoopHVAC();
-      if (t_airLoopHVAC) {
+      if (modelObject.airLoopHVAC() || modelObject.airLoopHVACOutdoorAirSystem()) {
         return false;
       }
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -258,7 +258,7 @@ namespace energyplus {
 
     struct Component
     {
-      Component(const IdfObject& obj, const std::string t_outletNodeName, unsigned t_inletIndex, unsigned t_outletIndex)
+      Component(const IdfObject& obj, const std::string& t_outletNodeName, unsigned t_inletIndex, unsigned t_outletIndex)
         : idfObject(obj), outletNodeName(t_outletNodeName), inletIndex(t_inletIndex), outletIndex(t_outletIndex) {}
       IdfObject idfObject;
       std::string outletNodeName;

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -289,7 +289,7 @@ namespace energyplus {
         idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanObjectName, idf_fan_->name().get());
         auto [inletIndex, outletIndex] = getFanInletOutletIndexes(idf_fan_.get());
         fanIndex = compsInOrder.size();  // Store index
-        compsInOrder.emplace_back(Component(idf_fan_.get(), "Fan Outlet Node", inletIndex, outletIndex));
+        compsInOrder.emplace_back(Component(idf_fan_.get(), modelObject.name().get() + " Fan Outlet Node", inletIndex, outletIndex));
       }
     };
 

--- a/src/model/AirLoopHVACOutdoorAirSystem.cpp
+++ b/src/model/AirLoopHVACOutdoorAirSystem.cpp
@@ -35,6 +35,8 @@
 #include "AirToAirComponent_Impl.hpp"
 #include "WaterToAirComponent.hpp"
 #include "WaterToAirComponent_Impl.hpp"
+#include "ZoneHVACComponent.hpp"
+#include "ZoneHVACComponent_Impl.hpp"
 #include "ControllerOutdoorAir.hpp"
 #include "ControllerOutdoorAir_Impl.hpp"
 #include "Node.hpp"
@@ -319,6 +321,10 @@ namespace model {
         } else if (boost::optional<WaterToAirComponent> comp = modelObject->optionalCast<WaterToAirComponent>()) {
           modelObjects.insert(modelObjects.begin(), *comp);
           modelObject = comp->airInletModelObject();
+        } else if (auto comp = modelObject->optionalCast<ZoneHVACComponent>()) {
+          // For AirLoopHVACUnitarySystem and ZoneHVACTerminalUnitVariableRefrigerantFlow
+          modelObjects.insert(modelObjects.begin(), *comp);
+          modelObject = comp->inletNode();
         } else {
           break;
           // log unhandled component
@@ -349,6 +355,9 @@ namespace model {
         } else if (boost::optional<WaterToAirComponent> comp = modelObject->optionalCast<WaterToAirComponent>()) {
           modelObjects.push_back(*comp);
           modelObject = comp->airOutletModelObject();
+        } else if (auto comp = modelObject->optionalCast<ZoneHVACComponent>()) {
+          modelObjects.insert(modelObjects.begin(), *comp);
+          modelObject = comp->outletNode();
         } else {
           // log unhandled component
         }

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -782,6 +782,8 @@ namespace model {
     autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
     setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
 
+    setSupplyAirFanPlacement("DrawThrough");
+
     CoilCoolingDXVariableRefrigerantFlow coolingCoil(model);
     coolingCoil.setName(name().get() + " Cooling Coil");
     getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setCoolingCoil(coolingCoil);

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -510,6 +510,18 @@ namespace model {
       return result;
     }
 
+    std::string ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplyAirFanPlacement() const {
+      boost::optional<std::string> value = getString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanPlacement, true);
+      OS_ASSERT(value);
+      return value.get();
+    }
+
+    bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement) {
+      bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanPlacement, supplyAirFanPlacement);
+      // OS_ASSERT(result);
+      return result;
+    }
+
     boost::optional<ThermalZone> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::controllingZoneorThermostatLocation() const {
       return getObject<ModelObject>().getModelObjectTarget<ThermalZone>(
         OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation);
@@ -818,20 +830,34 @@ namespace model {
     autosizeMaximumSupplyAirTemperaturefromSupplementalHeater();
     setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
 
-    getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setCoolingCoil(coolingCoil);
+    setSupplyAirFanPlacement("DrawThrough");
 
-    getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setHeatingCoil(heatingCoil);
+    bool ok = setCoolingCoil(coolingCoil);
+    if (!ok) {
+      remove();
+      LOG_AND_THROW("Unable to set " << briefDescription() << "'s Cooling Coil to " << coolingCoil.briefDescription() << ".");
+    }
 
-    getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFan(fan);
+    ok = setHeatingCoil(heatingCoil);
+    if (!ok) {
+      remove();
+      LOG_AND_THROW("Unable to set " << briefDescription() << "'s Heating Coil to " << fan.briefDescription() << ".");
+    }
+
+    ok = getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFan(fan);
+    if (!ok) {
+      remove();
+      LOG_AND_THROW("Unable to set " << briefDescription() << "'s Supply Air Fan to " << fan.briefDescription() << ".");
+    }
   }
 
   IddObjectType ZoneHVACTerminalUnitVariableRefrigerantFlow::iddObjectType() {
     return IddObjectType(IddObjectType::OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlow);
   }
 
-  std::vector<std::string> ZoneHVACTerminalUnitVariableRefrigerantFlow::supplyAirFanplacementValues() {
+  std::vector<std::string> ZoneHVACTerminalUnitVariableRefrigerantFlow::supplyAirFanPlacementValues() {
     return getIddKeyNames(IddFactory::instance().getObject(iddObjectType()).get(),
-                          OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanplacement);
+                          OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanPlacement);
   }
 
   Schedule ZoneHVACTerminalUnitVariableRefrigerantFlow::terminalUnitAvailabilityschedule() const {
@@ -1073,6 +1099,14 @@ namespace model {
 
   void ZoneHVACTerminalUnitVariableRefrigerantFlow::resetControllingZoneorThermostatLocation() {
     getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->resetControllingZoneorThermostatLocation();
+  }
+
+  std::string ZoneHVACTerminalUnitVariableRefrigerantFlow::supplyAirFanPlacement() const {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->supplyAirFanPlacement();
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement) {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFanPlacement(supplyAirFanPlacement);
   }
 
   /// @cond

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -225,12 +225,8 @@ namespace model {
       return value.get();
     }
 
-    HVACComponent ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplyAirFan() const {
-      boost::optional<HVACComponent> value = optionalSupplyAirFan();
-      if (!value) {
-        LOG_AND_THROW(briefDescription() << " does not have an Supply Air Fan attached.");
-      }
-      return value.get();
+    boost::optional<HVACComponent> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::supplyAirFan() const {
+      return getObject<ModelObject>().getModelObjectTarget<HVACComponent>(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFan);
     }
 
     boost::optional<CoilCoolingDXVariableRefrigerantFlow> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::coolingCoil() const {
@@ -410,10 +406,6 @@ namespace model {
         OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFanOperatingModeSchedule);
     }
 
-    boost::optional<HVACComponent> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::optionalSupplyAirFan() const {
-      return getObject<ModelObject>().getModelObjectTarget<HVACComponent>(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFan);
-    }
-
     unsigned ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::inletPort() const {
       return OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::TerminalUnitAirInletNode;
     }
@@ -424,6 +416,11 @@ namespace model {
 
     bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setSupplyAirFan(const HVACComponent& component) {
       return setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFan, component.handle());
+    }
+
+    void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::resetSupplyAirFan() {
+      bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::SupplyAirFan, "");
+      OS_ASSERT(result);
     }
 
     bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setCoolingCoil(const CoilCoolingDXVariableRefrigerantFlow& component) {
@@ -531,7 +528,10 @@ namespace model {
     ModelObject ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::clone(Model model) const {
       ModelObject terminalClone = ZoneHVACComponent_Impl::clone(model);
 
-      HVACComponent fanClone = supplyAirFan().clone(model).cast<HVACComponent>();
+      if (auto fan = supplyAirFan()) {
+        HVACComponent fanClone = fan->clone(model).cast<HVACComponent>();
+        terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFan(fanClone);
+      }
 
       if (auto coil = coolingCoil()) {
         auto coilClone = coil->clone(model).cast<CoilCoolingDXVariableRefrigerantFlow>();
@@ -548,8 +548,6 @@ namespace model {
         terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplementalHeatingCoil(coilClone);
       }
 
-      terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFan(fanClone);
-
       // TODO Move this into base clase
       terminalClone.setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::TerminalUnitAirInletNode, "");
       terminalClone.setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::TerminalUnitAirOutletNode, "");
@@ -560,7 +558,9 @@ namespace model {
     std::vector<ModelObject> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::children() const {
       std::vector<ModelObject> result;
 
-      result.push_back(supplyAirFan());
+      if (auto fan = supplyAirFan()) {
+        result.push_back(fan.get());
+      }
 
       if (auto coil = coolingCoil()) {
         result.push_back(coil.get());
@@ -899,7 +899,11 @@ namespace model {
   }
 
   HVACComponent ZoneHVACTerminalUnitVariableRefrigerantFlow::supplyAirFan() const {
-    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->supplyAirFan();
+    boost::optional<HVACComponent> fan_ = getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->supplyAirFan();
+    if (!fan_) {
+      LOG_AND_THROW(briefDescription() << " does not have an Supply Air Fan attached.");
+    }
+    return fan_.get();
   }
 
   boost::optional<CoilCoolingDXVariableRefrigerantFlow> ZoneHVACTerminalUnitVariableRefrigerantFlow::coolingCoil() const {

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -43,6 +43,8 @@
 #include "CoilCoolingDXVariableRefrigerantFlow_Impl.hpp"
 #include "ScheduleTypeLimits.hpp"
 #include "ScheduleTypeRegistry.hpp"
+#include "ThermalZone.hpp"
+#include "ThermalZone_Impl.hpp"
 #include <utilities/idd/IddFactory.hxx>
 
 #include <utilities/idd/OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlow_FieldEnums.hxx>
@@ -504,6 +506,21 @@ namespace model {
                               maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
       // OS_ASSERT(result);
       return result;
+    }
+
+    boost::optional<ThermalZone> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::controllingZoneorThermostatLocation() const {
+      return getObject<ModelObject>().getModelObjectTarget<ThermalZone>(
+        OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation);
+    }
+
+    bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setControllingZoneorThermostatLocation(const ThermalZone& thermalZone) {
+      bool result = setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation, thermalZone.handle());
+      return result;
+    }
+
+    void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::resetControllingZoneorThermostatLocation() {
+      bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation, "");
+      OS_ASSERT(result);
     }
 
     ModelObject ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::clone(Model model) const {
@@ -972,6 +989,18 @@ namespace model {
 
   double ZoneHVACTerminalUnitVariableRefrigerantFlow::maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const {
     return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation();
+  }
+
+  boost::optional<ThermalZone> ZoneHVACTerminalUnitVariableRefrigerantFlow::controllingZoneorThermostatLocation() const {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->controllingZoneorThermostatLocation();
+  }
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setControllingZoneorThermostatLocation(const ThermalZone& thermalZone) {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setControllingZoneorThermostatLocation(thermalZone);
+  }
+
+  void ZoneHVACTerminalUnitVariableRefrigerantFlow::resetControllingZoneorThermostatLocation() {
+    getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->resetControllingZoneorThermostatLocation();
   }
 
   /// @cond

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -136,6 +136,9 @@ namespace model {
 
     bool setSupplyAirFanOperatingModeSchedule(Schedule& schedule);
 
+    // Required for zone equipment. Leave blank if terminal unit is used in AirLoopHVAC:OutdoorAirSystem:EquipmentList.
+    // Also leave blank if terminal unit is used on main AirloopHVAC branch and terminal unit has no fan.
+    // TODO: not breaking API (yet), so leaving it as non optional
     HVACComponent supplyAirFan() const;
 
     boost::optional<CoilCoolingDXVariableRefrigerantFlow> coolingCoil() const;

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -63,7 +63,7 @@ namespace model {
 
     static IddObjectType iddObjectType();
 
-    static std::vector<std::string> supplyAirFanplacementValues();
+    static std::vector<std::string> supplyAirFanPlacementValues();
 
     Schedule terminalUnitAvailabilityschedule() const;
 
@@ -178,6 +178,10 @@ namespace model {
     // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
     double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
     bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+
+    // Supply Air Fan Placement
+    std::string supplyAirFanPlacement() const;
+    bool setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement);
 
     // Controlling Zone or Thermostat Location
     boost::optional<ThermalZone> controllingZoneorThermostatLocation() const;

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -41,6 +41,7 @@ namespace model {
   class Schedule;
   class CoilHeatingDXVariableRefrigerantFlow;
   class CoilCoolingDXVariableRefrigerantFlow;
+  class ThermalZone;
 
   namespace detail {
 
@@ -174,6 +175,11 @@ namespace model {
     // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
     double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
     bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+
+    // Controlling Zone or Thermostat Location
+    boost::optional<ThermalZone> controllingZoneorThermostatLocation() const;
+    bool setControllingZoneorThermostatLocation(const ThermalZone& thermalZone);
+    void resetControllingZoneorThermostatLocation();
 
     boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -139,7 +139,9 @@ namespace model {
     // Required for zone equipment. Leave blank if terminal unit is used in AirLoopHVAC:OutdoorAirSystem:EquipmentList.
     // Also leave blank if terminal unit is used on main AirloopHVAC branch and terminal unit has no fan.
     // TODO: not breaking API (yet), so leaving it as non optional
-    HVACComponent supplyAirFan() const;
+    HVACComponent supplyAirFan() const;  // TODO: OS_DEPRECATED
+    // bool setSupplyAirFan(const HVACComponent& fan);
+    // void resetSupplyAirFan();
 
     boost::optional<CoilCoolingDXVariableRefrigerantFlow> coolingCoil() const;
 

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -84,6 +84,8 @@ namespace model {
 
       virtual unsigned outletPort() const override;
 
+      virtual bool addToNode(Node& node) override;
+
       virtual ModelObject clone(Model model) const override;
 
       virtual std::vector<ModelObject> children() const override;

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -41,6 +41,7 @@ namespace model {
   class Schedule;
   class CoilHeatingDXVariableRefrigerantFlow;
   class CoilCoolingDXVariableRefrigerantFlow;
+  class ThermalZone;
 
   namespace detail {
 
@@ -149,6 +150,11 @@ namespace model {
       // Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation (default 21C)
       double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() const;
       bool setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
+
+      // Controlling Zone or Thermostat Location
+      boost::optional<ThermalZone> controllingZoneorThermostatLocation() const;
+      bool setControllingZoneorThermostatLocation(const ThermalZone& thermalZone);
+      void resetControllingZoneorThermostatLocation();
 
       boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -158,6 +158,10 @@ namespace model {
       bool setControllingZoneorThermostatLocation(const ThermalZone& thermalZone);
       void resetControllingZoneorThermostatLocation();
 
+      // Supply Air Fan Placement
+      std::string supplyAirFanPlacement() const;
+      bool setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement);
+
       boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 
       boost::optional<double> autosizedSupplyAirFlowRateWhenNoCoolingisNeeded() const;

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -126,7 +126,7 @@ namespace model {
 
       Schedule supplyAirFanOperatingModeSchedule() const;
 
-      HVACComponent supplyAirFan() const;
+      boost::optional<HVACComponent> supplyAirFan() const;
 
       boost::optional<CoilCoolingDXVariableRefrigerantFlow> coolingCoil() const;
 
@@ -221,6 +221,7 @@ namespace model {
       //@{
 
       bool setSupplyAirFan(const HVACComponent& component);
+      void resetSupplyAirFan();
 
       bool setCoolingCoil(const CoilCoolingDXVariableRefrigerantFlow& component);
 
@@ -233,7 +234,6 @@ namespace model {
 
       boost::optional<Schedule> optionalTerminalUnitAvailabilityschedule() const;
       boost::optional<Schedule> optionalSupplyAirFanOperatingModeSchedule() const;
-      boost::optional<HVACComponent> optionalSupplyAirFan() const;
 
       boost::optional<ModelObject> supplementalHeatingCoilAsModelObject() const;
       bool setSupplementalHeatingCoilAsModelObject(const boost::optional<ModelObject>& modelObject);

--- a/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -149,6 +149,7 @@ TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_addToNode_MainB
 
   EXPECT_TRUE(testObject.inletPort());
   EXPECT_TRUE(testObject.outletPort());
+  EXPECT_TRUE(testObject.airLoopHVAC());
 }
 
 TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_AddToNodeTwoSameObjects) {
@@ -217,20 +218,22 @@ TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_AddToNodeOutdoo
   EXPECT_EQ(3, airLoop.supplyComponents().size());
   EXPECT_EQ(1, outdoorAirSystem.oaComponents().size());
   EXPECT_EQ(1, outdoorAirSystem.reliefComponents().size());
-  ZoneHVACTerminalUnitVariableRefrigerantFlow testObject1(m);
 
   if (boost::optional<Node> OANode = outdoorAirSystem.outboardOANode()) {
-    EXPECT_TRUE(testObject1.addToNode(OANode.get()));
+    ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m);
+
+    EXPECT_TRUE(testObject.addToNode(OANode.get()));
     EXPECT_EQ(3, airLoop.supplyComponents().size());
     EXPECT_EQ(3, outdoorAirSystem.oaComponents().size());
+    EXPECT_TRUE(testObject.airLoopHVACOutdoorAirSystem());
   }
 
-  ZoneHVACTerminalUnitVariableRefrigerantFlow testObject2(m);
-
   if (boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode()) {
-    EXPECT_TRUE(testObject2.addToNode(reliefNode.get()));
+    ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m);
+    EXPECT_TRUE(testObject.addToNode(reliefNode.get()));
     EXPECT_EQ(3, airLoop.supplyComponents().size());
     EXPECT_EQ(3, outdoorAirSystem.reliefComponents().size());
+    EXPECT_TRUE(testObject.airLoopHVACOutdoorAirSystem());
   }
 }
 

--- a/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -263,3 +263,31 @@ TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_controllingZone
   testObject.resetControllingZoneorThermostatLocation();
   EXPECT_FALSE(testObject.controllingZoneorThermostatLocation());
 }
+
+TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_SupplyAirFanPlacement) {
+
+  Model m;
+
+  {
+    ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m);
+    EXPECT_EQ("DrawThrough", testObject.supplyAirFanPlacement());
+    EXPECT_TRUE(testObject.setSupplyAirFanPlacement("BlowThrough"));
+    EXPECT_EQ("BlowThrough", testObject.supplyAirFanPlacement());
+    EXPECT_FALSE(testObject.setSupplyAirFanPlacement("BADENUM"));
+    EXPECT_EQ("BlowThrough", testObject.supplyAirFanPlacement());
+  }
+
+  {
+    FanOnOff fan(m);
+    CoilCoolingDXVariableRefrigerantFlow cc(m);
+    CoilHeatingDXVariableRefrigerantFlow hc(m);
+
+    ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m, cc, hc, fan);
+
+    EXPECT_EQ("DrawThrough", testObject.supplyAirFanPlacement());
+    EXPECT_TRUE(testObject.setSupplyAirFanPlacement("BlowThrough"));
+    EXPECT_EQ("BlowThrough", testObject.supplyAirFanPlacement());
+    EXPECT_FALSE(testObject.setSupplyAirFanPlacement("BADENUM"));
+    EXPECT_EQ("BlowThrough", testObject.supplyAirFanPlacement());
+  }
+}

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -6321,6 +6321,24 @@ namespace osversion {
         m_refactored.push_back(RefactoredObjectData(object, newObject));
         ss << newObject;
 
+      } else if (iddname == "OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow") {
+
+        // Field 13 (0-index) 'Supply Air Fan Placement' is now defaulted inside the Ctor
+
+        auto iddObject = idd_3_1_1.getObject(iddname);
+        IdfObject newObject(iddObject.get());
+
+        for (size_t i = 0; i < object.numFields(); ++i) {
+          if ((value = object.getString(i))) {
+            newObject.setString(i, value.get());
+          }
+        }
+
+        newObject.setString(13, "DrawThrough");
+
+        m_refactored.push_back(RefactoredObjectData(object, newObject));
+        ss << newObject;
+
       } else if (iddname == "OS:Coil:Cooling:WaterToAirHeatPump:EquationFit") {
         auto iddObject = idd_3_1_1.getObject(iddname);
         IdfObject newObject(iddObject.get());

--- a/src/osversion/test/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.osm
+++ b/src/osversion/test/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.osm
@@ -1,0 +1,156 @@
+
+OS:Version,
+  {316560d2-6647-4283-bdca-fdfa3b5fbba8}, !- Handle
+  3.1.0;                                  !- Version Identifier
+
+OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
+  {6b321fad-eec1-4d95-bc7d-1e7ec18f54bf}, !- Handle
+  Zone HVAC Terminal Unit Variable Refrigerant Flow 1, !- Name
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Terminal Unit Availability schedule
+  ,                                       !- Terminal Unit Air Inlet Node
+  ,                                       !- Terminal Unit Air Outlet Node
+  autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  autosize,                               !- Supply Air Flow Rate When No Cooling is Needed {m3/s}
+  autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  autosize,                               !- Supply Air Flow Rate When No Heating is Needed {m3/s}
+  autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
+  autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
+  autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Supply Air Fan Operating Mode Schedule
+  ,                                       !- Supply Air Fan placement
+  {ed6257a6-24ab-4566-a60a-375fd89a805a}, !- Supply Air Fan
+  ,                                       !- Outside Air Mixer
+  {9a1aa970-62b7-4a86-aee4-58aaab463970}, !- Cooling Coil
+  {59367138-e887-4a52-91f6-8f39e542ab08}, !- Heating Coil
+  30,                                     !- Zone Terminal Unit On Parasitic Electric Energy Use {W}
+  20,                                     !- Zone Terminal Unit Off Parasitic Electric Energy Use {W}
+  1,                                      !- Rated Total Heating Capacity Sizing Ratio {W/W}
+  ,                                       !- Availability Manager List Name
+  ,                                       !- Design Specification ZoneHVAC Sizing Object Name
+  ,                                       !- Supplemental Heating Coil Name
+  Autosize,                               !- Maximum Supply Air Temperature from Supplemental Heater {C}
+  21;                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+
+OS:Schedule:Constant,
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Handle
+  Fan Op Schedule,                        !- Name
+  {6366dd7b-a323-43fe-9e38-ed06569e3609}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {6366dd7b-a323-43fe-9e38-ed06569e3609}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Coil:Cooling:DX:VariableRefrigerantFlow,
+  {9a1aa970-62b7-4a86-aee4-58aaab463970}, !- Handle
+  Zone HVAC Terminal Unit Variable Refrigerant Flow 1 Cooling Coil, !- Name
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Availability Schedule
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  {411f9e2d-2d51-4594-a7b7-d713bca0c678}, !- Cooling Capacity Ratio Modifier Function of Temperature Curve
+  {af6b20e5-1624-4029-ae4e-9ff91f32c606}; !- Cooling Capacity Modifier Curve Function of Flow Fraction
+
+OS:Curve:Biquadratic,
+  {411f9e2d-2d51-4594-a7b7-d713bca0c678}, !- Handle
+  VRFTUCoolCapFT,                         !- Name
+  0.0585884077803259,                     !- Coefficient1 Constant
+  0.0587396532718384,                     !- Coefficient2 x
+  -0.000210274979759697,                  !- Coefficient3 x**2
+  0.0109370473889647,                     !- Coefficient4 y
+  -0.0001219549,                          !- Coefficient5 y**2
+  -0.0005246615,                          !- Coefficient6 x*y
+  15,                                     !- Minimum Value of x
+  23.89,                                  !- Maximum Value of x
+  20,                                     !- Minimum Value of y
+  43.33,                                  !- Maximum Value of y
+  0.8083,                                 !- Minimum Curve Output
+  1.2583;                                 !- Maximum Curve Output
+
+OS:Curve:Quadratic,
+  {af6b20e5-1624-4029-ae4e-9ff91f32c606}, !- Handle
+  VRFACCoolCapFFF,                        !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Coil:Heating:DX:VariableRefrigerantFlow,
+  {59367138-e887-4a52-91f6-8f39e542ab08}, !- Handle
+  Zone HVAC Terminal Unit Variable Refrigerant Flow 1 Heating Coil, !- Name
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Availability Schedule
+  autosize,                               !- Rated Total Heating Capacity {W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  ,                                       !- Coil Air Inlet Node
+  ,                                       !- Coil Air Outlet Node
+  {352b168e-f348-4e0c-98a8-360a995c8401}, !- Heating Capacity Ratio Modifier Function of Temperature Curve
+  {61d38d40-8803-418a-97e1-07fd5d399071}; !- Heating Capacity Modifier Function of Flow Fraction Curve
+
+OS:Curve:Biquadratic,
+  {352b168e-f348-4e0c-98a8-360a995c8401}, !- Handle
+  Coil Heating DX Variable Refrigerant Flow 1 VRFTUHeatCAPFT, !- Name
+  0.375443994956127,                      !- Coefficient1 Constant
+  0.0668190645147821,                     !- Coefficient2 x
+  -0.00194171026482001,                   !- Coefficient3 x**2
+  0.0442618420640187,                     !- Coefficient4 y
+  -0.0004009578,                          !- Coefficient5 y**2
+  -0.0014819801,                          !- Coefficient6 x*y
+  21.11,                                  !- Minimum Value of x
+  27.22,                                  !- Maximum Value of x
+  -15,                                    !- Minimum Value of y
+  18.33,                                  !- Maximum Value of y
+  0.6074,                                 !- Minimum Curve Output
+  1;                                      !- Maximum Curve Output
+
+OS:Curve:Quadratic,
+  {61d38d40-8803-418a-97e1-07fd5d399071}, !- Handle
+  Coil Heating DX Variable Refrigerant Flow 1 VRFACCoolCapFFF, !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Fan:OnOff,
+  {ed6257a6-24ab-4566-a60a-375fd89a805a}, !- Handle
+  Supply Air Fan,                         !- Name
+  {1c609529-5e92-4ae7-8b09-53006e44eb66}, !- Availability Schedule Name
+  0.6,                                    !- Fan Total Efficiency
+  300,                                    !- Pressure Rise {Pa}
+  autosize,                               !- Maximum Flow Rate {m3/s}
+  0.8,                                    !- Motor Efficiency
+  1,                                      !- Motor In Airstream Fraction
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {5cc77388-dbb6-427f-a2ba-fb11af4132b1}, !- Fan Power Ratio Function of Speed Ratio Curve Name
+  {fc8ac138-dd5e-42dd-b44d-72e4b36e6247}, !- Fan Efficiency Ratio Function of Speed Ratio Curve Name
+  ;                                       !- End-Use Subcategory
+
+OS:Curve:Exponent,
+  {5cc77388-dbb6-427f-a2ba-fb11af4132b1}, !- Handle
+  Fan On Off Power Curve,                 !- Name
+  1,                                      !- Coefficient1 Constant
+  0,                                      !- Coefficient2 Constant
+  0,                                      !- Coefficient3 Constant
+  0,                                      !- Minimum Value of x
+  1,                                      !- Maximum Value of x
+  ,                                       !- Minimum Curve Output
+  ,                                       !- Maximum Curve Output
+  ,                                       !- Input Unit Type for X
+  ;                                       !- Output Unit Type
+
+OS:Curve:Cubic,
+  {fc8ac138-dd5e-42dd-b44d-72e4b36e6247}, !- Handle
+  Fan On Off Efficiency Curve,            !- Name
+  1,                                      !- Coefficient1 Constant
+  0,                                      !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+

--- a/src/osversion/test/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.rb
+++ b/src/osversion/test/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.rb
@@ -1,0 +1,10 @@
+# require '/usr/local/openstudio-3.1.0/Ruby/openstudio'
+
+include OpenStudio::Model
+
+m = Model.new
+
+vrf = ZoneHVACTerminalUnitVariableRefrigerantFlow.new(m)
+vrf.supplyAirFanOperatingModeSchedule.setName("Fan Op Schedule")
+vrf.supplyAirFan.setName("Supply Air Fan")
+m.save('test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.osm', true)

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -1638,3 +1638,22 @@ TEST_F(OSVersionFixture, update_3_1_0_to_3_1_1_HeatPumpWaterToWaterEquationFitHe
   // Field after: Reference Coefficient of Performance
   EXPECT_EQ(7.5, hp.getDouble(12).get());
 }
+
+TEST_F(OSVersionFixture, update_3_1_0_to_3_1_1_ZoneHVACTerminalUnitVariableRefrigerantFlow) {
+  openstudio::path path = resourcesPath() / toPath("osversion/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow.osm");
+  osversion::VersionTranslator vt;
+  boost::optional<model::Model> model = vt.loadModel(path);
+  ASSERT_TRUE(model) << "Failed to load " << path;
+
+  openstudio::path outPath = resourcesPath() / toPath("osversion/3_1_1/test_vt_ZoneHVACTerminalUnitVariableRefrigerantFlow_updated.osm");
+  model->save(outPath, true);
+
+  std::vector<WorkspaceObject> vrfs = model->getObjectsByType("OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow");
+  ASSERT_EQ(1u, vrfs.size());
+  WorkspaceObject vrf = vrfs[0];
+
+  // Field before
+  EXPECT_EQ("Fan Op Schedule", vrf.getString(12, false, true).get());
+  EXPECT_EQ("DrawThrough", vrf.getString(13, false, true).get());
+  EXPECT_EQ("Supply Air Fan", vrf.getString(14, false, true).get());
+}


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #3905
- Allow ZoneHVAC:TerminalUnit:VariableRefrigerantFlow to connect to AirLoopHVAC

- New regression test was added in https://github.com/NREL/OpenStudio-resources/pull/137



### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [x] If a new object or method, added a test in NREL/OpenStudio-resources: https://github.com/NREL/OpenStudio-resources/pull/137
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
