### PR TITLE
Fix #4252 - Error requiring rubocop

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -388,7 +388,7 @@ int main(int argc, char* argv[]) {
     rb_provide("racc/cparse");
     rb_provide("cparse.so");
     rb_provide("racc/cparse.so");
- 
+
     Init_date_core();
     rb_provide("date_core");
     rb_provide("date_core.so");

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -385,8 +385,10 @@ int main(int argc, char* argv[]) {
 
     Init_cparse();
     rb_provide("cparse");
+    rb_provide("racc/cparse");
     rb_provide("cparse.so");
-
+    rb_provide("racc/cparse.so");
+ 
     Init_date_core();
     rb_provide("date_core");
     rb_provide("date_core.so");


### PR DESCRIPTION
Fixes #4252 

Not sure why this takes so long to include rubocop using the cli but it might probably related to #4249
