### PR TITLE
Fix #4254 - Set ComponentType::COOLING for EvaporativeFluidCoolerTwoSpeed

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
@@ -579,7 +579,6 @@ namespace energyplus {
         return ComponentType::COOLING;
       }
       case openstudio::IddObjectType::OS_Generator_MicroTurbine_HeatRecovery: {
-        // TODO: @kbenne, address these comments
         // Maybe that should be both, in the case of an absorption chiller?
         // Also, should maybe check if it's in mode FollowThermal or FollowThermalLimitElectrical?
         // If not in these two modes, it doesn't care and just runs. Also, it's typically on the demand Side, and this method

--- a/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.cpp
@@ -73,6 +73,8 @@
 #include "../../model/PlantEquipmentOperationScheme_Impl.hpp"
 #include "../../model/EvaporativeFluidCoolerSingleSpeed.hpp"
 #include "../../model/EvaporativeFluidCoolerSingleSpeed_Impl.hpp"
+#include "../../model/EvaporativeFluidCoolerTwoSpeed.hpp"
+#include "../../model/EvaporativeFluidCoolerTwoSpeed_Impl.hpp"
 #include "../../model/FluidCoolerSingleSpeed.hpp"
 #include "../../model/FluidCoolerSingleSpeed_Impl.hpp"
 #include "../../model/FluidCoolerTwoSpeed.hpp"
@@ -170,7 +172,6 @@ namespace energyplus {
         result = hr.heatRecoveryWaterMaximumFlowRate();
         break;
       }
-      // TODO: @kbenne is this needed?
       case openstudio::IddObjectType::OS_Generator_MicroTurbine_HeatRecovery: {
         auto mchpHR = component.cast<GeneratorMicroTurbineHeatRecovery>();
         result = mchpHR.maximumHeatRecoveryWaterFlowRate();
@@ -251,6 +252,11 @@ namespace energyplus {
       }
       case openstudio::IddObjectType::OS_EvaporativeFluidCooler_SingleSpeed: {
         auto mo = component.cast<EvaporativeFluidCoolerSingleSpeed>();
+        result = mo.designWaterFlowRate();
+        break;
+      }
+      case openstudio::IddObjectType::OS_EvaporativeFluidCooler_TwoSpeed: {
+        auto mo = component.cast<EvaporativeFluidCoolerTwoSpeed>();
         result = mo.designWaterFlowRate();
         break;
       }
@@ -495,6 +501,9 @@ namespace energyplus {
         return ComponentType::COOLING;
       }
       case openstudio::IddObjectType::OS_EvaporativeFluidCooler_SingleSpeed: {
+        return ComponentType::COOLING;
+      }
+      case openstudio::IddObjectType::OS_EvaporativeFluidCooler_TwoSpeed: {
         return ComponentType::COOLING;
       }
       case openstudio::IddObjectType::OS_FluidCooler_SingleSpeed: {

--- a/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
+++ b/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
@@ -31,6 +31,7 @@
 #include "EnergyPlusFixture.hpp"
 
 #include "../ForwardTranslator.hpp"
+#include "../ForwardTranslator/ForwardTranslatePlantEquipmentOperationSchemes.hpp"
 
 #include "../../model/Model.hpp"
 #include "../../model/PlantLoop.hpp"
@@ -49,6 +50,7 @@
 #include "../../model/SolarCollectorFlatPlatePhotovoltaicThermal.hpp"
 #include "../../model/SolarCollectorIntegralCollectorStorage.hpp"
 #include "../../model/ThermalStorageIceDetailed.hpp"
+#include "../../model/EvaporativeFluidCoolerTwoSpeed.hpp"
 
 #include <utilities/idd/PlantLoop_FieldEnums.hxx>
 #include <utilities/idd/PlantEquipmentOperationSchemes_FieldEnums.hxx>
@@ -513,4 +515,14 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_Both_
   EXPECT_EQ("ThermalStorage:Ice:Detailed", w_eg.getString(PlantEquipmentOperation_ComponentSetpointExtensibleFields::EquipmentObjectType).get());
   EXPECT_EQ(ts.nameString(), w_eg.getString(PlantEquipmentOperation_ComponentSetpointExtensibleFields::EquipmentName).get());
   EXPECT_EQ("Dual", w_eg.getString(PlantEquipmentOperation_ComponentSetpointExtensibleFields::OperationType).get());
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_componentType) {
+
+  Model m;
+
+  {
+    EvaporativeFluidCoolerTwoSpeed cooler(m);
+    EXPECT_EQ(openstudio::energyplus::ComponentType::COOLING, openstudio::energyplus::componentType(cooler));
+  }
 }

--- a/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
+++ b/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
@@ -38,19 +38,42 @@
 #include "../../model/Node.hpp"
 #include "../../model/Node_Impl.hpp"
 
-#include "../../model/HeatExchangerFluidToFluid.hpp"
-#include "../../model/WaterHeaterMixed.hpp"
-#include "../../model/WaterHeaterStratified.hpp"
-
-#include "../../model/BoilerHotWater.hpp"
-#include "../../model/ChillerElectricEIR.hpp"
 #include "../../model/ScheduleConstant.hpp"
 #include "../../model/SetpointManagerScheduled.hpp"
-#include "../../model/SolarCollectorFlatPlateWater.hpp"
-#include "../../model/SolarCollectorFlatPlatePhotovoltaicThermal.hpp"
-#include "../../model/SolarCollectorIntegralCollectorStorage.hpp"
-#include "../../model/ThermalStorageIceDetailed.hpp"
+
+#include "../../model/BoilerHotWater.hpp"
+#include "../../model/CentralHeatPumpSystem.hpp"
+#include "../../model/ChillerAbsorption.hpp"
+#include "../../model/ChillerAbsorptionIndirect.hpp"
+#include "../../model/ChillerElectricEIR.hpp"
+#include "../../model/ChillerElectricReformulatedEIR.hpp"
+#include "../../model/CoolingTowerSingleSpeed.hpp"
+#include "../../model/CoolingTowerTwoSpeed.hpp"
+#include "../../model/CoolingTowerVariableSpeed.hpp"
+#include "../../model/DistrictCooling.hpp"
+#include "../../model/DistrictHeating.hpp"
+#include "../../model/EvaporativeFluidCoolerSingleSpeed.hpp"
 #include "../../model/EvaporativeFluidCoolerTwoSpeed.hpp"
+#include "../../model/FluidCoolerSingleSpeed.hpp"
+#include "../../model/FluidCoolerTwoSpeed.hpp"
+#include "../../model/GeneratorFuelCellExhaustGasToWaterHeatExchanger.hpp"
+#include "../../model/GeneratorMicroTurbine.hpp"
+#include "../../model/GeneratorMicroTurbineHeatRecovery.hpp"
+#include "../../model/GroundHeatExchangerHorizontalTrench.hpp"
+#include "../../model/GroundHeatExchangerVertical.hpp"
+#include "../../model/HeatExchangerFluidToFluid.hpp"
+#include "../../model/HeatPumpWaterToWaterEquationFitCooling.hpp"
+#include "../../model/HeatPumpWaterToWaterEquationFitHeating.hpp"
+#include "../../model/PlantComponentTemperatureSource.hpp"
+#include "../../model/PlantComponentUserDefined.hpp"
+#include "../../model/SolarCollectorFlatPlatePhotovoltaicThermal.hpp"
+#include "../../model/SolarCollectorFlatPlateWater.hpp"
+#include "../../model/SolarCollectorIntegralCollectorStorage.hpp"
+#include "../../model/ThermalStorageChilledWaterStratified.hpp"
+#include "../../model/ThermalStorageIceDetailed.hpp"
+#include "../../model/WaterHeaterHeatPumpWrappedCondenser.hpp"
+#include "../../model/WaterHeaterMixed.hpp"
+#include "../../model/WaterHeaterStratified.hpp"
 
 #include <utilities/idd/PlantLoop_FieldEnums.hxx>
 #include <utilities/idd/PlantEquipmentOperationSchemes_FieldEnums.hxx>
@@ -522,7 +545,207 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_compo
   Model m;
 
   {
-    EvaporativeFluidCoolerTwoSpeed cooler(m);
-    EXPECT_EQ(openstudio::energyplus::ComponentType::COOLING, openstudio::energyplus::componentType(cooler));
+    EvaporativeFluidCoolerTwoSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    GeneratorFuelCellExhaustGasToWaterHeatExchanger obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    BoilerHotWater obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    DistrictHeating obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ChillerElectricEIR obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ChillerElectricReformulatedEIR obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ChillerAbsorptionIndirect obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ChillerAbsorption obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ThermalStorageChilledWaterStratified obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    DistrictCooling obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    CoolingTowerSingleSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    CoolingTowerVariableSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    CoolingTowerTwoSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    EvaporativeFluidCoolerSingleSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    EvaporativeFluidCoolerTwoSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    FluidCoolerSingleSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    FluidCoolerTwoSpeed obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    GroundHeatExchangerVertical obj(m);
+    EXPECT_EQ(ComponentType::BOTH, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    GroundHeatExchangerHorizontalTrench obj(m);
+    EXPECT_EQ(ComponentType::BOTH, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    SolarCollectorFlatPlatePhotovoltaicThermal obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    SolarCollectorFlatPlateWater obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    SolarCollectorIntegralCollectorStorage obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    PlantComponentUserDefined obj(m);
+    EXPECT_EQ(ComponentType::BOTH, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    HeatPumpWaterToWaterEquationFitHeating obj(m);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    HeatPumpWaterToWaterEquationFitCooling obj(m);
+    EXPECT_EQ(ComponentType::COOLING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    GeneratorMicroTurbine chp(m);
+    GeneratorMicroTurbineHeatRecovery obj(m, chp);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    PlantComponentTemperatureSource obj(m);
+    EXPECT_EQ(ComponentType::BOTH, openstudio::energyplus::componentType(obj));
+  }
+
+  /***********************************************
+  *          C O M P L E X    T Y P E S          *
+  ***********************************************/
+  {
+    WaterHeaterMixed obj(m);
+
+    // No Capacity, not on a loop, not in a HPWH => NONE
+    obj.setHeaterMaximumCapacity(0.0);
+    EXPECT_EQ(ComponentType::NONE, openstudio::energyplus::componentType(obj));
+
+    // If it has a capacity, it's heating
+    obj.setHeaterMaximumCapacity(1000);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    WaterHeaterStratified obj(m);
+    // If it has a capacity, it's heating
+    obj.setHeater1Capacity(0.0);
+    obj.setHeater2Capacity(0.0);
+    EXPECT_EQ(ComponentType::NONE, openstudio::energyplus::componentType(obj));
+
+    // Any of the two heaters has a capacity? => HEATING
+    obj.setHeater1Capacity(100.0);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+    obj.setHeater1Capacity(0.0);
+    EXPECT_EQ(ComponentType::NONE, openstudio::energyplus::componentType(obj));
+
+    obj.setHeater2Capacity(100.0);
+    EXPECT_EQ(ComponentType::HEATING, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    // This is a special case for CentralHeatPumpSystem, it's handled later
+    CentralHeatPumpSystem obj(m);
+    EXPECT_EQ(ComponentType::NONE, openstudio::energyplus::componentType(obj));
+  }
+
+  {
+    ThermalStorageIceDetailed obj(m);
+    // TODO
+  }
+
+  {
+    HeatExchangerFluidToFluid obj(m);
+
+    std::vector<std::pair<std::string, ComponentType>> expectedResults{
+      {"UncontrolledOn", ComponentType::NONE},  // Not on a plant loop
+
+      {"HeatingSetpointModulated", ComponentType::HEATING},
+      {"HeatingSetpointOnOff", ComponentType::HEATING},
+
+      {"CoolingSetpointModulated", ComponentType::COOLING},
+      {"CoolingSetpointOnOff", ComponentType::COOLING},
+      {"CoolingDifferentialOnOff", ComponentType::COOLING},
+      {"CoolingSetpointOnOffWithComponentOverride", ComponentType::COOLING},
+
+      {"OperationSchemeModulated", ComponentType::BOTH},
+      {"OperationSchemeOnOff", ComponentType::BOTH},
+      {"DualDeadbandSetpointModulated", ComponentType::BOTH},
+      {"DualDeadbandSetpointOnOff", ComponentType::BOTH},
+    };
+
+    for (const auto& [controlType, ComponentType] : expectedResults) {
+      obj.setControlType(controlType);
+      EXPECT_EQ(ComponentType, openstudio::energyplus::componentType(obj));
+    }
   }
 }

--- a/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
+++ b/src/energyplus/Test/PlantEquipmentOperationSchemes_GTest.cpp
@@ -743,9 +743,9 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_PlantEquipmentOperationSchemes_compo
       {"DualDeadbandSetpointOnOff", ComponentType::BOTH},
     };
 
-    for (const auto& [controlType, ComponentType] : expectedResults) {
+    for (const auto& [controlType, compType] : expectedResults) {
       obj.setControlType(controlType);
-      EXPECT_EQ(ComponentType, openstudio::energyplus::componentType(obj));
+      EXPECT_EQ(compType, openstudio::energyplus::componentType(obj));
     }
   }
 }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4254 - Set ComponentType::COOLING for EvaporativeFluidCoolerTwoSpeed

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
