### PR TITLE
Hotfix #4265 following  #3863 - Do not translate ControllerList if no external controllers for AirLoopHVACDedicatedOutdoorAirSystem

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -10218,28 +10218,6 @@ OS:AirLoopHVAC,
        \required-field
        \object-list ConnectionObject
 
-OS:AirLoopHVAC:ControllerList,
-       \memo List controllers in order of control sequence
-       \extensible:2
-       \min-fields 4
-  A1, \field Handle
-       \type handle
-       \required-field
-  A2, \field Name
-       \type alpha
-       \required-field
-       \reference ControllerLists
-  A3, \field Controller Object Type
-       \type choice
-       \required-field
-       \begin-extensible
-       \key Controller:WaterCoil
-       \key Controller:OutdoorAir
-  A4; \field Controller Name
-       \type object-list
-       \required-field
-       \object-list AirLoopControllers
-
 OS:AirLoopHVAC:OutdoorAirSystem,
        \min-fields 4
   A1, \field Handle

--- a/src/energyplus/ForwardTranslator.cpp
+++ b/src/energyplus/ForwardTranslator.cpp
@@ -3127,7 +3127,6 @@ namespace energyplus {
     result.push_back(IddObjectType::OS_Exterior_WaterEquipment);
 
     result.push_back(IddObjectType::OS_AirLoopHVAC);
-    result.push_back(IddObjectType::OS_AirLoopHVAC_ControllerList);
 
     // Translated by AirLoopHVAC
     // result.push_back(IddObjectType::OS_AirLoopHVAC_OutdoorAirSystem);

--- a/src/model/AirLoopHVAC.cpp
+++ b/src/model/AirLoopHVAC.cpp
@@ -110,7 +110,6 @@
 #include <utilities/idd/OS_AirLoopHVAC_ZoneSplitter_FieldEnums.hxx>
 #include <utilities/idd/OS_AirTerminal_SingleDuct_ConstantVolume_NoReheat_FieldEnums.hxx>
 #include <utilities/idd/OS_AvailabilityManagerAssignmentList_FieldEnums.hxx>
-#include <utilities/idd/OS_AirLoopHVAC_ControllerList_FieldEnums.hxx>
 #include <utilities/idd/OS_Controller_OutdoorAir_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include "../utilities/core/Compare.hpp"

--- a/src/model/AirLoopHVACOutdoorAirSystem.cpp
+++ b/src/model/AirLoopHVACOutdoorAirSystem.cpp
@@ -51,7 +51,6 @@
 #include "../utilities/idf/IdfExtensibleGroup.hpp"
 #include <utilities/idd/OS_AirLoopHVAC_OutdoorAirSystem_FieldEnums.hxx>
 #include <utilities/idd/OS_AvailabilityManagerAssignmentList_FieldEnums.hxx>
-#include <utilities/idd/OS_AirLoopHVAC_ControllerList_FieldEnums.hxx>
 #include <utilities/idd/OS_Controller_OutdoorAir_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include <utility>


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4265 following  #3863 - Do not translate ControllerList if no external controllers for AirLoopHVACDedicatedOutdoorAirSystem

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
