### PR TITLE
Fix #4268 - correct implementation of IdfObject_Impl::resizeToMinFields so that it handles truncated extensible groups correctly

### DIFF
--- a/src/utilities/idf/IdfObject.cpp
+++ b/src/utilities/idf/IdfObject.cpp
@@ -1383,14 +1383,14 @@ namespace detail {
     unsigned n = numFields();
     if (n < min_n) {
       m_fields.resize(min_n);
+      n = min_n;
     }
     // also make sure extensible groups are whole
     if (m_iddObject.properties().extensible) {
-      n = numFields();
       int nExtFields = n - m_iddObject.numFields();
       if (nExtFields > 0) {
         int groupSize = m_iddObject.properties().numExtensible;
-        int nToAdd = nExtFields % groupSize;
+        int nToAdd = (groupSize - nExtFields) % groupSize;
         if (nToAdd > 0) {
           m_fields.resize(n + nToAdd);
         }

--- a/src/utilities/idf/IdfObject.cpp
+++ b/src/utilities/idf/IdfObject.cpp
@@ -1390,9 +1390,9 @@ namespace detail {
       int nExtFields = n - m_iddObject.numFields();
       if (nExtFields > 0) {
         int groupSize = m_iddObject.properties().numExtensible;
-        int nToAdd = (groupSize - nExtFields) % groupSize;
-        if (nToAdd > 0) {
-          m_fields.resize(n + nToAdd);
+        int modulo = nExtFields % groupSize;
+        if (modulo > 0) {
+          m_fields.resize(n + (groupSize - modulo));
         }
       }
     }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4268 - correct implementation of IdfObject_Impl::resizeToMinFields so that it handles truncated extensible groups correctly

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [x] IdfObject Changes / Additions
 - [x] Tested changes before and after via two new unit tests API methods are tested (in `src/model/test`)
 - [x] All new and existing tests passes


**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
