### PR TITLE
Fix #125 Fix #1559 - Treat ComponentData as a ResourceObject so ResourceObjects from BCL can be purged

### DIFF
--- a/src/model/ComponentData.cpp
+++ b/src/model/ComponentData.cpp
@@ -47,17 +47,17 @@ namespace model {
   namespace detail {
 
     ComponentData_Impl::ComponentData_Impl(const IdfObject& idfObject, Model_Impl* model, bool keepHandle)
-      : ModelObject_Impl(idfObject, model, keepHandle) {
+      : ResourceObject_Impl(idfObject, model, keepHandle) {
       OS_ASSERT(idfObject.iddObject().type() == ComponentData::iddObjectType());
     }
 
     ComponentData_Impl::ComponentData_Impl(const openstudio::detail::WorkspaceObject_Impl& other, Model_Impl* model, bool keepHandle)
-      : ModelObject_Impl(other, model, keepHandle) {
+      : ResourceObject_Impl(other, model, keepHandle) {
       OS_ASSERT(other.iddObject().type() == ComponentData::iddObjectType());
     }
 
     ComponentData_Impl::ComponentData_Impl(const ComponentData_Impl& other, Model_Impl* model, bool keepHandle)
-      : ModelObject_Impl(other, model, keepHandle) {}
+      : ResourceObject_Impl(other, model, keepHandle) {}
 
     const std::vector<std::string>& ComponentData_Impl::outputVariableNames() const {
       static const std::vector<std::string> result;
@@ -194,14 +194,14 @@ namespace model {
   }
 
   /// @cond
-  ComponentData::ComponentData(const Model& model) : ModelObject(iddObjectType(), model) {
+  ComponentData::ComponentData(const Model& model) : ResourceObject(iddObjectType(), model) {
     OS_ASSERT(getImpl<detail::ComponentData_Impl>());
     setString(OS_ComponentDataFields::UUID, toString(createUUID()));
     setInt(OS_ComponentDataFields::CreationTimestamp, (int)time(nullptr));
     createVersionUUID();
   }
 
-  ComponentData::ComponentData(std::shared_ptr<detail::ComponentData_Impl> impl) : ModelObject(std::move(impl)) {}
+  ComponentData::ComponentData(std::shared_ptr<detail::ComponentData_Impl> impl) : ResourceObject(std::move(impl)) {}
   /// @endcond
 
 }  // namespace model

--- a/src/model/ComponentData.hpp
+++ b/src/model/ComponentData.hpp
@@ -31,7 +31,7 @@
 #define MODEL_COMPONENTDATA_HPP
 
 #include "ModelAPI.hpp"
-#include "ModelObject.hpp"
+#include "ResourceObject.hpp"
 
 #include "../utilities/core/UUID.hpp"
 
@@ -47,7 +47,7 @@ namespace model {
  *  identifiers and timestamps) that link the Component back to the Building Component Library
  *  (BCL). It is used in \link Model Models \endlink to indicate which objects are associated
  *  with which Components. */
-  class MODEL_API ComponentData : public ModelObject
+  class MODEL_API ComponentData : public ResourceObject
   {
    public:
     /** @name Constructors and Destructors */

--- a/src/model/ComponentData_Impl.hpp
+++ b/src/model/ComponentData_Impl.hpp
@@ -32,14 +32,14 @@
 
 #include "ComponentData.hpp"
 
-#include "ModelObject_Impl.hpp"
+#include "ResourceObject_Impl.hpp"
 
 namespace openstudio {
 namespace model {
 
   namespace detail {
 
-    class MODEL_API ComponentData_Impl : public ModelObject_Impl
+    class MODEL_API ComponentData_Impl : public ResourceObject_Impl
     {
 
      public:

--- a/src/model/test/Component_GTest.cpp
+++ b/src/model/test/Component_GTest.cpp
@@ -356,7 +356,7 @@ TEST_F(ModelFixture, Component_BadSwaps) {
   EXPECT_ANY_THROW(component.swap(model));
 }
 
-TEST_F(ModelFixture, Component_Purge) {
+TEST_F(ModelFixture, Component_Purge_ResourceObject) {
   // test for #125 and #1559: ComponentData counts towards the directUseCount, so we can't purge BCL Components
 
   // We need a **ResourceObject** with a ComponentData pointing to it
@@ -387,5 +387,79 @@ TEST_F(ModelFixture, Component_Purge) {
   // Now we can purge the unused resource objects
   auto purgedObjects = m.purgeUnusedResourceObjects();
   EXPECT_EQ(2u, purgedObjects.size());
-  EXPECT_EQ(0u, m.numObjects());  // Should the ComponentData count?
+  EXPECT_EQ(0u, m.numObjects());
+  EXPECT_EQ(0u, m.getConcreteModelObjects<Construction>().size());
+  EXPECT_EQ(0u, m.getConcreteModelObjects<ComponentData>().size());
+}
+
+TEST_F(ModelFixture, Component_Delete_ResourceObject) {
+  // test for #125 and #1559: ComponentData counts towards the directUseCount, so we can't purge BCL Components
+
+  // We need a **ResourceObject** with a ComponentData pointing to it
+  Model m;
+  Construction c(m);
+  EXPECT_EQ(1, m.numObjects());
+
+  Component cComponent = c.createComponent();
+
+  m = Model();
+  EXPECT_EQ(0u, m.numObjects());
+  OptionalComponentData ocd = m.insertComponent(cComponent);
+  ASSERT_TRUE(ocd);
+  EXPECT_EQ(2u, m.numObjects());
+
+  auto cs = m.getConcreteModelObjects<Construction>();
+  ASSERT_EQ(1u, cs.size());
+  c = cs[0];
+  EXPECT_EQ(1u, c.directUseCount());
+  EXPECT_EQ(0u, c.nonResourceObjectUseCount());
+
+  auto compDatas = m.getConcreteModelObjects<ComponentData>();
+  ASSERT_EQ(1u, compDatas.size());
+  ComponentData compData = compDatas[0];
+  EXPECT_EQ(1u, compData.numComponentObjects());
+  EXPECT_EQ(c, compData.componentObjects()[0]);
+
+  // If I delete the object the ComponentData points to, the ComponentData be deleted as well
+  auto deletedObjects = c.remove();
+  EXPECT_EQ(1u, deletedObjects.size());  // ResourceObjects are kinda weird, they will likely not end up in the count
+  // But we can still verify that both got deleted
+  EXPECT_EQ(0u, m.numObjects());
+  EXPECT_EQ(0u, m.getConcreteModelObjects<Construction>().size());
+  EXPECT_EQ(0u, m.getConcreteModelObjects<ComponentData>().size());
+}
+
+TEST_F(ModelFixture, Component_Purge_NonResourceObject) {
+  // test for #125 and #1559: ComponentData counts towards the directUseCount, so we can't purge BCL Components
+
+  // We test with a **NON ResourceObject** with a ComponentData pointing to it
+  Model m;
+  DesignDay designDay(m);
+  EXPECT_EQ(1u, m.numObjects());
+
+  Component designDayComponent = designDay.createComponent();
+
+  m = Model();
+  EXPECT_EQ(0u, m.numObjects());
+  OptionalComponentData ocd = m.insertComponent(designDayComponent);
+  ASSERT_TRUE(ocd);
+  EXPECT_EQ(2u, m.numObjects());
+
+  auto dds = m.getConcreteModelObjects<DesignDay>();
+  ASSERT_EQ(1u, dds.size());
+  designDay = dds[0];
+  EXPECT_EQ(1u, designDay.sources().size());
+
+  auto compDatas = m.getConcreteModelObjects<ComponentData>();
+  ASSERT_EQ(1u, compDatas.size());
+  ComponentData compData = compDatas[0];
+  EXPECT_EQ(1u, compData.numComponentObjects());
+  EXPECT_EQ(designDay, compData.componentObjects()[0]);
+
+  // Now we can purge the unused resource objects: the ComponentData.
+  auto purgedObjects = m.purgeUnusedResourceObjects();
+  EXPECT_EQ(1u, purgedObjects.size());
+  EXPECT_EQ(1u, m.numObjects());
+  EXPECT_EQ(1u, m.getConcreteModelObjects<DesignDay>().size());
+  EXPECT_EQ(0u, m.getConcreteModelObjects<ComponentData>().size());
 }


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #125 
- Fix #1559
- Treat ComponentData as a ResourceObject so ResourceObjects from BCL can be purged

- [ ] TODO: add a test for a non resourceobject with componentdata

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
