### PR TITLE
Fix #4014 - Cannot download Components from remote BCL: handle crash when times out + add ability to change timeout on http client

### DIFF
--- a/src/utilities/bcl/RemoteBCL.cpp
+++ b/src/utilities/bcl/RemoteBCL.cpp
@@ -113,7 +113,7 @@ RemoteBCL::RemoteBCL()
     m_apiVersion("2.0"),
     validProdAuthKey(false),
     validDevAuthKey(false),
-    m_timeOutSeconds(60) {
+    m_timeOutSeconds(120) {
   useRemoteProductionUrl();
 }
 

--- a/src/utilities/bcl/RemoteBCL.hpp
+++ b/src/utilities/bcl/RemoteBCL.hpp
@@ -32,6 +32,7 @@
 
 #include "BCL.hpp"
 #include "../core/Path.hpp"
+#include "../core/Deprecated.hpp"
 
 #if (defined(__GNUC__))
 #  pragma GCC diagnostic push
@@ -183,19 +184,23 @@ class UTILITIES_API RemoteBCL : public BCL
 
   /// Wait number of milliseconds for download to complete
   /// Returns the download if it completed in the allowable time
-  boost::optional<BCLComponent> waitForComponentDownload(int msec = 120000) const;
+  boost::optional<BCLComponent> waitForComponentDownload() const;
+  OS_DEPRECATED boost::optional<BCLComponent> waitForComponentDownload(int) const;
 
   /// Wait number of milliseconds for download to complete
   /// Returns the download if it completed in the allowable time
-  boost::optional<BCLMeasure> waitForMeasureDownload(int msec = 120000) const;
+  boost::optional<BCLMeasure> waitForMeasureDownload() const;
+  OS_DEPRECATED boost::optional<BCLMeasure> waitForMeasureDownload(int) const;
 
   /// Wait number of milliseconds for download to complete
   /// Returns the download if it completed in the allowable time
-  boost::optional<BCLMetaSearchResult> waitForMetaSearch(int msec = 120000) const;
+  boost::optional<BCLMetaSearchResult> waitForMetaSearch() const;
+  OS_DEPRECATED boost::optional<BCLMetaSearchResult> waitForMetaSearch(int) const;
 
   /// Wait number of milliseconds for download to complete
   /// Returns the download if it completed in the allowable time
-  std::vector<BCLSearchResult> waitForSearch(int msec = 120000) const;
+  std::vector<BCLSearchResult> waitForSearch() const;
+  OS_DEPRECATED std::vector<BCLSearchResult> waitForSearch(int) const;
 
   //@}
   /** @name Non-blocking class members */
@@ -236,7 +241,7 @@ class UTILITIES_API RemoteBCL : public BCL
   /// Validate an OAuth key
   bool validateAuthKey(const std::string& authKey, const std::string& remoteUrl);
 
-  bool waitForLock(int msec) const;
+  bool waitForLock() const;
 
   boost::optional<RemoteQueryResponse> processReply(const std::string& reply);
 

--- a/src/utilities/bcl/RemoteBCL.hpp
+++ b/src/utilities/bcl/RemoteBCL.hpp
@@ -178,6 +178,9 @@ class UTILITIES_API RemoteBCL : public BCL
   /// Return the number of pages of results
   int numResultPages() const;
 
+  unsigned timeOutSeconds() const;
+  bool setTimeOutSeconds(unsigned timeOutSeconds);
+
   /// Wait number of milliseconds for download to complete
   /// Returns the download if it completed in the allowable time
   boost::optional<BCLComponent> waitForComponentDownload(int msec = 120000) const;
@@ -250,7 +253,7 @@ class UTILITIES_API RemoteBCL : public BCL
   // members
 
   // A helper function to prepare a client, allowing us to change the http_client_config in one place only
-  static web::http::client::http_client getClient(const std::string& url);
+  static web::http::client::http_client getClient(const std::string& url, unsigned timeOutSeconds = 60);
 
   boost::optional<pplx::task<void>> m_httpResponse;
 
@@ -304,6 +307,8 @@ class UTILITIES_API RemoteBCL : public BCL
   std::vector<BCLSearchResult> m_componentsWithUpdates;
 
   std::vector<BCLSearchResult> m_measuresWithUpdates;
+
+  unsigned m_timeOutSeconds;
 };
 
 }  // namespace openstudio

--- a/src/utilities/bcl/test/BCL_GTest.cpp
+++ b/src/utilities/bcl/test/BCL_GTest.cpp
@@ -429,3 +429,36 @@ TEST_F(BCLFixture, RemoteBCLMetaSearchTest) {
   }
   EXPECT_TRUE(result->taxonomyTerms().empty());
 }
+
+TEST_F(BCLFixture, 4014_Crash) {
+
+  // "Asbestos-cement Board- 1/4 in."
+  // remote = OpenStudio::RemoteBCL.new; results = remote.searchComponentLibrary("asbestos", "Material"); result = results[0];
+  std::string uid = "67656770-7926-0130-b66f-0026b9d40ccf";
+  std::string versionId = "67662ac0-7926-0130-b671-0026b9d40ccf";
+
+  /// delete this component if we already have it
+  boost::optional<BCLComponent> testComponent = LocalBCL::instance().getComponent(uid, versionId);
+  if (testComponent) {
+    bool test = LocalBCL::instance().removeComponent(*testComponent);
+    EXPECT_TRUE(test);
+  }
+  testComponent = LocalBCL::instance().getComponent(uid, versionId);
+  EXPECT_FALSE(testComponent);
+
+  RemoteBCL remoteBCL;
+  EXPECT_EQ(60u, remoteBCL.timeOutSeconds());
+
+  // this is going to timeout below, which is what I what to test
+  remoteBCL.setTimeOutSeconds(11);
+  EXPECT_EQ(11u, remoteBCL.timeOutSeconds());
+
+  bool success = remoteBCL.downloadComponent(uid);
+  ASSERT_TRUE(success);
+
+  boost::optional<BCLComponent> component = remoteBCL.waitForComponentDownload();
+  EXPECT_FALSE(component);
+
+  // Try again, should not segfault
+  success = remoteBCL.downloadComponent(uid);
+}

--- a/src/utilities/bcl/test/BCL_GTest.cpp
+++ b/src/utilities/bcl/test/BCL_GTest.cpp
@@ -447,7 +447,7 @@ TEST_F(BCLFixture, 4014_Crash) {
   EXPECT_FALSE(testComponent);
 
   RemoteBCL remoteBCL;
-  EXPECT_EQ(60u, remoteBCL.timeOutSeconds());
+  EXPECT_EQ(120u, remoteBCL.timeOutSeconds());
 
   // this is going to timeout below, which is what I what to test
   remoteBCL.setTimeOutSeconds(11);


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4014 - Cannot download Components frrom remote BCL

#4021 had increased timeout from 30 to 60secs, but BCL is super slow **for components** (not measures) so increasing it to 120secs. Also cleaning up the RemoteBCL class and its use of cpprestsdk to avoid a crash and allow changing the timeout manually

### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
