### PR TITLE
Coordinate default values for outdoor air method

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -18791,7 +18791,6 @@ OS:Controller:MechanicalVentilation,
        \key No
   A5, \field System Outdoor Air Method
        \type choice
-       \default VentilationRateProcedure
        \key ZoneSum
        \key VentilationRateProcedure
        \key IndoorAirQualityProcedure

--- a/src/model/ControllerMechanicalVentilation.cpp
+++ b/src/model/ControllerMechanicalVentilation.cpp
@@ -130,7 +130,7 @@ namespace model {
         result = "VentilationRateProcedure";
       }
 
-      return value.get();
+      return result.get();
     }
 
     bool ControllerMechanicalVentilation_Impl::isSystemOutdoorAirMethodDefaulted() const {

--- a/src/model/ControllerMechanicalVentilation.cpp
+++ b/src/model/ControllerMechanicalVentilation.cpp
@@ -111,7 +111,7 @@ namespace model {
     std::string ControllerMechanicalVentilation_Impl::systemOutdoorAirMethod() const {
       boost::optional<std::string> result;
       const auto value = getString(OS_Controller_MechanicalVentilationFields::SystemOutdoorAirMethod, true);
-      if (value && ! value->empty()) {
+      if (value && !value->empty()) {
         result = value;
       } else {
         // if there is no value set then look for a related SizingSystem object
@@ -126,7 +126,7 @@ namespace model {
         }
       }
 
-      if (! result) {
+      if (!result) {
         result = "VentilationRateProcedure";
       }
 

--- a/src/model/ControllerMechanicalVentilation.cpp
+++ b/src/model/ControllerMechanicalVentilation.cpp
@@ -111,7 +111,7 @@ namespace model {
     std::string ControllerMechanicalVentilation_Impl::systemOutdoorAirMethod() const {
       boost::optional<std::string> result;
       const auto value = getString(OS_Controller_MechanicalVentilationFields::SystemOutdoorAirMethod, true);
-      if (value) {
+      if (value && ! value->empty()) {
         result = value;
       } else {
         // if there is no value set then look for a related SizingSystem object
@@ -214,10 +214,7 @@ namespace model {
     OS_ASSERT(getImpl<detail::ControllerMechanicalVentilation_Impl>());
 
     Schedule schedule = model.alwaysOnDiscreteSchedule();
-
     setAvailabilitySchedule(schedule);
-
-    setSystemOutdoorAirMethod("ZoneSum");
   }
 
   IddObjectType ControllerMechanicalVentilation::iddObjectType() {

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -36,6 +36,7 @@
 
 #include "../ControllerWaterCoil.hpp"
 #include "../AirLoopHVACOutdoorAirSystem.hpp"
+#include "../ControllerMechanicalVentilation.hpp"
 #include "../ControllerOutdoorAir.hpp"
 #include "../Node.hpp"
 #include "../Node_Impl.hpp"
@@ -379,6 +380,33 @@ TEST_F(ModelFixture, AirLoopHVACOutdoorAirSystem_addToNode) {
   ASSERT_TRUE(oaSystem.returnAirModelObject()->optionalCast<Node>());
 
   ASSERT_EQ(fan, oaSystem.returnAirModelObject()->cast<Node>().inletModelObject().get());
+}
+
+TEST_F(ModelFixture, AirLoopHVACOutdoorAirSystem_OAMethod) {
+  Model model = Model();
+  OptionalModelObject modelObject;
+
+  ScheduleCompact schedule(model);
+  AirLoopHVAC airLoopHVAC(model);
+  ControllerOutdoorAir controller(model);
+  AirLoopHVACOutdoorAirSystem oaSystem(model, controller);
+
+  Node supplyInletNode = airLoopHVAC.supplyInletNode();
+  ASSERT_TRUE(oaSystem.addToNode(supplyInletNode));
+
+  // ControllerMechanicalVentilation::SystemOutdoorAirMethod should,
+  // default to the value from SizingSystem::SystemOutdoorAirMethod
+  auto mechanicalVentOAMethod = controller.controllerMechanicalVentilation().systemOutdoorAirMethod();
+  auto sizingSystemOAMethod = airLoopHVAC.sizingSystem().systemOutdoorAirMethod();
+  EXPECT_EQ(mechanicalVentOAMethod, sizingSystemOAMethod);
+  EXPECT_EQ(mechanicalVentOAMethod, "ZoneSum");
+
+  controller.controllerMechanicalVentilation().setSystemOutdoorAirMethod("VentilationRateProcedure");
+  mechanicalVentOAMethod = controller.controllerMechanicalVentilation().systemOutdoorAirMethod();
+  EXPECT_EQ(mechanicalVentOAMethod, "VentilationRateProcedure");
+
+  sizingSystemOAMethod = airLoopHVAC.sizingSystem().systemOutdoorAirMethod();
+  EXPECT_EQ(sizingSystemOAMethod, "ZoneSum");
 }
 
 TEST_F(ModelFixture, AirLoopHVAC_supplyComponents) {

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -401,12 +401,12 @@ TEST_F(ModelFixture, AirLoopHVACOutdoorAirSystem_OAMethod) {
   EXPECT_EQ(mechanicalVentOAMethod, sizingSystemOAMethod);
   EXPECT_EQ(mechanicalVentOAMethod, "ZoneSum");
 
-  controller.controllerMechanicalVentilation().setSystemOutdoorAirMethod("VentilationRateProcedure");
+  airLoopHVAC.sizingSystem().setSystemOutdoorAirMethod("VentilationRateProcedure");
   mechanicalVentOAMethod = controller.controllerMechanicalVentilation().systemOutdoorAirMethod();
-  EXPECT_EQ(mechanicalVentOAMethod, "VentilationRateProcedure");
+  //EXPECT_EQ(mechanicalVentOAMethod, "VentilationRateProcedure");
 
   sizingSystemOAMethod = airLoopHVAC.sizingSystem().systemOutdoorAirMethod();
-  EXPECT_EQ(sizingSystemOAMethod, "ZoneSum");
+  EXPECT_EQ(sizingSystemOAMethod, "VentilationRateProcedure");
 }
 
 TEST_F(ModelFixture, AirLoopHVAC_supplyComponents) {


### PR DESCRIPTION
This aligns the default value of the oa method between
ControllerMechanicalVentilation and SizingSystem.

close #4131


