### PR TITLE
update conan remotes for bintray sunset

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -28,8 +28,12 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   message(STATUS "openstudio: RUNNING CONAN")
 
   # Add NREL remote and place it first in line, since we vendored dependencies to NREL's repo, they will be picked first
-  conan_add_remote(NAME nrel INDEX 0
-    URL https://api.bintray.com/conan/commercialbuilding/nrel)
+  # TJC 2021-04-27 bintray.com is decommissioned as of 2021-05-01. See commercialbuildings as replacement below. 
+  #  conan_add_remote(NAME nrel INDEX 0
+  #   URL https://api.bintray.com/conan/commercialbuilding/nrel)
+
+  conan_add_remote(NAME commercialbuildings 
+     URL https://conan.commercialbuildings.dev/artifactory/api/conan/openstudio)
 
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)


### PR DESCRIPTION
Fix #4201. 

Bintray is sunsetting as of 2021-05-01 so moving to new remote.  
Build recipes and binary packages have been transferred to new remote.   


