### PR TITLE
Fix #4298 - Do not Warn if Sql doesn't have a Year field, just Info if f there are no timeseries reporting lower than Runperiod

### DIFF
--- a/src/utilities/sql/SqlFile_Impl.cpp
+++ b/src/utilities/sql/SqlFile_Impl.cpp
@@ -515,7 +515,13 @@ namespace detail {
       // Check if zero
       boost::optional<int> maxYear = execAndReturnFirstInt("SELECT MAX(Year) FROM Time");
       if (!maxYear.is_initialized() || maxYear.get() <= 0) {
-        LOG(Warn, "Using EnergyPlusVersion version " << version.str() << " which should have 'Year' field, but it's always zero");
+        auto nOtherThanRunPeriod =
+          execAndReturnFirstInt("SELECT COUNT(ReportingFrequency) FROM ReportDataDictionary WHERE ReportingFrequency NOT LIKE '%Run Period%'");
+        if (nOtherThanRunPeriod > 0) {
+          LOG(Warn, "Using EnergyPlusVersion version " << version.str() << " which should have 'Year' field, but it's always zero");
+        } else {
+          LOG(Info, "Your SQLFile does not contain the 'Year' field since you did not request any outputs at a frequency lower than Run Period");
+        }
         m_hasYear = false;
       }
     }

--- a/src/utilities/sql/Test/SqlFile_GTest.cpp
+++ b/src/utilities/sql/Test/SqlFile_GTest.cpp
@@ -34,6 +34,7 @@
 #include "../../time/Date.hpp"
 #include "../../time/Calendar.hpp"
 #include "../../core/Optional.hpp"
+#include "../../core/StringStreamLogSink.hpp"
 #include "../../data/DataEnums.hpp"
 #include "../../data/TimeSeries.hpp"
 #include "../../filetypes/EpwFile.hpp"
@@ -46,6 +47,7 @@
 #include <utilities/idd/Exterior_FuelEquipment_FieldEnums.hxx>
 #include <utilities/idd/Exterior_WaterEquipment_FieldEnums.hxx>
 
+#include <algorithm>
 #include <iostream>
 #include <boost/regex.hpp>
 #include <resources.hxx>
@@ -773,4 +775,29 @@ TEST_F(SqlFileFixture, EndUseFuelTypes_test) {
     }
     //}
   }
+}
+
+TEST_F(SqlFileFixture, 4298_YearField) {
+  // Test for #4298 - Issue just an Info message if there is no 'Year' field in the SQL
+  // but you have zero timeseries a reporting frequency lower than 'Runperiod'
+
+  StringStreamLogSink sink;
+  sink.setLogLevel(LogLevel::Info);
+
+  // This one does not have any timeseries output
+  openstudio::path path = resourcesPath() / toPath("energyplus/AllFuelTypes/eplusout.sql");
+  sqlFile = openstudio::SqlFile(path);
+  ASSERT_TRUE(sqlFile.connectionOpen());
+
+  auto messages = sink.logMessages();
+  auto numInfos = std::count_if(messages.begin(), messages.end(), [](const LogMessage& message) { return message.logLevel() == LogLevel::Info; });
+  ASSERT_EQ(1, numInfos);
+  auto it = std::find_if(messages.begin(), messages.end(), [](const LogMessage& message) { return message.logLevel() == LogLevel::Info; });
+  ASSERT_NE(it, messages.end());
+  EXPECT_EQ("Your SQLFile does not contain the 'Year' field since you did not request any outputs at a frequency lower than Run Period",
+            it->logMessage());
+
+  auto reportingFreqs = sqlFile.execAndReturnVectorOfString("SELECT ReportingFrequency FROM ReportDataDictionary");
+  ASSERT_TRUE(reportingFreqs);
+  EXPECT_EQ(0, reportingFreqs->size());
 }


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4298
- Do not year if Sql doesn't have a Year field, just Info if f there are no timeseries reporting lower than Runperiod


### Pull Request Author

Add to this list or remove from it as applicable.  This is a simple templated set of guidelines.

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Checked behavior in OpenStudioApplication, adjusted policies as needed (`src/openstudio_lib/library/OpenStudioPolicy.xml`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
