### PR TITLE
Fix #4338 - AirLoopHVAC_Impl::terminalForLastBranch doesn't handle Dual duct correctly

### DIFF
--- a/src/energyplus/Test/AirTerminalDualDuctConstantVolume_GTest.cpp
+++ b/src/energyplus/Test/AirTerminalDualDuctConstantVolume_GTest.cpp
@@ -70,7 +70,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AirTerminalDualDuctConstantVolume) {
   ScheduleConstant sch(m);
   EXPECT_TRUE(atu.setAvailabilitySchedule(sch));
 
-  AirLoopHVAC a(m);
+  AirLoopHVAC a(m, true);
+  ASSERT_TRUE(a.isDualDuct());
   a.addBranchForZone(z, atu);
 
   ForwardTranslator ft;

--- a/src/energyplus/Test/AirTerminalDualDuctVAVOutdoorAir_GTest.cpp
+++ b/src/energyplus/Test/AirTerminalDualDuctVAVOutdoorAir_GTest.cpp
@@ -81,7 +81,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_AirTerminalDualDuctVAVOutdoorAir) {
 
   EXPECT_TRUE(atu.setAvailabilitySchedule(sch));
 
-  AirLoopHVAC a(m);
+  AirLoopHVAC a(m, true);
+  ASSERT_TRUE(a.isDualDuct());
   a.addBranchForZone(z, atu);
 
   ForwardTranslator ft;

--- a/src/model/AirLoopHVAC.cpp
+++ b/src/model/AirLoopHVAC.cpp
@@ -1132,7 +1132,7 @@ namespace model {
     //  }
     //}
 
-    bool AirLoopHVAC_Impl::addBranchForHVACComponent(HVACComponent hvacComponent) {
+    bool AirLoopHVAC_Impl::addBranchForHVACComponent(HVACComponent& hvacComponent) {
       Model _model = this->model();
 
       if (hvacComponent.model() != _model) {
@@ -2136,7 +2136,7 @@ namespace model {
     return getImpl<detail::AirLoopHVAC_Impl>()->addBranchForZone(thermalZone, airTerminal);
   }
 
-  bool AirLoopHVAC::addBranchForHVACComponent(HVACComponent component) {
+  bool AirLoopHVAC::addBranchForHVACComponent(HVACComponent& component) {
     return getImpl<detail::AirLoopHVAC_Impl>()->addBranchForHVACComponent(component);
   }
 

--- a/src/model/AirLoopHVAC.hpp
+++ b/src/model/AirLoopHVAC.hpp
@@ -267,7 +267,7 @@ namespace model {
    *  Returns true if the airTerminal was accepted, otherwise false.  The argument, hvacComponent,
    *  can be an air terminal, AirLoopHVACSupplyPlenum, or airLoopHVACReturnPlenum.
    **/
-    bool addBranchForHVACComponent(HVACComponent hvacComponent);
+    bool addBranchForHVACComponent(HVACComponent& hvacComponent);
 
     /** Removes the Zone identified by zoneLabel from the air loop and returns true
    * upon successful removal.

--- a/src/model/AirLoopHVAC_Impl.hpp
+++ b/src/model/AirLoopHVAC_Impl.hpp
@@ -188,7 +188,7 @@ namespace model {
 
       bool moveBranchForZone(ThermalZone& thermalZone, Mixer& newMixer);
 
-      bool addBranchForHVACComponent(HVACComponent airTerminal);
+      bool addBranchForHVACComponent(HVACComponent& airTerminal);
 
       SizingSystem sizingSystem() const;
 

--- a/src/model/AirLoopHVAC_Impl.hpp
+++ b/src/model/AirLoopHVAC_Impl.hpp
@@ -31,6 +31,7 @@
 #define MODEL_AIRLOOPHVAC_IMPL_HPP
 
 #include "Loop_Impl.hpp"
+#include <utilities/idd/IddEnums.hxx>
 
 namespace openstudio {
 namespace model {
@@ -164,6 +165,9 @@ namespace model {
       boost::optional<HVACComponent> returnFan() const;
 
       boost::optional<HVACComponent> reliefFan() const;
+
+      // Helper to enforce that an ATU type (Single or Dual Duct) matches the AirLoopHVAC Type
+      bool isTerminalTypeValid(const HVACComponent& airTerminal);
 
       bool multiAddBranchForZone(ThermalZone& thermalZone);
 

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -69,6 +69,7 @@
 #include "../AirTerminalSingleDuctParallelPIUReheat_Impl.hpp"
 #include "../AirTerminalSingleDuctConstantVolumeReheat.hpp"
 #include "../AirTerminalSingleDuctConstantVolumeReheat_Impl.hpp"
+#include "../AirTerminalDualDuctConstantVolume.hpp"
 
 #include "../ThermalZone.hpp"
 #include "../ScheduleCompact.hpp"
@@ -1708,4 +1709,31 @@ TEST_F(ModelFixture, AirLoopHVAC_dualDuct_Clone_WithComponents) {
       EXPECT_EQ(3u, comps.size());
     }
   }
+}
+
+TEST_F(ModelFixture, AirLoopHVAC_addBranchForZone_DualDuct_terminalForLastBranch) {
+
+  // Test for #4338
+  Model m;
+
+  AirLoopHVAC a(m);
+  ThermalZone z(m);
+  AirTerminalDualDuctConstantVolume atu(m);
+
+  EXPECT_TRUE(a.addBranchForHVACComponent(atu));
+  auto splitter = a.demandSplitter();
+  auto mixer = a.demandMixer();
+  ASSERT_EQ(1u, splitter.outletModelObjects().size());
+  // (Splitter) -> Node -> ATU -> Node -> Mixer
+  EXPECT_EQ(4u, a.components(splitter.outletModelObjects()[0].cast<HVACComponent>(), mixer).size());
+
+  EXPECT_TRUE(a.addBranchForZone(z));
+  EXPECT_EQ(1u, splitter.outletModelObjects().size());
+  ASSERT_GE(splitter.outletModelObjects().size(), 1u);
+  auto startComp = splitter.outletModelObjects()[0].cast<HVACComponent>();
+  // (Splitter) -> Node -> ATU -> Node -> Zone -> Node -> Mixer
+  EXPECT_EQ(6u, a.components(startComp, mixer).size());
+  EXPECT_EQ(3u, a.components(startComp, mixer, openstudio::IddObjectType::OS_Node).size());
+  EXPECT_EQ(1u, a.components(startComp, mixer, openstudio::IddObjectType::OS_AirTerminal_DualDuct_ConstantVolume).size());
+  EXPECT_EQ(1u, a.components(startComp, mixer, openstudio::IddObjectType::OS_ThermalZone).size());
 }

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -1716,9 +1716,11 @@ TEST_F(ModelFixture, AirLoopHVAC_addBranchForZone_DualDuct_terminalForLastBranch
   // Test for #4338
   Model m;
 
-  AirLoopHVAC a(m);
+  AirLoopHVAC a(m, true);
   ThermalZone z(m);
   AirTerminalDualDuctConstantVolume atu(m);
+
+  ASSERT_TRUE(a.isDualDuct());
 
   EXPECT_TRUE(a.addBranchForHVACComponent(atu));
   auto splitter = a.demandSplitter();

--- a/src/model/test/AirLoopHVAC_GTest.cpp
+++ b/src/model/test/AirLoopHVAC_GTest.cpp
@@ -1769,3 +1769,30 @@ TEST_F(ModelFixture, AirLoopHVAC_addBranchForZone_SingleDuct_terminalForLastBran
   EXPECT_EQ(1u, a.components(startComp, mixer, openstudio::IddObjectType::OS_AirTerminal_SingleDuct_ConstantVolume_NoReheat).size());
   EXPECT_EQ(1u, a.components(startComp, mixer, openstudio::IddObjectType::OS_ThermalZone).size());
 }
+
+TEST_F(ModelFixture, AirLoopHVAC_Enforce_Correct_ATU_Type_SingleDuct) {
+  // Test for #4340 - If I make a SingleDuct AirLoopHVAC, then I shouldn't accept a Dual duct ATU
+  Model m;
+
+  AirLoopHVAC a(m);
+  ThermalZone z(m);
+  AirTerminalDualDuctConstantVolume atu(m);
+
+  ASSERT_FALSE(a.isDualDuct());
+
+  EXPECT_FALSE(a.addBranchForHVACComponent(atu));
+}
+
+TEST_F(ModelFixture, AirLoopHVAC_Enforce_Correct_ATU_Type_DualDuct) {
+  // Test for #4340 - If I make a DualDuct AirLoopHVAC, then I shouldn't accept a Single duct ATU
+  Model m;
+
+  AirLoopHVAC a(m, true);
+  ThermalZone z(m);
+  ScheduleCompact scheduleCompact(m);
+  AirTerminalSingleDuctConstantVolumeNoReheat atu(m, scheduleCompact);
+
+  ASSERT_TRUE(a.isDualDuct());
+
+  EXPECT_FALSE(a.addBranchForHVACComponent(atu));
+}

--- a/src/model/test/AirTerminalDualDuctConstantVolume_GTest.cpp
+++ b/src/model/test/AirTerminalDualDuctConstantVolume_GTest.cpp
@@ -97,7 +97,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctConstantVolume_AddToAirLoopHVAC) {
     Model m;
     AirTerminalDualDuctConstantVolume atu(m);
 
-    AirLoopHVAC a(m);
+    AirLoopHVAC a(m, true);
+    ASSERT_TRUE(a.isDualDuct());
     {
       auto t_zoneSplitters = a.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());
@@ -127,7 +128,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctConstantVolume_AddToAirLoopHVAC) {
     Model m;
     AirTerminalDualDuctConstantVolume atu(m);
 
-    AirLoopHVAC a(m);
+    AirLoopHVAC a(m, true);
+    ASSERT_TRUE(a.isDualDuct());
     {
       auto t_zoneSplitters = a.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());

--- a/src/model/test/AirTerminalDualDuctVAVOutdoorAir_GTest.cpp
+++ b/src/model/test/AirTerminalDualDuctVAVOutdoorAir_GTest.cpp
@@ -109,7 +109,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctVAVOutdoorAir_AddToAirLoopHVAC) {
     Model m;
     AirTerminalDualDuctVAVOutdoorAir atu(m);
 
-    AirLoopHVAC a(m);
+    AirLoopHVAC a(m, true);
+    ASSERT_TRUE(a.isDualDuct());
     {
       auto t_zoneSplitters = a.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());
@@ -139,7 +140,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctVAVOutdoorAir_AddToAirLoopHVAC) {
     Model m;
     AirTerminalDualDuctVAVOutdoorAir atu(m);
 
-    AirLoopHVAC a(m);
+    AirLoopHVAC a(m, true);
+    ASSERT_TRUE(a.isDualDuct());
     {
       auto t_zoneSplitters = a.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());

--- a/src/model/test/AirTerminalDualDuctVAV_GTest.cpp
+++ b/src/model/test/AirTerminalDualDuctVAV_GTest.cpp
@@ -60,7 +60,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctVAV) {
     Model m;
     AirTerminalDualDuctVAV terminal(m);
 
-    AirLoopHVAC airLoopHVAC(m);
+    AirLoopHVAC airLoopHVAC(m, true);
+    ASSERT_TRUE(airLoopHVAC.isDualDuct());
     {
       auto t_zoneSplitters = airLoopHVAC.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());
@@ -80,7 +81,8 @@ TEST_F(ModelFixture, AirTerminalDualDuctVAV) {
     Model m;
     AirTerminalDualDuctVAV terminal(m);
 
-    AirLoopHVAC airLoopHVAC(m);
+    AirLoopHVAC airLoopHVAC(m, true);
+    ASSERT_TRUE(airLoopHVAC.isDualDuct());
     {
       auto t_zoneSplitters = airLoopHVAC.zoneSplitters();
       EXPECT_EQ(1u, t_zoneSplitters.size());


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4338 - AirLoopHVAC_Impl::terminalForLastBranch doesn't handle Dual duct correctly

- Fix #4340 - enforce that an ATU type (Single or Dual Duct) matches the AirLoopHVAC Type
    - Re this change: I realized after modifying the Regression tests that this means you can no longer create a single duct airloophvac and try to connect a Dual Duct ATU directly. If you do add a ConnectorSplitter on the supply side before you do (which is what the reg tests do, then it's fine). I personally do not consider this change much of an API breakage (and one that would likely affect very very very few people), but if @kbenne feels strongly I can revert


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
