### PR TITLE
Fix #4327 - FanSystemModel electricPowerFraction should be optional

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateFanSystemModel.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateFanSystemModel.cpp
@@ -179,7 +179,9 @@ namespace energyplus {
       for (const FanSystemModelSpeed& speed : speeds) {
         auto eg = idfObject.pushExtensibleGroup();
         eg.setDouble(Fan_SystemModelExtensibleFields::SpeedFlowFraction, speed.flowFraction());
-        eg.setDouble(Fan_SystemModelExtensibleFields::SpeedElectricPowerFraction, speed.electricPowerFraction());
+        if (auto epf_ = speed.electricPowerFraction()) {
+          eg.setDouble(Fan_SystemModelExtensibleFields::SpeedElectricPowerFraction, epf_.get());
+        }
       }
     }
 

--- a/src/model/FanSystemModel.hpp
+++ b/src/model/FanSystemModel.hpp
@@ -52,18 +52,18 @@ namespace model {
   class MODEL_API FanSystemModelSpeed
   {
    public:
-    /* Only accepts ModelObjects that are of type Surface, Subsurface or InternalMass, will throw otherwise */
+    FanSystemModelSpeed(double flowFraction);
+
     FanSystemModelSpeed(double flowFraction, double electricPowerFraction);
 
     double flowFraction() const;
-    double electricPowerFraction() const;
+    boost::optional<double> electricPowerFraction() const;
 
-    // this operator is to support sorting of TableMultiVariableLookupPoint in the order required by EnergyPlus Table:Lookup object
     bool operator<(const FanSystemModelSpeed& other) const;
 
    private:
     double m_flowFraction;
-    double m_electricPowerFraction;
+    boost::optional<double> m_electricPowerFraction;
     REGISTER_LOGGER("openstudio.model.FanSystemModelSpeed");
   };
 
@@ -147,7 +147,11 @@ namespace model {
     /** If a speed group is already present (= the flowFraction already exists) (cf `speedIndex()`), it will Warn and override the electricPowerFraction value */
     bool addSpeed(const FanSystemModelSpeed& speed);
 
+    // This one leaves the electricPowerFraction blank, so the electricPowerFunctionofFlowFractionCurve is used.
+    bool addSpeed(double flowFraction);
+
     // Overloads, it creates a FanSystemModelSpeed wrapper, then call `addSpeed(const FanSystemModelSpeed&)`
+    // This one specifies both
     bool addSpeed(double flowFraction, double electricPowerFraction);
 
     bool removeSpeed(unsigned speedIndex);

--- a/src/model/FanSystemModel_Impl.hpp
+++ b/src/model/FanSystemModel_Impl.hpp
@@ -145,6 +145,7 @@ namespace model {
       bool addSpeed(const FanSystemModelSpeed& speed);
 
       // Overloads, it creates a FanSystemModelSpeed wrapper, then call `addSpeed(const FanSystemModelSpeed&)`
+      bool addSpeed(double flowFraction);
       bool addSpeed(double flowFraction, double electricPowerFraction);
 
       bool removeSpeed(unsigned speedIndex);
@@ -220,7 +221,7 @@ namespace model {
 
       virtual boost::optional<HVACComponent> containingHVACComponent() const override;
 
-      bool addSpeedPrivate(double flowFraction, double electricPowerFraction);
+      bool addSpeedPrivate(double flowFraction, boost::optional<double> electricPowerFraction);
     };
 
   }  // namespace detail

--- a/src/model/test/FanSystemModel_GTest.cpp
+++ b/src/model/test/FanSystemModel_GTest.cpp
@@ -574,7 +574,8 @@ TEST_F(ModelFixture, FanSystemModelSpeed) {
 
   FanSystemModelSpeed speed(0.5, 0.45);
   EXPECT_EQ(0.5, speed.flowFraction());
-  EXPECT_EQ(0.45, speed.electricPowerFraction());
+  ASSERT_TRUE(speed.electricPowerFraction());
+  EXPECT_EQ(0.45, speed.electricPowerFraction().get());
 
   ASSERT_THROW(FanSystemModelSpeed(-0.1, 0.45), openstudio::Exception);
   ASSERT_THROW(FanSystemModelSpeed(1.1, 0.45), openstudio::Exception);
@@ -602,9 +603,11 @@ TEST_F(ModelFixture, FanSystemModel_Speeds) {
   std::vector<FanSystemModelSpeed> speeds = fan.speeds();
   EXPECT_EQ(2, speeds.size());
   EXPECT_EQ(0.15, speeds[0].flowFraction());
-  EXPECT_EQ(0.7, speeds[0].electricPowerFraction());
+  ASSERT_TRUE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.7, speeds[0].electricPowerFraction().get());
   EXPECT_EQ(0.45, speeds[1].flowFraction());
-  EXPECT_EQ(0.5, speeds[1].electricPowerFraction());
+  ASSERT_TRUE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.5, speeds[1].electricPowerFraction().get());
 
   EXPECT_TRUE(fan.addSpeed(FanSystemModelSpeed(0.75, 0.8)));
   EXPECT_EQ(3, fan.numExtensibleGroups());
@@ -612,11 +615,14 @@ TEST_F(ModelFixture, FanSystemModel_Speeds) {
   speeds = fan.speeds();
   EXPECT_EQ(3, speeds.size());
   EXPECT_EQ(0.15, speeds[0].flowFraction());
-  EXPECT_EQ(0.7, speeds[0].electricPowerFraction());
+  ASSERT_TRUE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.7, speeds[0].electricPowerFraction().get());
   EXPECT_EQ(0.45, speeds[1].flowFraction());
-  EXPECT_EQ(0.5, speeds[1].electricPowerFraction());
+  ASSERT_TRUE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.5, speeds[1].electricPowerFraction().get());
   EXPECT_EQ(0.75, speeds[2].flowFraction());
-  EXPECT_EQ(0.8, speeds[2].electricPowerFraction());
+  ASSERT_TRUE(speeds[2].electricPowerFraction());
+  EXPECT_EQ(0.8, speeds[2].electricPowerFraction().get());
 
   fan.removeSpeed(1);
   EXPECT_EQ(2, fan.numExtensibleGroups());
@@ -624,9 +630,11 @@ TEST_F(ModelFixture, FanSystemModel_Speeds) {
   speeds = fan.speeds();
   EXPECT_EQ(2, speeds.size());
   EXPECT_EQ(0.15, speeds[0].flowFraction());
-  EXPECT_EQ(0.7, speeds[0].electricPowerFraction());
+  ASSERT_TRUE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.7, speeds[0].electricPowerFraction().get());
   EXPECT_EQ(0.75, speeds[1].flowFraction());
-  EXPECT_EQ(0.8, speeds[1].electricPowerFraction());
+  ASSERT_TRUE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.8, speeds[1].electricPowerFraction().get());
 
   fan.removeAllSpeeds();
   EXPECT_EQ(0, fan.numExtensibleGroups());
@@ -641,9 +649,78 @@ TEST_F(ModelFixture, FanSystemModel_Speeds) {
   speeds = fan.speeds();
   EXPECT_EQ(3, speeds.size());
   EXPECT_EQ(0.15, speeds[0].flowFraction());
-  EXPECT_EQ(0.7, speeds[0].electricPowerFraction());
+  ASSERT_TRUE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.7, speeds[0].electricPowerFraction().get());
   EXPECT_EQ(0.35, speeds[1].flowFraction());
-  EXPECT_EQ(0.72, speeds[1].electricPowerFraction());
+  ASSERT_TRUE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.72, speeds[1].electricPowerFraction().get());
   EXPECT_EQ(0.75, speeds[2].flowFraction());
-  EXPECT_EQ(0.8, speeds[2].electricPowerFraction());
+  ASSERT_TRUE(speeds[2].electricPowerFraction());
+  EXPECT_EQ(0.8, speeds[2].electricPowerFraction().get());
+}
+
+TEST_F(ModelFixture, FanSystemModel_Speeds_noElectricPowerFraction) {
+  Model m;
+  FanSystemModel fan(m);
+
+  // If no extensible groups, same as having one speed (= the design one)
+  EXPECT_EQ(0, fan.numExtensibleGroups());
+  EXPECT_EQ(1, fan.numberofSpeeds());
+
+  EXPECT_TRUE(fan.addSpeed(0.45));
+  EXPECT_EQ(1, fan.numExtensibleGroups());
+  EXPECT_EQ(1, fan.numberofSpeeds());
+
+  EXPECT_TRUE(fan.addSpeed(0.15));
+  EXPECT_EQ(2, fan.numExtensibleGroups());
+  EXPECT_EQ(2, fan.numberofSpeeds());
+
+  // This should have been sorted...
+  std::vector<FanSystemModelSpeed> speeds = fan.speeds();
+  EXPECT_EQ(2, speeds.size());
+  EXPECT_EQ(0.15, speeds[0].flowFraction());
+  EXPECT_FALSE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.45, speeds[1].flowFraction());
+  EXPECT_FALSE(speeds[1].electricPowerFraction());
+
+  EXPECT_TRUE(fan.addSpeed(FanSystemModelSpeed(0.75)));
+  EXPECT_EQ(3, fan.numExtensibleGroups());
+  EXPECT_EQ(3, fan.numberofSpeeds());
+  speeds = fan.speeds();
+  EXPECT_EQ(3, speeds.size());
+  EXPECT_EQ(0.15, speeds[0].flowFraction());
+  EXPECT_FALSE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.45, speeds[1].flowFraction());
+  EXPECT_FALSE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.75, speeds[2].flowFraction());
+  EXPECT_FALSE(speeds[2].electricPowerFraction());
+
+  fan.removeSpeed(1);
+  EXPECT_EQ(2, fan.numExtensibleGroups());
+  EXPECT_EQ(2, fan.numberofSpeeds());
+  speeds = fan.speeds();
+  EXPECT_EQ(2, speeds.size());
+  EXPECT_EQ(0.15, speeds[0].flowFraction());
+  EXPECT_FALSE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.75, speeds[1].flowFraction());
+  EXPECT_FALSE(speeds[1].electricPowerFraction());
+
+  fan.removeAllSpeeds();
+  EXPECT_EQ(0, fan.numExtensibleGroups());
+  EXPECT_EQ(0, fan.speeds().size());
+  EXPECT_EQ(1, fan.numberofSpeeds());
+
+  // Use the setSpeeds, which should sort too
+  speeds.push_back(FanSystemModelSpeed(0.35));
+  EXPECT_TRUE(fan.setSpeeds(speeds));
+  EXPECT_EQ(3, fan.numExtensibleGroups());
+  EXPECT_EQ(3, fan.numberofSpeeds());
+  speeds = fan.speeds();
+  EXPECT_EQ(3, speeds.size());
+  EXPECT_EQ(0.15, speeds[0].flowFraction());
+  EXPECT_FALSE(speeds[0].electricPowerFraction());
+  EXPECT_EQ(0.35, speeds[1].flowFraction());
+  EXPECT_FALSE(speeds[1].electricPowerFraction());
+  EXPECT_EQ(0.75, speeds[2].flowFraction());
+  EXPECT_FALSE(speeds[2].electricPowerFraction());
 }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4327 - FanSystemModel electricPowerFraction should be optional

The API changes are only in the helper class FanSystemModelSpeed that I create just for the extensible groups, so I think it's fine. This prevents a feature users want (at least @shorowit) so this small api change is warranted and worth it IMHO. @kbenne please advise.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
