### PR TITLE
Fix #4335 - Should reset the air nodes when cloning a AirLoopHVACUnitarySystem

### DIFF
--- a/src/model/AirLoopHVACUnitarySystem.cpp
+++ b/src/model/AirLoopHVACUnitarySystem.cpp
@@ -125,7 +125,10 @@ namespace model {
     }
 
     ModelObject AirLoopHVACUnitarySystem_Impl::clone(Model model) const {
+      // Mimic what StraightComponent_Impl::clone would do (we inherit ZoneHVACComponent here...)
       AirLoopHVACUnitarySystem modelObjectClone = ModelObject_Impl::clone(model).cast<AirLoopHVACUnitarySystem>();
+      modelObjectClone.setString(modelObjectClone.inletPort(), "");
+      modelObjectClone.setString(modelObjectClone.outletPort(), "");
 
       if (boost::optional<HVACComponent> supplyFan = this->supplyFan()) {
         modelObjectClone.setSupplyFan(supplyFan->clone(model).cast<HVACComponent>());


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4335 - Should reset the air nodes when cloning a AirLoopHVACUnitarySystem


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
