### PR TITLE
Fix #2145 - Do not create an extra singlezone SPM humidity min created if humidifier downstream of fan

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVAC.cpp
@@ -196,9 +196,11 @@ namespace energyplus {
         std::vector<SetpointManager> _setpointManagers = lowerNode.setpointManagers();
         if (std::find_if(_setpointManagers.begin(), _setpointManagers.end(), isTemperatureControl) == _setpointManagers.end()) {
           for (auto _setpointManager : _supplyOutletSetpointManagers) {
-            SetpointManager spmClone = _setpointManager.clone(t_model).cast<SetpointManager>();
-            spmClone.addToNode(lowerNode);
-            spmClone.setName(lowerNode.name().get() + " OS Default SPM");
+            if (isTemperatureControl(_setpointManager)) {
+              SetpointManager spmClone = _setpointManager.clone(t_model).cast<SetpointManager>();
+              spmClone.addToNode(lowerNode);
+              spmClone.setName(lowerNode.name().get() + " OS Default SPM");
+            }
           }
         }
       }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #2145 - Do not create an extra singlezone SPM humidity min created if humidifier downstream of fan

I took the regression test `humidity_control_2.rb`: https://github.com/NREL/OpenStudio-resources/blob/48ce9f5134aa94156df3a6b755e4ce767a34629a/model/simulationtests/humidity_control_2.rb#L57-L83

Simulated before and after fix. The in.idf will have three less SPMs (as expected), but the eplusout.err stays clean and there is no EUI deviation.




### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] EnergyPlus ForwardTranslator API Changes / Additions
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [x] All new and existing tests passes


**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
