### PR TITLE
Fix #3514 - Make strings returned from openstudio to ruby UTF8

### DIFF
--- a/ruby/rubystrings.swg
+++ b/ruby/rubystrings.swg
@@ -1,0 +1,57 @@
+/* ------------------------------------------------------------
+ *  utility methods for char strings 
+ * ------------------------------------------------------------ */
+
+%fragment("SWIG_AsCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+SWIGINTERN int
+SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
+{
+  if (TYPE(obj) == T_STRING) {
+    char *cstr = StringValuePtr(obj); 
+    size_t size = RSTRING_LEN(obj) + 1;
+    if (cptr)  {
+      if (alloc) {
+	if (*alloc == SWIG_NEWOBJ) {
+	  *cptr = %new_copy_array(cstr, size, char);
+	} else {
+	  *cptr = cstr;
+	  *alloc = SWIG_OLDOBJ;
+	}
+      }
+    }
+    if (psize) *psize = size;
+    return SWIG_OK;
+  } else {
+    swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
+    if (pchar_descriptor) {
+      void* vptr = 0;
+      if (SWIG_ConvertPtr(obj, &vptr, pchar_descriptor, 0) == SWIG_OK) {
+	if (cptr) *cptr = (char *)vptr;
+	if (psize) *psize = vptr ? (strlen((char*)vptr) + 1) : 0;
+	if (alloc) *alloc = SWIG_OLDOBJ;
+	return SWIG_OK;
+      }
+    }
+  }  
+  return SWIG_TypeError;
+}
+}
+
+%fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
+SWIGINTERNINLINE VALUE 
+SWIG_FromCharPtrAndSize(const char* carray, size_t size)
+{
+  if (carray) {
+    if (size > LONG_MAX) {
+      swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
+      return pchar_descriptor ? 
+	SWIG_NewPointerObj(%const_cast(carray,char *), pchar_descriptor, 0) : Qnil;
+    } else {
+      return rb_str_new(carray, %numeric_cast(size,long));
+    }
+  } else {
+    return Qnil;
+  }
+}
+}
+

--- a/ruby/rubystrings.swg
+++ b/ruby/rubystrings.swg
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------
- *  utility methods for char strings 
+ *  utility methods for char strings
  * ------------------------------------------------------------ */
 
 %fragment("SWIG_AsCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
@@ -7,16 +7,16 @@ SWIGINTERN int
 SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
 {
   if (TYPE(obj) == T_STRING) {
-    char *cstr = StringValuePtr(obj); 
+    char *cstr = StringValuePtr(obj);
     size_t size = RSTRING_LEN(obj) + 1;
     if (cptr)  {
       if (alloc) {
-	if (*alloc == SWIG_NEWOBJ) {
-	  *cptr = %new_copy_array(cstr, size, char);
-	} else {
-	  *cptr = cstr;
-	  *alloc = SWIG_OLDOBJ;
-	}
+        if (*alloc == SWIG_NEWOBJ) {
+          *cptr = %new_copy_array(cstr, size, char);
+        } else {
+          *cptr = cstr;
+          *alloc = SWIG_OLDOBJ;
+        }
       }
     }
     if (psize) *psize = size;
@@ -26,28 +26,28 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
     if (pchar_descriptor) {
       void* vptr = 0;
       if (SWIG_ConvertPtr(obj, &vptr, pchar_descriptor, 0) == SWIG_OK) {
-	if (cptr) *cptr = (char *)vptr;
-	if (psize) *psize = vptr ? (strlen((char*)vptr) + 1) : 0;
-	if (alloc) *alloc = SWIG_OLDOBJ;
-	return SWIG_OK;
+        if (cptr) *cptr = (char *)vptr;
+        if (psize) *psize = vptr ? (strlen((char*)vptr) + 1) : 0;
+        if (alloc) *alloc = SWIG_OLDOBJ;
+        return SWIG_OK;
       }
     }
-  }  
+  }
   return SWIG_TypeError;
 }
 }
 
 %fragment("SWIG_FromCharPtrAndSize","header",fragment="SWIG_pchar_descriptor") {
-SWIGINTERNINLINE VALUE 
+SWIGINTERNINLINE VALUE
 SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 {
   if (carray) {
     if (size > LONG_MAX) {
       swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
-      return pchar_descriptor ? 
-	SWIG_NewPointerObj(%const_cast(carray,char *), pchar_descriptor, 0) : Qnil;
+      return pchar_descriptor ?
+        SWIG_NewPointerObj(%const_cast(carray,char *), pchar_descriptor, 0) : Qnil;
     } else {
-      return rb_str_new(carray, %numeric_cast(size,long));
+      return rb_utf8_str_new(carray, %numeric_cast(size,long));
     }
   } else {
     return Qnil;


### PR DESCRIPTION
Pull request overview
---------------------

Fix #3514 - replace rubystrings.swg fragment to use rb_utf8_str_new instead of rb_str_new

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
