### PR TITLE
Fix #4354 - Issue in AirLoopHVACOutdoorAirSystem::reliefComponents with ZoneHVACComponents: wrong order

### DIFF
--- a/src/model/AirLoopHVACOutdoorAirSystem.cpp
+++ b/src/model/AirLoopHVACOutdoorAirSystem.cpp
@@ -355,7 +355,7 @@ namespace model {
           modelObjects.push_back(*comp);
           modelObject = comp->airOutletModelObject();
         } else if (auto comp = modelObject->optionalCast<ZoneHVACComponent>()) {
-          modelObjects.insert(modelObjects.begin(), *comp);
+          modelObjects.push_back(*comp);
           modelObject = comp->outletNode();
         } else {
           // log unhandled component

--- a/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
+++ b/src/model/test/ZoneHVACTerminalUnitVariableRefrigerantFlow_GTest.cpp
@@ -219,21 +219,42 @@ TEST_F(ModelFixture, ZoneHVACTerminalUnitVariableRefrigerantFlow_AddToNodeOutdoo
   EXPECT_EQ(1, outdoorAirSystem.oaComponents().size());
   EXPECT_EQ(1, outdoorAirSystem.reliefComponents().size());
 
-  if (boost::optional<Node> OANode = outdoorAirSystem.outboardOANode()) {
+  {
+    boost::optional<Node> OANode = outdoorAirSystem.outboardOANode();
+    ASSERT_TRUE(OANode);
     ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m);
 
     EXPECT_TRUE(testObject.addToNode(OANode.get()));
     EXPECT_EQ(3, airLoop.supplyComponents().size());
-    EXPECT_EQ(3, outdoorAirSystem.oaComponents().size());
+    auto oaComps = outdoorAirSystem.oaComponents();
+    ASSERT_EQ(3, oaComps.size());
+
     EXPECT_TRUE(testObject.airLoopHVACOutdoorAirSystem());
+
+    // Test for #4354
+    EXPECT_EQ(testObject.inletNode().get(), oaComps[0]);
+    EXPECT_EQ(OANode.get(), oaComps[0]);
+    EXPECT_EQ(testObject, oaComps[1]);
+    EXPECT_EQ(testObject.outletNode().get(), oaComps[2]);
   }
 
-  if (boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode()) {
+  {
+    boost::optional<Node> reliefNode = outdoorAirSystem.outboardReliefNode();
+    ASSERT_TRUE(reliefNode);
+
     ZoneHVACTerminalUnitVariableRefrigerantFlow testObject(m);
     EXPECT_TRUE(testObject.addToNode(reliefNode.get()));
     EXPECT_EQ(3, airLoop.supplyComponents().size());
-    EXPECT_EQ(3, outdoorAirSystem.reliefComponents().size());
+    auto reliefComps = outdoorAirSystem.reliefComponents();
+    ASSERT_EQ(3, reliefComps.size());
+
     EXPECT_TRUE(testObject.airLoopHVACOutdoorAirSystem());
+
+    // Test for #4354
+    EXPECT_EQ(testObject.inletNode().get(), reliefComps[0]);
+    EXPECT_EQ(testObject, reliefComps[1]);
+    EXPECT_EQ(testObject.outletNode().get(), reliefComps[2]);
+    EXPECT_EQ(reliefNode.get(), reliefComps[2]);
   }
 }
 


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4354 - Issue in AirLoopHVACOutdoorAirSystem::refliefComponents with ZoneHVACComponents: wrong order



### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Model API Changes / Additions
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] All new and existing tests passes


**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`: N/A
 - [x] If breaking existing API, add the label `APIChange`: N/A
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
