### PR TITLE
Addresses #4364, Availability Schedule for DaylightingControl

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -24887,9 +24887,12 @@ OS:ThermalZone,
        \type choice
        \key Yes
        \key No
-  A16; \field Humidistat Name
+  A16, \field Humidistat Name
        \type object-list
        \object-list HumidistatNames
+  A17; \field Daylighting Controls Availability Schedule Name
+       \type object-list
+       \object-list ScheduleNames
 
 OS:ZoneControl:Humidistat,
        \memo Specifies zone relative humidity setpoint schedules for humidifying and dehumidifying.

--- a/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -339,7 +339,7 @@ namespace energyplus {
 
         // Availability Schedule Name
         if (boost::optional<Schedule> sched = modelObject.daylightingControlsAvailabilitySchedule()) {
-          if ((idfo = translateAndMapModelObject(sched.get()))) {
+          if (boost::optional<IdfObject> idfo = translateAndMapModelObject(sched.get())) {
             daylightingControlObject.setString(Daylighting_ControlsFields::AvailabilityScheduleName, idfo->name().get());
           }
         }

--- a/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateThermalZone.cpp
@@ -334,7 +334,15 @@ namespace energyplus {
         daylightingControlObject.setName(modelObject.name().get() + " DaylightingControls");
         m_idfObjects.push_back(daylightingControlObject);
 
+        // Zone Name
         daylightingControlObject.setString(Daylighting_ControlsFields::ZoneName, modelObject.nameString());
+
+        // Availability Schedule Name
+        if (boost::optional<Schedule> sched = modelObject.daylightingControlsAvailabilitySchedule()) {
+          if ((idfo = translateAndMapModelObject(sched.get()))) {
+            daylightingControlObject.setString(Daylighting_ControlsFields::AvailabilityScheduleName, idfo->name().get());
+          }
+        }
 
         // Primary Control
         IdfObject primaryReferencePoint(openstudio::IddObjectType::Daylighting_ReferencePoint);

--- a/src/energyplus/Test/DaylightingControl_GTest.cpp
+++ b/src/energyplus/Test/DaylightingControl_GTest.cpp
@@ -124,3 +124,39 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_DaylightingControl_3216) {
   EXPECT_EQ(daylightingControl.phiRotationAroundZAxis(),
             idf_d.getDouble(Daylighting_ControlsFields::GlareCalculationAzimuthAngleofViewDirectionClockwisefromZoneyAxis).get());
 }
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_DaylightingControl_AvailabilitySchedule) {
+  // Test for #4364 - Availability Schedule for DaylightingControl
+  Model model;
+
+  ThermalZone thermalZone(model);
+  Space space(model);
+  space.setThermalZone(thermalZone);
+  DaylightingControl daylightingControl(model);
+  daylightingControl.setSpace(space);
+
+  {
+    ForwardTranslator forwardTranslator;
+    Workspace workspace = forwardTranslator.translateModel(model);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::Daylighting_Controls);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_d(idfObjs[0]);
+
+    EXPECT_EQ("", idf_d.getString(Daylighting_ControlsFields::AvailabilityScheduleName).get());
+  }
+
+  {
+    auto schedule = model.alwaysOffDiscreteSchedule();
+    thermalZone.setDaylightingControlsAvailabilitySchedule(schedule);
+
+    ForwardTranslator forwardTranslator;
+    Workspace workspace = forwardTranslator.translateModel(model);
+
+    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::Daylighting_Controls);
+    ASSERT_EQ(1u, idfObjs.size());
+    WorkspaceObject idf_d(idfObjs[0]);
+
+    EXPECT_EQ(schedule.nameString(), idf_d.getString(Daylighting_ControlsFields::AvailabilityScheduleName).get());
+  }
+}

--- a/src/energyplus/Test/DaylightingControl_GTest.cpp
+++ b/src/energyplus/Test/DaylightingControl_GTest.cpp
@@ -40,6 +40,8 @@
 #include "../../model/Space_Impl.hpp"
 #include "../../model/ThermalZone.hpp"
 #include "../../model/ThermalZone_Impl.hpp"
+#include "../../model/Schedule.hpp"
+#include "../../model/Schedule_Impl.hpp"
 
 #include <utilities/idd/Daylighting_Controls_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
@@ -134,12 +136,13 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_DaylightingControl_AvailabilitySched
   space.setThermalZone(thermalZone);
   DaylightingControl daylightingControl(model);
   daylightingControl.setSpace(space);
+  EXPECT_TRUE(thermalZone.setPrimaryDaylightingControl(daylightingControl));
 
   {
     ForwardTranslator forwardTranslator;
     Workspace workspace = forwardTranslator.translateModel(model);
 
-    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::Daylighting_Controls);
+    WorkspaceObjectVector idfObjs = workspace.getObjectsByType(IddObjectType::Daylighting_Controls);
     ASSERT_EQ(1u, idfObjs.size());
     WorkspaceObject idf_d(idfObjs[0]);
 
@@ -153,7 +156,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_DaylightingControl_AvailabilitySched
     ForwardTranslator forwardTranslator;
     Workspace workspace = forwardTranslator.translateModel(model);
 
-    WorkspaceObjectVector idfObjs = w.getObjectsByType(IddObjectType::Daylighting_Controls);
+    WorkspaceObjectVector idfObjs = workspace.getObjectsByType(IddObjectType::Daylighting_Controls);
     ASSERT_EQ(1u, idfObjs.size());
     WorkspaceObject idf_d(idfObjs[0]);
 

--- a/src/model/ScheduleTypeRegistry.cpp
+++ b/src/model/ScheduleTypeRegistry.cpp
@@ -407,7 +407,7 @@ namespace model {
        OptionalDouble()},
       {"ThermostatSetpointDualSetpoint", "Cooling Setpoint Temperature", "coolingSetpointTemperatureSchedule", true, "Temperature", OptionalDouble(),
        OptionalDouble()},
-      {"ThermalZone", "Daylighting Controls Availability Schedule", "daylightingControlsAvailabilitySchedule", false, "Availability", 0.0, 1.0},
+      {"ThermalZone", "Daylighting Controls Availability", "daylightingControlsAvailabilitySchedule", false, "Availability", 0.0, 1.0},
       {"ZoneControlThermostatStagedDualSetpoint", "Heating Temperature Setpoint Schedule", "heatingTemperatureSetpointSchedule", true, "Temperature",
        OptionalDouble(), OptionalDouble()},
       {"ZoneControlThermostatStagedDualSetpoint", "Cooling Temperature Setpoint Base Schedule", "coolingTemperatureSetpointBaseSchedule", true,

--- a/src/model/ScheduleTypeRegistry.cpp
+++ b/src/model/ScheduleTypeRegistry.cpp
@@ -407,6 +407,7 @@ namespace model {
        OptionalDouble()},
       {"ThermostatSetpointDualSetpoint", "Cooling Setpoint Temperature", "coolingSetpointTemperatureSchedule", true, "Temperature", OptionalDouble(),
        OptionalDouble()},
+      {"ThermalZone", "Daylighting Controls Availability Schedule", "daylightingControlsAvailabilitySchedule", false, "Availability", 0.0, 1.0},
       {"ZoneControlThermostatStagedDualSetpoint", "Heating Temperature Setpoint Schedule", "heatingTemperatureSetpointSchedule", true, "Temperature",
        OptionalDouble(), OptionalDouble()},
       {"ZoneControlThermostatStagedDualSetpoint", "Cooling Temperature Setpoint Base Schedule", "coolingTemperatureSetpointBaseSchedule", true,

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -779,6 +779,20 @@ namespace model {
       setDaylightingControlsAndIlluminanceMaps(this->primaryDaylightingControl(), this->secondaryDaylightingControl(), this->illuminanceMap());
     }
 
+    boost::optional<Schedule> ThermalZone_Impl::daylightingControlsAvailabilitySchedule() const {
+      return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName);
+    }
+
+    bool ThermalZone_Impl::setDaylightingControlsAvailabilitySchedule(Schedule& schedule) {
+      bool result = setSchedule(OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName, "ThermalZone", "Availability", schedule);
+      return result;
+    }
+
+    void ThermalZone_Impl::resetDaylightingControlsAvailabilitySchedule() {
+      bool result = setString(OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName, "");
+      OS_ASSERT(result);
+    }
+
     boost::optional<RenderingColor> ThermalZone_Impl::renderingColor() const {
       return getObject<ModelObject>().getModelObjectTarget<RenderingColor>(OS_ThermalZoneFields::GroupRenderingName);
     }
@@ -2850,6 +2864,18 @@ namespace model {
 
   void ThermalZone::checkDaylightingControlsAndIlluminanceMaps() {
     getImpl<detail::ThermalZone_Impl>()->checkDaylightingControlsAndIlluminanceMaps();
+  }
+
+  boost::optional<Schedule> ThermalZone::daylightingControlsAvailabilitySchedule() const {
+    return getImpl<detail::ThermalZone_Impl>()->daylightingControlsAvailabilitySchedule();
+  }
+
+  bool ThermalZone::setDaylightingControlsAvailabilitySchedule(Schedule& schedule) {
+    return getImpl<detail::ThermalZone_Impl>()->setDaylightingControlsAvailabilitySchedule(schedule);
+  }
+
+  void ThermalZone::resetDaylightingControlsAvailabilitySchedule() {
+    getImpl<detail::ThermalZone_Impl>()->resetDaylightingControlsAvailabilitySchedule();
   }
 
   boost::optional<RenderingColor> ThermalZone::renderingColor() const {

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -111,6 +111,8 @@
 #include "AirflowNetworkZone_Impl.hpp"
 #include "ZonePropertyUserViewFactorsBySurfaceName.hpp"
 #include "ZonePropertyUserViewFactorsBySurfaceName_Impl.hpp"
+#include "ScheduleTypeLimits.hpp"
+#include "ScheduleTypeRegistry.hpp"
 
 #include <utilities/idd/IddFactory.hxx>
 
@@ -454,6 +456,16 @@ namespace model {
       return edges;
     }
 
+    std::vector<ScheduleTypeKey> ThermalZone_Impl::getScheduleTypeKeys(const Schedule& schedule) const {
+      std::vector<ScheduleTypeKey> result;
+      UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
+      UnsignedVector::const_iterator b(fieldIndices.begin()), e(fieldIndices.end());
+      if (std::find(b, e, OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName) != e) {
+        result.push_back(ScheduleTypeKey("ThermalZone", "Daylighting Controls Availability"));
+      }
+      return result;
+    }
+
     int ThermalZone_Impl::multiplier() const {
       boost::optional<int> value = getInt(OS_ThermalZoneFields::Multiplier, true);
       OS_ASSERT(value);
@@ -784,7 +796,8 @@ namespace model {
     }
 
     bool ThermalZone_Impl::setDaylightingControlsAvailabilitySchedule(Schedule& schedule) {
-      bool result = setSchedule(OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName, "ThermalZone", "Availability", schedule);
+      bool result =
+        setSchedule(OS_ThermalZoneFields::DaylightingControlsAvailabilityScheduleName, "ThermalZone", "Daylighting Controls Availability", schedule);
       return result;
     }
 

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -224,6 +224,12 @@ namespace model {
 
     void checkDaylightingControlsAndIlluminanceMaps();
 
+    boost::optional<Schedule> daylightingControlsAvailabilitySchedule() const;
+
+    bool setDaylightingControlsAvailabilitySchedule(Schedule& schedule);
+
+    void resetDaylightingControlsAvailabilitySchedule();
+
     /// Returns the rendering color.
     boost::optional<RenderingColor> renderingColor() const;
 

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -51,6 +51,7 @@ namespace model {
   class ZoneMixing;
   class AirflowNetworkZone;
   class ZonePropertyUserViewFactorsBySurfaceName;
+  class Schedule;
 
   namespace detail {
 

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -237,6 +237,12 @@ namespace model {
 
       void checkDaylightingControlsAndIlluminanceMaps();
 
+      boost::optional<Schedule> daylightingControlsAvailabilitySchedule() const;
+
+      bool setDaylightingControlsAvailabilitySchedule(Schedule& schedule);
+
+      void resetDaylightingControlsAvailabilitySchedule();
+
       /// Returns the rendering color.
       boost::optional<RenderingColor> renderingColor() const;
 

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -52,6 +52,7 @@ namespace model {
   class ZoneHVACEquipmentList;
   class AirflowNetworkZone;
   class ZonePropertyUserViewFactorsBySurfaceName;
+  class Schedule;
 
   namespace detail {
 
@@ -91,6 +92,8 @@ namespace model {
       virtual IddObjectType iddObjectType() const override;
 
       virtual std::vector<HVACComponent> edges(const boost::optional<HVACComponent>& prev) override;
+
+      virtual std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const override;
 
       /** @name Getters */
       //@{

--- a/src/model/test/ThermalZone_GTest.cpp
+++ b/src/model/test/ThermalZone_GTest.cpp
@@ -805,12 +805,11 @@ TEST_F(ModelFixture, ThermalZone_DaylightingControlsAvailabilitySchedule) {
 
   EXPECT_FALSE(z.daylightingControlsAvailabilitySchedule());
 
-  ScheduleConstant schedule(m);
-  schedule.setValue(0.5);
+  auto schedule = m.alwaysOffDiscreteSchedule();
 
   EXPECT_TRUE(z.setDaylightingControlsAvailabilitySchedule(schedule));
   ASSERT_TRUE(z.daylightingControlsAvailabilitySchedule());
-  EXPECT_EQ(schedule, z.daylightingControlsAvailabilitySchedule.get());
+  EXPECT_EQ(schedule, z.daylightingControlsAvailabilitySchedule().get());
 
   z.resetDaylightingControlsAvailabilitySchedule();
   EXPECT_FALSE(z.daylightingControlsAvailabilitySchedule());

--- a/src/model/test/ThermalZone_GTest.cpp
+++ b/src/model/test/ThermalZone_GTest.cpp
@@ -54,6 +54,8 @@
 #include "../ScheduleCompact.hpp"
 #include "../ScheduleRuleset.hpp"
 #include "../ScheduleRuleset_Impl.hpp"
+#include "../ScheduleConstant.hpp"
+#include "../ScheduleConstant_Impl.hpp"
 #include "../SetpointManagerSingleZoneReheat.hpp"
 #include "../SizingZone.hpp"
 #include "../SizingZone_Impl.hpp"
@@ -795,4 +797,21 @@ TEST_F(ModelFixture, ThermalZone_AddToNode_NotInSeries) {
   connectingNode = mixer.lastInletModelObject()->cast<Node>();
   EXPECT_FALSE(z2.multiAddToNode(connectingNode));
   EXPECT_EQ(13u, a.demandComponents().size());
+}
+
+TEST_F(ModelFixture, ThermalZone_DaylightingControlsAvailabilitySchedule) {
+  Model m;
+  ThermalZone z(m);
+
+  EXPECT_FALSE(z.daylightingControlsAvailabilitySchedule());
+
+  ScheduleConstant schedule(m);
+  schedule.setValue(0.5);
+
+  EXPECT_TRUE(z.setDaylightingControlsAvailabilitySchedule(schedule));
+  ASSERT_TRUE(z.daylightingControlsAvailabilitySchedule());
+  EXPECT_EQ(schedule, z.daylightingControlsAvailabilitySchedule.get());
+
+  z.resetDaylightingControlsAvailabilitySchedule();
+  EXPECT_FALSE(z.daylightingControlsAvailabilitySchedule());
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4364

Adds to `ThermalZone`:
* `daylightingControlsAvailabilitySchedule`
* `setDaylightingControlsAvailabilitySchedule`
* `resetDaylightingControlsAvailabilitySchedule`

Questions:
* Do we need version translation if we're just adding a new optional field? Answer: since the new field is at the end, we don't need it.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
