### PR TITLE
Fix #4309 - disable RUBYLIB env and use --include or -I using cli

### DIFF
--- a/src/cli/embedded_help.rb
+++ b/src/cli/embedded_help.rb
@@ -54,9 +54,10 @@ BINDING = Kernel::binding()
 module Kernel
   # ":" is our root path to the embedded file system
   # make sure it is in the ruby load path
-  if ENV['RUBYLIB']
-    ENV['RUBYLIB'].split(File::PATH_SEPARATOR).each {|lib| $LOAD_PATH.unshift(lib)}
-  end
+  # TJC remove RUBYLIB env and use --include or -I via cli args instead
+  #if ENV['RUBYLIB']
+  #  ENV['RUBYLIB'].split(File::PATH_SEPARATOR).each {|lib| $LOAD_PATH.unshift(lib)}
+  #end
   $LOAD_PATH << ':'
   $LOAD_PATH << ':/ruby/2.7.0'
   $LOAD_PATH << ':/ruby/2.7.0/x86_64-darwin16'


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4309

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

Many users have a bash profile setup that automatically sets the RUBYLIB env to point to OpenStudio Ruby bindings (e.g. export RUBYLIB=/Applications/OpenStudio-3.2.1/Ruby), and while this works fine when using Ruby bindings, when using the cli directly odd runtime behavior happens such as changing the verbosity levels of log messages as described in the bug report. 

If a user wants to add ruby libs and modify the the ruby load path,  the options -`-include` or `-I` should be passed to the CLI vs setting this RUBYLIB.  This is what was done for bundler options such as GEM_HOME, GEM_PATH.  The main issue with these ruby specific envs is other embedded ruby gems can use these variables and cause some runtime issues, which  is what is happening with this bug. 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
