### PR TITLE
Addresses #1515, Reverse Translator should retain thermal zone name from IDF instead of re-naming it

### DIFF
--- a/src/energyplus/ReverseTranslator/ReverseTranslateZone.cpp
+++ b/src/energyplus/ReverseTranslator/ReverseTranslateZone.cpp
@@ -67,7 +67,7 @@ namespace energyplus {
     OptionalString s = workspaceObject.name();
     if (s) {
       space.setName(*s);
-      thermalZone.setName(*s + " Thermal Zone");
+      thermalZone.setName(*s);
       _idfZoneName = *s;
     }
 

--- a/src/energyplus/Test/ReverseTranslator_GTest.cpp
+++ b/src/energyplus/Test/ReverseTranslator_GTest.cpp
@@ -812,7 +812,7 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZonePropertyUserViewFactorsBySurface
   std::vector<ThermalZone> thermalZones = model.getModelObjects<ThermalZone>();
   ASSERT_EQ(1u, thermalZones.size());
   ThermalZone thermalZone = thermalZones[0];
-  EXPECT_EQ(thermalZone.name().get(), "Thermal Zone 1 Thermal Zone");
+  EXPECT_EQ(thermalZone.name().get(), "Thermal Zone 1");
   std::vector<Surface> surfaces = model.getModelObjects<Surface>();
   EXPECT_EQ(2u, surfaces.size());
   std::sort(surfaces.begin(), surfaces.end(), openstudio::WorkspaceObjectNameLess());
@@ -822,7 +822,7 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZonePropertyUserViewFactorsBySurface
   EXPECT_EQ(1u, zoneProp.numberofViewFactors());
   std::vector<ViewFactor> viewFactors = zoneProp.viewFactors();
   ViewFactor viewFactor = viewFactors[0];
-  EXPECT_EQ(zoneProp.thermalZone().name().get(), "Thermal Zone 1 Thermal Zone");
+  EXPECT_EQ(zoneProp.thermalZone().name().get(), "Thermal Zone 1");
   EXPECT_EQ(viewFactor.fromSurface().name().get(), "Surface 1");
   EXPECT_EQ(viewFactor.toSurface().name().get(), "Surface 2");
   EXPECT_EQ(0.25, viewFactor.viewFactor());
@@ -882,13 +882,13 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZonePropertyUserViewFactorsBySurface
   std::vector<ThermalZone> thermalZones = model.getModelObjects<ThermalZone>();
   ASSERT_EQ(1u, thermalZones.size());
   ThermalZone thermalZone = thermalZones[0];
-  EXPECT_EQ(thermalZone.name().get(), "Thermal Zone 1 Thermal Zone");
+  EXPECT_EQ(thermalZone.name().get(), "Thermal Zone 1");
   std::vector<Surface> surfaces = model.getModelObjects<Surface>();
   ASSERT_EQ(1u, surfaces.size());
   Surface surface = surfaces[0];
   EXPECT_EQ(surface.name().get(), "Surface 1");
   ZonePropertyUserViewFactorsBySurfaceName zoneProp = thermalZone.getZonePropertyUserViewFactorsBySurfaceName();
-  EXPECT_EQ(zoneProp.thermalZone().name().get(), "Thermal Zone 1 Thermal Zone");
+  EXPECT_EQ(zoneProp.thermalZone().name().get(), "Thermal Zone 1");
 
   // We allow toSurface to be equal to fromSurface
   EXPECT_EQ(1u, zoneProp.numberofViewFactors());
@@ -940,10 +940,10 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZoneList) {
     std::vector<openstudio::model::ThermalZone> zones = model.getModelObjects<openstudio::model::ThermalZone>();
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::ThermalZone>().size());
     boost::optional<openstudio::model::ThermalZone> _zone1 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString() + " Thermal Zone");
+      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
     ASSERT_TRUE(_zone1);
     boost::optional<openstudio::model::ThermalZone> _zone2 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString() + " Thermal Zone");
+      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
     ASSERT_TRUE(_zone2);
 
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::Space>().size());
@@ -987,10 +987,10 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZoneList) {
     std::vector<openstudio::model::ThermalZone> zones = model.getModelObjects<openstudio::model::ThermalZone>();
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::ThermalZone>().size());
     boost::optional<openstudio::model::ThermalZone> _zone1 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString() + " Thermal Zone");
+      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
     ASSERT_TRUE(_zone1);
     boost::optional<openstudio::model::ThermalZone> _zone2 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString() + " Thermal Zone");
+      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
     ASSERT_TRUE(_zone2);
 
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::Space>().size());

--- a/src/energyplus/Test/ReverseTranslator_GTest.cpp
+++ b/src/energyplus/Test/ReverseTranslator_GTest.cpp
@@ -939,11 +939,9 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZoneList) {
 
     std::vector<openstudio::model::ThermalZone> zones = model.getModelObjects<openstudio::model::ThermalZone>();
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::ThermalZone>().size());
-    boost::optional<openstudio::model::ThermalZone> _zone1 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
+    boost::optional<openstudio::model::ThermalZone> _zone1 = model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
     ASSERT_TRUE(_zone1);
-    boost::optional<openstudio::model::ThermalZone> _zone2 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
+    boost::optional<openstudio::model::ThermalZone> _zone2 = model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
     ASSERT_TRUE(_zone2);
 
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::Space>().size());
@@ -986,11 +984,9 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ZoneList) {
 
     std::vector<openstudio::model::ThermalZone> zones = model.getModelObjects<openstudio::model::ThermalZone>();
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::ThermalZone>().size());
-    boost::optional<openstudio::model::ThermalZone> _zone1 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
+    boost::optional<openstudio::model::ThermalZone> _zone1 = model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone1->nameString());
     ASSERT_TRUE(_zone1);
-    boost::optional<openstudio::model::ThermalZone> _zone2 =
-      model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
+    boost::optional<openstudio::model::ThermalZone> _zone2 = model.getModelObjectByName<openstudio::model::ThermalZone>(_i_zone2->nameString());
     ASSERT_TRUE(_zone2);
 
     ASSERT_EQ(static_cast<unsigned>(2), model.getModelObjects<openstudio::model::Space>().size());

--- a/src/energyplus/Test/ShadowCalculation_GTest.cpp
+++ b/src/energyplus/Test/ShadowCalculation_GTest.cpp
@@ -359,11 +359,11 @@ TEST_F(EnergyPlusFixture, ReverseTranslator_ShadowCalculation) {
 
     EXPECT_EQ(3u, m.getConcreteModelObjects<ThermalZone>().size());
 
-    boost::optional<openstudio::model::ThermalZone> _z1 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone1 Thermal Zone");
+    boost::optional<openstudio::model::ThermalZone> _z1 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone1");
     ASSERT_TRUE(_z1);
-    boost::optional<openstudio::model::ThermalZone> _z2 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone2 Thermal Zone");
+    boost::optional<openstudio::model::ThermalZone> _z2 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone2");
     ASSERT_TRUE(_z2);
-    boost::optional<openstudio::model::ThermalZone> _z3 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone3 Thermal Zone");
+    boost::optional<openstudio::model::ThermalZone> _z3 = m.getModelObjectByName<openstudio::model::ThermalZone>("Zone3");
     ASSERT_TRUE(_z3);
 
     {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #1515

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
