### PR TITLE
Provide more options for installation of openstudio dlls

### DIFF
--- a/ruby/openstudio.rb
+++ b/ruby/openstudio.rb
@@ -33,20 +33,24 @@ if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
 
   if defined?(RubyInstaller::Runtime)
 
-    cur_location = File.dirname(__FILE__)  
-  
+    cur_location = File.dirname(__FILE__)
+
     build_type = File.basename(cur_location)
 
     if build_type == "Debug" or build_type == "Release" or build_type == "RelWithDebugInfo" or build_type == "RelMinSize"
       # in build dir execution
-      relative_dll_path = File.join(File.dirname(File.dirname(cur_location)), build_type)  
+      relative_dll_path = File.join(File.dirname(File.dirname(cur_location)), build_type)
       RubyInstaller::Runtime.add_dll_directory(relative_dll_path)
-    else 
+    else
       # install dir execution
-      RubyInstaller::Runtime.add_dll_directory(File.join(File.dirname(cur_location), "lib"))
+      ['bin', 'lib'].each do |p|
+        if File.exists?(File.join(File.dirname(cur_location), p))
+          RubyInstaller::Runtime.add_dll_directory(File.join(File.dirname(cur_location), p))
+        end
+      end
     end
   end
-else  
+else
   # Do something here for Mac OSX environments
   ENV['PATH'] = "#{File.dirname(__FILE__)}:#{original_path}"
 end


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes https://github.com/openstudiocoalition/OpenStudioApplication/issues/407

Different applications may install OpenStudio in a variety of different ways, this provides for installing the openstudio lib dlls in a bin directory rather than the lib directory

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
