### PR TITLE
Fix #4390 - add OSRunner::getOptionalBoolArgumentValue

### DIFF
--- a/src/measure/OSRunner.cpp
+++ b/src/measure/OSRunner.cpp
@@ -605,6 +605,20 @@ namespace measure {
     return false;
   }
 
+  boost::optional<bool> OSRunner::getOptionalBoolArgumentValue(const std::string& argument_name,
+                                                               const std::map<std::string, OSArgument>& user_arguments) {
+    auto it = user_arguments.find(argument_name);
+    if (it != user_arguments.end()) {
+      if (it->second.hasValue()) {
+        return it->second.valueAsBool();
+      } else if (it->second.hasDefaultValue()) {
+        return it->second.defaultValueAsBool();
+      }
+    }
+
+    return boost::none;
+  }
+
   double OSRunner::getDoubleArgumentValue(const std::string& argument_name, const std::map<std::string, OSArgument>& user_arguments) {
     std::stringstream ss;
 

--- a/src/measure/OSRunner.hpp
+++ b/src/measure/OSRunner.hpp
@@ -211,6 +211,10 @@ namespace measure {
    *  required or has a default. */
     bool getBoolArgumentValue(const std::string& argument_name, const std::map<std::string, OSArgument>& user_arguments);
 
+    /** Call this method to retrieve the value of an OSArgument of type boolean that is optional
+   *  (not required and does not have a default). */
+    boost::optional<bool> getOptionalBoolArgumentValue(const std::string& argument_name, const std::map<std::string, OSArgument>& user_arguments);
+
     /** Call this method to retrieve the value of an OSArgument of type double that is either
    *  required or has a default. */
     double getDoubleArgumentValue(const std::string& argument_name, const std::map<std::string, OSArgument>& user_arguments);

--- a/src/measure/test/OSRunner_GTest.cpp
+++ b/src/measure/test/OSRunner_GTest.cpp
@@ -33,6 +33,7 @@
 #include "../OSRunner.hpp"
 #include "../OSMeasure.hpp"
 #include "../ModelMeasure.hpp"
+#include "../OSArgument.hpp"
 
 #include "../../model/Model.hpp"
 
@@ -90,4 +91,38 @@ TEST_F(MeasureFixture, OSRunner_StdOut) {
   EXPECT_EQ("Standard Output\n", step.result()->stdOut().get());
   ASSERT_TRUE(step.result()->stdErr());
   EXPECT_EQ("Standard Error\n", step.result()->stdErr().get());
+}
+
+TEST_F(MeasureFixture, OSRunner_getOptionalBoolArgumentValue) {
+
+  WorkflowJSON workflow;
+  OSRunner runner(workflow);
+
+  constexpr bool required = false;
+  constexpr auto arg_name = "heat_pump_is_ducted";
+
+  std::vector<boost::optional<bool>> tests{
+    boost::optional<bool>(),
+    boost::optional<bool>(true),
+    boost::optional<bool>(false),
+  };
+
+  for (const auto& test : tests) {
+    std::vector<OSArgument> argumentVector;
+    OSArgument boolArgument = OSArgument::makeBoolArgument(arg_name, required);
+    if (test.has_value()) {
+      boolArgument.setValue(test.get());
+    }
+    argumentVector.push_back(boolArgument);
+
+    std::map<std::string, OSArgument> argumentMap = convertOSArgumentVectorToMap(argumentVector);
+
+    boost::optional<bool> result_ = runner.getOptionalBoolArgumentValue(arg_name, argumentMap);
+    if (!test.has_value()) {
+      EXPECT_FALSE(result_.has_value());
+    } else {
+      ASSERT_TRUE(result_.has_value());
+      EXPECT_EQ(test.get(), result_.get());
+    }
+  }
 }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4390 - add OSRunner::getOptionalBoolArgumentValue

### Pull Request Author

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
