### PR TITLE
Resolves #4395 Add in CLI option to use epJSON

### DIFF
--- a/src/cli/openstudio_cli.rb
+++ b/src/cli/openstudio_cli.rb
@@ -914,6 +914,7 @@ class Run
     options[:no_simulation] = false
     options[:osw_path] = './workflow.osw'
     options[:post_process] = false
+    options[:ep_json] = false
 
     opts = OptionParser.new do |o|
       o.banner = 'Usage: openstudio run [options]'
@@ -929,6 +930,9 @@ class Run
       end
       o.on('-p', '--postprocess_only', 'Only run the reporting measures') do
         options[:post_process] = true
+      end
+      o.on('--export-epJSON', 'export epJSON file format. The default is IDF') do
+        options[:ep_json] = true
       end
       o.on('-s', '--socket PORT', 'Pipe status messages to a socket on localhost PORT') do |port|
         options[:socket] = port
@@ -963,6 +967,10 @@ class Run
     if options[:debug]
       run_options[:debug] = true
       run_options[:cleanup] = false
+    end
+
+    if options[:ep_json]
+      run_options[:ep_json] = true
     end
 
     if options[:socket]


### PR DESCRIPTION
Pull request overview
---------------------

 - Resolves  #4395.  Related https://github.com/NREL/OpenStudio-workflow-gem/pull/136

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

This adds in a cli option --epjson to pass into the workflow gem to use epJSON vs IDF. 

See https://github.com/NREL/OpenStudio-workflow-gem/pull/136 for all the details on usage in workflow gem. 


### Pull Request Author


 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
