### PR TITLE
Fix #4439 - Correctly Reverse Translate gbXML Schedules

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -269,6 +269,7 @@ SET(gbxml_resources_src
   gbxml/ZNETH.xml
   gbxml/3951_Geometry_bug.xml
   gbxml/3997_WindowScaling_bug.xml
+  gbxml/TestSchedules.xml
 )
 
 # update the resources

--- a/resources/gbxml/TestSchedules.xml
+++ b/resources/gbxml/TestSchedules.xml
@@ -1,0 +1,164 @@
+<gbXML xmlns="http://www.gbxml.org/schema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.gbxml.org/schema http://gbxml.org/schema/6-01/GreenBuildingXML_Ver6.01.xsd" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" useSIUnitsForResults="true" SurfaceReferenceLocation="Centerline" temperatureUnit="F" lengthUnit="Feet" areaUnit="SquareFeet" volumeUnit="CubicFeet" version="6.01">
+  <Campus id="Facility">
+
+    <Description>A gbxml test file for Schedules</Description>
+
+    <Building id="1">
+      <Area>200000</Area>
+      <BuildingStorey id="storey-1">
+        <Name>storey 1</Name>
+        <Level>0</Level>
+      </BuildingStorey>
+    </Building>
+  </Campus>
+
+  <Schedule type="Fraction" id="Simple_Schedule">
+    <YearSchedule id="Simple_Schedule_YearSchedule">
+      <BeginDate>2017-01-01</BeginDate>
+      <EndDate>2017-12-31</EndDate>
+      <WeekScheduleId weekScheduleIdRef="Simple_Schedule_WeekSchedule" />
+    </YearSchedule>
+    <Name>Simple Year Schedule</Name>
+  </Schedule>
+  <WeekSchedule type="Fraction" id="Simple_Schedule_WeekSchedule">
+    <Day dayScheduleIdRef="Simple_Schedule_DaySchedule" dayType="All" />
+    <Name>Simple Year Schedule - Typical Week</Name>
+  </WeekSchedule>
+  <DaySchedule type="Fraction" id="Simple_Schedule_DaySchedule">
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0.1</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.8</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.2</ScheduleValue>
+    <ScheduleValue>0.2</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <Name>Simple Year Schedule - Typical Day</Name>
+</DaySchedule>
+
+
+  <Schedule type="Fraction" id="Complex_Schedule">
+    <YearSchedule id="Complex_Schedule_YearSchedule_BeginYear">
+      <BeginDate>2017-01-01</BeginDate>
+      <EndDate>2017-06-30</EndDate>
+      <WeekScheduleId weekScheduleIdRef="Complex_Schedule_WeekSchedule_BeginYear" />
+    </YearSchedule>
+    <YearSchedule id="Complex_Schedule_YearSchedule_EndYear">
+      <BeginDate>2017-07-01</BeginDate>
+      <EndDate>2017-12-31</EndDate>
+      <WeekScheduleId weekScheduleIdRef="Complex_Schedule_WeekSchedule_EndYear" />
+    </YearSchedule>
+    <Name>Complex Year Schedule</Name>
+  </Schedule>
+  <WeekSchedule type="Fraction" id="Complex_Schedule_WeekSchedule_BeginYear">
+    <Day dayScheduleIdRef="Complex_Schedule_DaySchedule_BeginYear" dayType="All" />
+    <Name>Complex Year Schedule - Typical Week January to June</Name>
+  </WeekSchedule>
+  <DaySchedule type="Fraction" id="Complex_Schedule_DaySchedule_BeginYear">
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0.1</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.8</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.9</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.3</ScheduleValue>
+    <ScheduleValue>0.2</ScheduleValue>
+    <ScheduleValue>0.2</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <Name>Complex Year Schedule - Typical Day January to June</Name>
+  </DaySchedule>
+
+  <WeekSchedule type="Fraction" id="Complex_Schedule_WeekSchedule_EndYear">
+    <Day dayScheduleIdRef="Complex_Schedule_DaySchedule_EndYear_Weekday" dayType="Weekday" />
+    <Day dayScheduleIdRef="Complex_Schedule_DaySchedule_EndYear_Weekend" dayType="Weekend" />
+    <Name>Complex Year Schedule - Typical Week July to December</Name>
+  </WeekSchedule>
+  <DaySchedule type="Fraction" id="Complex_Schedule_DaySchedule_EndYear_Weekday">
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0.5</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <Name>Complex Year Schedule - Typical Weekday July to December</Name>
+  </DaySchedule>
+  <DaySchedule type="Fraction" id="Complex_Schedule_DaySchedule_EndYear_Weekend">
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>1.0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <ScheduleValue>0</ScheduleValue>
+    <Name>Complex Year Schedule - Typical Weekend July to December</Name>
+  </DaySchedule>
+
+
+</gbXML>
+
+

--- a/src/gbxml/MapSchedules.cpp
+++ b/src/gbxml/MapSchedules.cpp
@@ -218,7 +218,7 @@ namespace gbxml {
       OS_ASSERT(yd.calendarYear().get() == std::stoi(endDateParts.at(0)));
       openstudio::Date endDate = yd.makeDate(std::stoi(endDateParts.at(1)), std::stoi(endDateParts.at(2)));
 
-      std::string weekScheduleId = element.child("WeekScheduleId").attribute("weekScheduleIdRef").value();
+      std::string weekScheduleId = scheduleYearElement.child("WeekScheduleId").attribute("weekScheduleIdRef").value();
 
       // this can be made more efficient using QXPath in QXmlPatterns later
       for (auto& scheduleWeekElement : root.children("WeekSchedule")) {

--- a/src/gbxml/Test/ReverseTranslator_GTest.cpp
+++ b/src/gbxml/Test/ReverseTranslator_GTest.cpp
@@ -46,6 +46,12 @@
 #include "../../model/Building_Impl.hpp"
 #include "../../model/ThermalZone.hpp"
 #include "../../model/ThermalZone_Impl.hpp"
+#include "../../model/ScheduleDay.hpp"
+#include "../../model/ScheduleDay_Impl.hpp"
+#include "../../model/ScheduleWeek.hpp"
+#include "../../model/ScheduleWeek_Impl.hpp"
+#include "../../model/ScheduleYear.hpp"
+#include "../../model/ScheduleYear_Impl.hpp"
 #include "../../model/Space.hpp"
 #include "../../model/Space_Impl.hpp"
 #include "../../model/Surface.hpp"
@@ -67,6 +73,7 @@
 #include <resources.hxx>
 
 #include <sstream>
+#include <utility>
 
 using namespace openstudio::energyplus;
 using namespace openstudio::model;
@@ -265,7 +272,7 @@ TEST_F(gbXMLFixture, ReverseTranslator_FloorSurfaces) {
   struct ExpectedSurfaceInfo
   {
     ExpectedSurfaceInfo(std::string t_name, std::string t_surfaceType, std::string t_spaceName)
-      : name(t_name), surfaceType(t_surfaceType), spaceName(t_spaceName){};
+      : name(std::move(t_name)), surfaceType(std::move(t_surfaceType)), spaceName(std::move(t_spaceName)){};
 
     const std::string name;
     const std::string surfaceType;
@@ -589,4 +596,18 @@ TEST_F(gbXMLFixture, ReverseTranslator_3997_WindowScaling) {
     EXPECT_EQ(0u, _surf->subSurfaces().size());
     EXPECT_EQ("Outdoors", _surf->outsideBoundaryCondition());
   }
+}
+
+TEST_F(gbXMLFixture, ReverseTranslator_Schedules_Basic) {
+
+  // Test for #4439 - Properly RT gbxml Schedules
+  openstudio::path inputPath = resourcesPath() / openstudio::toPath("gbxml/TestCube.xml");
+
+  openstudio::gbxml::ReverseTranslator reverseTranslator;
+  boost::optional<openstudio::model::Model> model = reverseTranslator.loadModel(inputPath);
+  ASSERT_TRUE(model);
+
+  EXPECT_EQ(2U, model->getConcreteModelObjects<ScheduleYear>().size());
+  EXPECT_EQ(2U, model->getConcreteModelObjects<ScheduleWeek>().size());
+  EXPECT_EQ(2U, model->getConcreteModelObjects<ScheduleDay>().size());
 }


### PR DESCRIPTION
Pull request overview
---------------------

Fix #4439 - Correctly Reverse Translate gbXML Schedules.

This is largely a PR that adds tests for gbxml Schedules in the RT. The fix is a single line change.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] gbXML ReverseTranslator API Changes / Additions
 - [x] gbXML ReverseTranslator Tests (in `src/gbxml/Test`)
 - [x] All new and existing tests passes
 - [x] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
