### PR TITLE
Fix #4446 - add SizingSystem::autosizedOccupantDiversity.

### DIFF
--- a/src/model/SizingSystem.cpp
+++ b/src/model/SizingSystem.cpp
@@ -956,8 +956,9 @@ namespace model {
     boost::optional<double> SizingSystem_Impl::autosizedOccupantDiversity() const {
       boost::optional<double> result;
 
-      // TODO: as of 9.6.0, for some reason, it returns one entry for cooling and one for heating...
+      // Note: as of 9.6.0, for some reason, it returns one entry for cooling and one for heating...
       // And it's only present in the tabular report 'Standard62.1Summary'
+      // Both the Heating and Cooling are actually the same underlying value. Cf https://github.com/NREL/OpenStudio/pull/4450#issue-1011104323
       std::string tableName = "System Ventilation Requirements for Cooling";
 
       // Get the parent AirLoopHVAC

--- a/src/model/SizingSystem.hpp
+++ b/src/model/SizingSystem.hpp
@@ -305,6 +305,7 @@ namespace model {
     boost::optional<double> autosizedCentralHeatingMaximumSystemAirFlowRatio() const;
     boost::optional<double> autosizedCoolingDesignCapacity() const;
     boost::optional<double> autosizedHeatingDesignCapacity() const;
+    boost::optional<double> autosizedOccupantDiversity() const;
 
     void autosize();
 

--- a/src/model/SizingSystem_Impl.hpp
+++ b/src/model/SizingSystem_Impl.hpp
@@ -292,6 +292,8 @@ namespace model {
 
       boost::optional<double> autosizedHeatingDesignCapacity() const;
 
+      boost::optional<double> autosizedOccupantDiversity() const;
+
       void autosize();
 
       void applySizingValues();


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4446 

As indicated on  https://github.com/NREL/OpenStudio/issues/4446#issuecomment-930264664 I got puzzled by the fact that the tabular reports the Occupant Diversity for both heating and cooling.

But both report the same value:

https://github.com/NREL/EnergyPlus/blob/f420c06a69737dddcf4ba740ad855b45a03a8ef3/src/EnergyPlus/SizingManager.cc#L1594-L1595

```
        OutputReportPredefined::PreDefTableEntry(
            state, state.dataOutRptPredefined->pdchS62svrClD, FinalSysSizing(AirLoopNum).AirPriLoopName, state.dataSize->DBySys(AirLoopNum), 4); // D
```


https://github.com/NREL/EnergyPlus/blob/f420c06a69737dddcf4ba740ad855b45a03a8ef3/src/EnergyPlus/SizingManager.cc#L1679-L1680

```
        OutputReportPredefined::PreDefTableEntry(
            state, state.dataOutRptPredefined->pdchS62svrHtD, FinalSysSizing(AirLoopNum).AirPriLoopName, state.dataSize->DBySys(AirLoopNum), 4); // D
```


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
