### PR TITLE
Fix #4472 - Modify Python in typemaps for `path` to accept string with Python 3 support

### DIFF
--- a/ruby/test/Path_Test.rb
+++ b/ruby/test/Path_Test.rb
@@ -51,7 +51,13 @@ class Path_Test < MiniTest::Unit::TestCase
     assert_equal("./here", p.to_s())
   end
 
-  def test_funcOnlyTakesAPath
+  def test_function_accepting_path_takes_a_string
+    w = OpenStudio::Workspace::load('hello.idf')
+    assert w.empty?
+  end
+
+
+  def DISABLED_test_funcOnlyTakesAPath
 
     functions = []
     functions << OpenStudio.method("funcOnlyTakesAPath")
@@ -92,7 +98,7 @@ class Path_Test < MiniTest::Unit::TestCase
     end
   end
 
-  def test_defaultArgFuncTakesAPath
+  def DISABLED_test_defaultArgFuncTakesAPath
 
     functions = []
     functions << OpenStudio.method("defaultArgFuncTakesAPath")

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -308,7 +308,12 @@ namespace openstudio {
         }else{
           SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path const &");
         }
+      } else if(PyUnicode_Check($input)) {
+        // Python 3
+        std::string s(PyUnicode_AsUTF8($input));
+        $1 = openstudio::toPath(s);
       } else if(PyString_Check($input)) {
+        // Python2, PyString_Check does PyBytes_Check
         std::string s(PyString_AsString($input));
         $1 = openstudio::toPath(s);
       } else {
@@ -317,7 +322,7 @@ namespace openstudio {
     }
 
     %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) (path) {
-      bool stringType = PyString_Check($input);
+      bool stringType = PyString_Check($input) || PyUnicode_Check($input);
       bool pathType = false;
       if (!stringType){
         void *vptr = 0;
@@ -347,7 +352,12 @@ namespace openstudio {
         }else{
           SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path const &");
         }
+      } else if(PyUnicode_Check($input)) {
+        // Python 3
+        std::string s(PyUnicode_AsUTF8($input));
+        $1 = new openstudio::path(openstudio::toPath(s));
       } else if(PyString_Check($input)) {
+        // Python2, PyString_Check does PyBytes_Check
         std::string s(PyString_AsString($input));
         $1 = new openstudio::path(openstudio::toPath(s));
       } else {
@@ -356,7 +366,7 @@ namespace openstudio {
     }
 
     %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) (const path&) {
-      bool stringType = PyString_Check($input);
+      bool stringType = PyString_Check($input) || PyUnicode_Check($input);
       bool pathType = false;
       if (!stringType){
         void *vptr = 0;

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -391,55 +391,54 @@ namespace openstudio {
 
 
 // DLM@20100101: demo purposes only, should be able to automatically convert a string input, delete when working
-%{
-  openstudio::path funcOnlyTakesAConstPathRef(const openstudio::path& p)
-  {
-    openstudio::path copy(p);
-    return copy;
-  }
-  openstudio::path funcOnlyTakesAConstPath(const openstudio::path p)
-  {
-    openstudio::path copy(p);
-    return copy;
-  }
-  openstudio::path funcOnlyTakesAPath(openstudio::path p)
-  {
-    openstudio::path copy(p);
-    return copy;
-  }
-
-  openstudio::path defaultArgFuncTakesAConstPathRef(const openstudio::path& p, bool copy = true)
-  {
-    openstudio::path result;
-    if (copy){
-      result = p;
-    }
-    return result;
-  }
-  openstudio::path defaultArgFuncTakesAConstPath(const openstudio::path p, bool copy = true)
-  {
-    openstudio::path result;
-    if (copy){
-      result = p;
-    }
-    return result;
-  }
-  openstudio::path defaultArgFuncTakesAPath(openstudio::path p, bool copy = true)
-  {
-    openstudio::path result;
-    if (copy){
-      result = p;
-    }
-    return result;
-  }
-%}
-openstudio::path funcOnlyTakesAConstPathRef(const openstudio::path& p);
-openstudio::path funcOnlyTakesAConstPath(const openstudio::path p);
-openstudio::path funcOnlyTakesAPath(openstudio::path p);
-
-openstudio::path defaultArgFuncTakesAConstPathRef(const openstudio::path& p, bool copy = true);
-openstudio::path defaultArgFuncTakesAConstPath(const openstudio::path p, bool copy = true);
-openstudio::path defaultArgFuncTakesAPath(openstudio::path p, bool copy = true);
-
+// %{
+//   openstudio::path funcOnlyTakesAConstPathRef(const openstudio::path& p)
+//   {
+//     openstudio::path copy(p);
+//     return copy;
+//   }
+//   openstudio::path funcOnlyTakesAConstPath(const openstudio::path p)
+//   {
+//     openstudio::path copy(p);
+//     return copy;
+//   }
+//   openstudio::path funcOnlyTakesAPath(openstudio::path p)
+//   {
+//     openstudio::path copy(p);
+//     return copy;
+//   }
+//
+//   openstudio::path defaultArgFuncTakesAConstPathRef(const openstudio::path& p, bool copy = true)
+//   {
+//     openstudio::path result;
+//     if (copy){
+//       result = p;
+//     }
+//     return result;
+//   }
+//   openstudio::path defaultArgFuncTakesAConstPath(const openstudio::path p, bool copy = true)
+//   {
+//     openstudio::path result;
+//     if (copy){
+//       result = p;
+//     }
+//     return result;
+//   }
+//   openstudio::path defaultArgFuncTakesAPath(openstudio::path p, bool copy = true)
+//   {
+//     openstudio::path result;
+//     if (copy){
+//       result = p;
+//     }
+//     return result;
+//   }
+// %}
+// openstudio::path funcOnlyTakesAConstPathRef(const openstudio::path& p);
+// openstudio::path funcOnlyTakesAConstPath(const openstudio::path p);
+// openstudio::path funcOnlyTakesAPath(openstudio::path p);
+//
+// openstudio::path defaultArgFuncTakesAConstPathRef(const openstudio::path& p, bool copy = true);
+// openstudio::path defaultArgFuncTakesAConstPath(const openstudio::path p, bool copy = true);
+// openstudio::path defaultArgFuncTakesAPath(openstudio::path p, bool copy = true);
 
 #endif // UTILITIES_CORE_PATH_I


### PR DESCRIPTION
Pull request overview
---------------------

 Fix #4472 - Modify Python in typemaps for `path` to convert from string with Py3 support (type of str changed from Py2 to Py3)


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
