### PR TITLE
Fix #4456 - Improve performance of OpenStudio::UnzipFile::extractAllFiles

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -440,6 +440,7 @@ if(BUILD_BENCHMARK)
 
   set(core_benchmark_src
     core/test/Checksum_Benchmark.cpp
+    core/test/Zip_Benchmark.cpp
   )
   set(${target_name}_benchmark_src
     ${core_benchmark_src}

--- a/src/utilities/core/UnzipFile.cpp
+++ b/src/utilities/core/UnzipFile.cpp
@@ -91,11 +91,12 @@ std::vector<openstudio::path> UnzipFile::extractAllFilesMod(const openstudio::pa
     openstudio::path zippedFileRelPath = openstudio::toPath(fileName);
     openstudio::path createdFilePath = outputPath / zippedFileRelPath;
 
-    if (fileName.back() == '/') {
-      // Entry is a directory, create it
-      openstudio::filesystem::create_directories(createdFilePath);
+    if ((fileName.back() == '/') || (fileName == ".")) {
+      // This is a directory - skip it
     } else {
       // Entry is a file, so extract it.
+      // First we do need to create the parent directory(ies). The order is not necessarilly good so we can't do it in the other branch of if above
+      openstudio::filesystem::create_directories(createdFilePath.parent_path());
 
       // Open the zipped file
       if (unzOpenCurrentFile(m_unzFile) != UNZ_OK) {

--- a/src/utilities/core/UnzipFile.hpp
+++ b/src/utilities/core/UnzipFile.hpp
@@ -56,8 +56,6 @@ class UTILITIES_API UnzipFile
   /// Extracts all files in the archive to the given path, preserving relative paths.
   std::vector<openstudio::path> extractAllFiles(const openstudio::path& outputPath) const;
 
-  std::vector<openstudio::path> extractAllFilesMod(const openstudio::path& outputPath) const;
-
   unsigned long chunksize() const;
   void setChunksize(unsigned long chunksize);
 

--- a/src/utilities/core/UnzipFile.hpp
+++ b/src/utilities/core/UnzipFile.hpp
@@ -56,8 +56,14 @@ class UTILITIES_API UnzipFile
   /// Extracts all files in the archive to the given path, preserving relative paths.
   std::vector<openstudio::path> extractAllFiles(const openstudio::path& outputPath) const;
 
+  std::vector<openstudio::path> extractAllFilesMod(const openstudio::path& outputPath) const;
+
+  unsigned long chunksize() const;
+  void setChunksize(unsigned long chunksize);
+
  private:
   void* m_unzFile;
+  unsigned long m_chunksize;
 };
 
 }  // namespace openstudio

--- a/src/utilities/core/test/Zip_Benchmark.cpp
+++ b/src/utilities/core/test/Zip_Benchmark.cpp
@@ -42,5 +42,5 @@ static void BM_Mod(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Current)->Iterations(5)->Unit(benchmark::kMillisecond)->Arg(32768);  // ->RangeMultiplier(2)->Range(1024, 8 << 13);
-BENCHMARK(BM_Mod)->Iterations(5)->Unit(benchmark::kMillisecond)->Arg(32768);      // RangeMultiplier(2)->Range(1024, 8 << 13);
+BENCHMARK(BM_Current)->Iterations(5)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1024, 8 << 13);
+BENCHMARK(BM_Mod)->Iterations(5)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1024, 8 << 13);

--- a/src/utilities/core/test/Zip_Benchmark.cpp
+++ b/src/utilities/core/test/Zip_Benchmark.cpp
@@ -1,0 +1,46 @@
+#include <benchmark/benchmark.h>
+
+#include "../UnzipFile.hpp"
+#include "../Path.hpp"
+#include "utilities/core/FilesystemHelpers.hpp"
+#include <resources.hxx>
+
+#include <string>
+#include <vector>
+
+openstudio::path prepareOutDir(const std::string& test_case) {
+  openstudio::path outpath = openstudio::tempDir() / openstudio::toPath(test_case);
+  openstudio::filesystem::remove_all(outpath);
+  return outpath;
+}
+
+static void BM_Current(benchmark::State& state) {
+  openstudio::path p = resourcesPath() / openstudio::toPath("utilities/Zip/test1.zip");
+  openstudio::path outpath = prepareOutDir("Current");
+
+  openstudio::UnzipFile uf(p);
+  uf.setChunksize(state.range(0));
+
+  // Code inside this loop is measured repeatedly
+  for (auto _ : state) {
+    uf.extractAllFiles(outpath);
+    openstudio::filesystem::remove_all(outpath);
+  }
+}
+
+static void BM_Mod(benchmark::State& state) {
+  openstudio::path p = resourcesPath() / openstudio::toPath("utilities/Zip/test1.zip");
+  openstudio::path outpath = prepareOutDir("Mod");
+
+  openstudio::UnzipFile uf(p);
+  uf.setChunksize(state.range(0));
+
+  // Code inside this loop is measured repeatedly
+  for (auto _ : state) {
+    uf.extractAllFilesMod(outpath);
+    openstudio::filesystem::remove_all(outpath);
+  }
+}
+
+BENCHMARK(BM_Current)->Iterations(5)->Unit(benchmark::kMillisecond)->Arg(32768);  // ->RangeMultiplier(2)->Range(1024, 8 << 13);
+BENCHMARK(BM_Mod)->Iterations(5)->Unit(benchmark::kMillisecond)->Arg(32768);      // RangeMultiplier(2)->Range(1024, 8 << 13);

--- a/src/utilities/core/test/Zip_Benchmark.cpp
+++ b/src/utilities/core/test/Zip_Benchmark.cpp
@@ -14,7 +14,7 @@ openstudio::path prepareOutDir(const std::string& test_case) {
   return outpath;
 }
 
-static void BM_Current(benchmark::State& state) {
+static void BM_Unzip(benchmark::State& state) {
   openstudio::path p = resourcesPath() / openstudio::toPath("utilities/Zip/test1.zip");
   openstudio::path outpath = prepareOutDir("Current");
 
@@ -28,19 +28,4 @@ static void BM_Current(benchmark::State& state) {
   }
 }
 
-static void BM_Mod(benchmark::State& state) {
-  openstudio::path p = resourcesPath() / openstudio::toPath("utilities/Zip/test1.zip");
-  openstudio::path outpath = prepareOutDir("Mod");
-
-  openstudio::UnzipFile uf(p);
-  uf.setChunksize(state.range(0));
-
-  // Code inside this loop is measured repeatedly
-  for (auto _ : state) {
-    uf.extractAllFilesMod(outpath);
-    openstudio::filesystem::remove_all(outpath);
-  }
-}
-
-BENCHMARK(BM_Current)->Iterations(5)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1024, 8 << 13);
-BENCHMARK(BM_Mod)->Iterations(5)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1024, 8 << 13);
+BENCHMARK(BM_Unzip)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1024, 8 << 13);


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4456
- Improve performance of OpenStudio::UnzipFile::extractAllFiles

Bench results, using a local zip that is about 53MB (every EnergyPlus weatherdata/ file TWICE), between the Current implementation on develop and this Modified one.

```
2021-11-04T16:33:33+01:00
Running Products/Zip_Benchmark
Run on (12 X 4100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 9216 KiB (x1)
Load Average: 1.54, 1.21, 1.27
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
BM_Current/1024/iterations:5        2367 ms         2363 ms            5
BM_Current/2048/iterations:5        2042 ms         2041 ms            5
BM_Current/4096/iterations:5        1908 ms         1907 ms            5
BM_Current/8192/iterations:5        1846 ms         1845 ms            5
BM_Current/16384/iterations:5       1787 ms         1786 ms            5
BM_Current/32768/iterations:5       1804 ms         1802 ms            5
BM_Current/65536/iterations:5       1729 ms         1728 ms            5
BM_Mod/1024/iterations:5            1603 ms         1601 ms            5
BM_Mod/2048/iterations:5            1392 ms         1389 ms            5
BM_Mod/4096/iterations:5            1249 ms         1248 ms            5
BM_Mod/8192/iterations:5            1234 ms         1233 ms            5
BM_Mod/16384/iterations:5           1157 ms         1156 ms            5
BM_Mod/32768/iterations:5           1092 ms         1091 ms            5
BM_Mod/65536/iterations:5           1063 ms         1062 ms            5
```

**Note that it remains considerably slower than using ruby's own `rubyzip` gem which is included in the CLI so please use that instead**

```ruby
require 'zip'
Zip::File.open(path) do |zip_file|
    zip_file.each do |f|
      fpath = File.join(destination, f.name)
      zip_file.extract(f, fpath) unless File.exist?(fpath)
    end
  end
```

rubyzip is much more complicated than our implementation and infers stuff more effectively. If you need to unzip several hundred MB files, then use that!

As can be seen it's marginally faster than the previous version... Not much else we can do. Benchcode used is on #4456. Original benchmarking on #4456 was wrong: I realized only later that I needed to an expensive operation inside a loop to ensure correctness of the output...

![image](https://user-images.githubusercontent.com/5479063/140380119-e2cb14d6-fb17-4e4c-80d7-8a7ce6418be7.png)


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
