### PR TITLE
Addresses #4495, ElectricLoadCenterDistribution FT has incomplete charge/discharge logic

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
@@ -242,36 +242,46 @@ namespace energyplus {
       if ((optD = modelObject.designStorageControlChargePower())) {
         idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, optD.get());
       } else {
-        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                  << " but you didn't specify the required 'Design Storage Control Charge Power'");
-        return boost::none;
+        if (openstudio::istringEqual("FacilityDemandLeveling", storageOperationScheme)
+            || openstudio::istringEqual("TrackChargeDischargeSchedules", storageOperationScheme)) {
+          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                    << " but you didn't specify the required 'Design Storage Control Charge Power'");
+          return boost::none;
+        }
       }
 
       // Design Storage Control Discharge Power
       if ((optD = modelObject.designStorageControlDischargePower())) {
         idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, optD.get());
       } else {
-        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                  << " but you didn't specify the required 'Design Storage Control Discharge Power'");
-        return boost::none;
+        if (openstudio::istringEqual("FacilityDemandLeveling", storageOperationScheme)
+            || openstudio::istringEqual("TrackChargeDischargeSchedules", storageOperationScheme)) {
+          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                    << " but you didn't specify the required 'Design Storage Control Discharge Power'");
+          return boost::none;
+        }
       }
 
       // Storage Charge Power Fraction Schedule Name
       if ((schedule = modelObject.storageChargePowerFractionSchedule())) {
         idfObject.setString(ElectricLoadCenter_DistributionFields::StorageChargePowerFractionScheduleName, schedule->name().get());
       } else {
-        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                  << " but you didn't specify the required 'Storage Charge Power Fraction Schedule Name'");
-        return boost::none;
+        if (openstudio::istringEqual("TrackChargeDischargeSchedules", storageOperationScheme)) {
+          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                    << " but you didn't specify the required 'Storage Charge Power Fraction Schedule Name'");
+          return boost::none;
+        }
       }
 
       // Discharge Power Fraction Schedule Name
       if ((schedule = modelObject.storageDischargePowerFractionSchedule())) {
         idfObject.setString(ElectricLoadCenter_DistributionFields::StorageDischargePowerFractionScheduleName, schedule->name().get());
       } else {
-        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                  << " but you didn't specify the required 'Storage Discharge Power Fraction Schedule Name'");
-        return boost::none;
+        if (openstudio::istringEqual("TrackChargeDischargeSchedules", storageOperationScheme)) {
+          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                    << " but you didn't specify the required 'Storage Discharge Power Fraction Schedule Name'");
+          return boost::none;
+        }
       }
 
       /// Further testing based on storageOperationScheme

--- a/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateElectricLoadCenterDistribution.cpp
@@ -238,6 +238,42 @@ namespace energyplus {
         }
       }
 
+      // Design Storage Control Charge Power
+      if ((optD = modelObject.designStorageControlChargePower())) {
+        idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, optD.get());
+      } else {
+        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                  << " but you didn't specify the required 'Design Storage Control Charge Power'");
+        return boost::none;
+      }
+
+      // Design Storage Control Discharge Power
+      if ((optD = modelObject.designStorageControlDischargePower())) {
+        idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, optD.get());
+      } else {
+        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                  << " but you didn't specify the required 'Design Storage Control Discharge Power'");
+        return boost::none;
+      }
+
+      // Storage Charge Power Fraction Schedule Name
+      if ((schedule = modelObject.storageChargePowerFractionSchedule())) {
+        idfObject.setString(ElectricLoadCenter_DistributionFields::StorageChargePowerFractionScheduleName, schedule->name().get());
+      } else {
+        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                  << " but you didn't specify the required 'Storage Charge Power Fraction Schedule Name'");
+        return boost::none;
+      }
+
+      // Discharge Power Fraction Schedule Name
+      if ((schedule = modelObject.storageDischargePowerFractionSchedule())) {
+        idfObject.setString(ElectricLoadCenter_DistributionFields::StorageDischargePowerFractionScheduleName, schedule->name().get());
+      } else {
+        LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
+                                                  << " but you didn't specify the required 'Storage Discharge Power Fraction Schedule Name'");
+        return boost::none;
+      }
+
       /// Further testing based on storageOperationScheme
       if (openstudio::istringEqual("TrackMeterDemandStoreExcessOnSite", storageOperationScheme)) {
         // Storage Control Track Meter Name, required if operation = TrackMeterDemandStoreExcessOnSite or it'll produce a fatal
@@ -257,65 +293,11 @@ namespace energyplus {
           return boost::none;
         }
 
-        // Design Storage Control Charge Power
-        if ((optD = modelObject.designStorageControlChargePower())) {
-          idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, optD.get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Design Storage Control Charge Power'");
-          return boost::none;
-        }
-
-        // Design Storage Control Discharge Power
-        if ((optD = modelObject.designStorageControlDischargePower())) {
-          idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, optD.get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Design Storage Control Discharge Power'");
-          return boost::none;
-        }
-
-        // Storage Charge Power Fraction Schedule Name
-        if ((schedule = modelObject.storageChargePowerFractionSchedule())) {
-          idfObject.setString(ElectricLoadCenter_DistributionFields::StorageChargePowerFractionScheduleName, schedule->name().get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Storage Charge Power Fraction Schedule Name'");
-          return boost::none;
-        }
-
-        // Discharge Power Fraction Schedule Name
-        if ((schedule = modelObject.storageDischargePowerFractionSchedule())) {
-          idfObject.setString(ElectricLoadCenter_DistributionFields::StorageDischargePowerFractionScheduleName, schedule->name().get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Storage Discharge Power Fraction Schedule Name'");
-          return boost::none;
-        }
-
       } else if (openstudio::istringEqual("FacilityDemandLeveling", storageOperationScheme)) {
         // Storage Converter Object Name - This is actually a mandatory field
         if (!has_storage_conv) {
           LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
                                                     << " but you didn't specify the required 'Storage Converter Object Name'");
-          return boost::none;
-        }
-
-        // Design Storage Control Charge Power
-        if ((optD = modelObject.designStorageControlChargePower())) {
-          idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, optD.get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Design Storage Control Charge Power'");
-          return boost::none;
-        }
-
-        // Design Storage Control Discharge Power
-        if ((optD = modelObject.designStorageControlDischargePower())) {
-          idfObject.setDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, optD.get());
-        } else {
-          LOG(Error, modelObject.briefDescription() << ": You set the Storage Operation Scheme to " << storageOperationScheme
-                                                    << " but you didn't specify the required 'Design Storage Control Discharge Power'");
           return boost::none;
         }
 

--- a/src/energyplus/Test/ElectricLoadCenterDistribution_GTest.cpp
+++ b/src/energyplus/Test/ElectricLoadCenterDistribution_GTest.cpp
@@ -151,21 +151,21 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_NoGen
 
 TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_TrackFacilityElectricDemandStoreExcessOnSite) {
   // Test for #4495: ElectricLoadCenterDistribution FT has incomplete charge/discharge logic
-  
+
   Model model;
 
   ElectricLoadCenterDistribution elcd(model);
   elcd.setStorageOperationScheme("TrackFacilityElectricDemandStoreExcessOnSite");
   elcd.setDesignStorageControlChargePower(10000);
   elcd.setDesignStorageControlDischargePower(15000);
-  
+
   ElectricLoadCenterStorageLiIonNMCBattery elcs(model);
   elcd.setElectricalBussType("AlternatingCurrentWithStorage");
   elcd.setElectricalStorage(elcs);
 
   ForwardTranslator forwardTranslator;
   Workspace workspace = forwardTranslator.translateModel(model);
-  
+
   ASSERT_EQ(1u, workspace.getObjectsByType(IddObjectType::ElectricLoadCenter_Storage_LiIonNMCBattery).size());
 
   WorkspaceObjectVector idf_elcds(workspace.getObjectsByType(IddObjectType::ElectricLoadCenter_Distribution));

--- a/src/energyplus/Test/ElectricLoadCenterDistribution_GTest.cpp
+++ b/src/energyplus/Test/ElectricLoadCenterDistribution_GTest.cpp
@@ -50,6 +50,8 @@
 #include "../../model/GeneratorPVWatts_Impl.hpp"
 #include "../../model/ElectricLoadCenterInverterPVWatts.hpp"
 #include "../../model/ElectricLoadCenterInverterPVWatts_Impl.hpp"
+#include "../../model/ElectricLoadCenterStorageLiIonNMCBattery.hpp"
+#include "../../model/ElectricLoadCenterStorageLiIonNMCBattery_Impl.hpp"
 
 #include "../../model/Version.hpp"
 #include "../../model/Version_Impl.hpp"
@@ -85,7 +87,6 @@ using namespace openstudio::model;
 using namespace openstudio;
 
 TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_NoInverter) {
-
   Model model;
 
   ElectricLoadCenterDistribution elcd(model);
@@ -122,7 +123,6 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_NoInv
 }
 
 TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_NoGenerators) {
-
   Model model;
 
   ElectricLoadCenterDistribution elcd(model);
@@ -147,4 +147,34 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_NoGen
   WorkspaceObject inverter = workspace.getObjectsByType(IddObjectType::ElectricLoadCenter_Inverter_PVWatts)[0];
 
   EXPECT_EQ(inverter.nameString(), distribution.getString(ElectricLoadCenter_DistributionFields::InverterName, false).get());
+}
+
+TEST_F(EnergyPlusFixture, ForwardTranslator_ElectricLoadCenterDistribution_TrackFacilityElectricDemandStoreExcessOnSite) {
+  // Test for #4495: ElectricLoadCenterDistribution FT has incomplete charge/discharge logic
+  
+  Model model;
+
+  ElectricLoadCenterDistribution elcd(model);
+  elcd.setStorageOperationScheme("TrackFacilityElectricDemandStoreExcessOnSite");
+  elcd.setDesignStorageControlChargePower(10000);
+  elcd.setDesignStorageControlDischargePower(15000);
+  
+  ElectricLoadCenterStorageLiIonNMCBattery elcs(model);
+  elcd.setElectricalBussType("AlternatingCurrentWithStorage");
+  elcd.setElectricalStorage(elcs);
+
+  ForwardTranslator forwardTranslator;
+  Workspace workspace = forwardTranslator.translateModel(model);
+  
+  ASSERT_EQ(1u, workspace.getObjectsByType(IddObjectType::ElectricLoadCenter_Storage_LiIonNMCBattery).size());
+
+  WorkspaceObjectVector idf_elcds(workspace.getObjectsByType(IddObjectType::ElectricLoadCenter_Distribution));
+  EXPECT_EQ(1u, idf_elcds.size());
+  WorkspaceObject idf_elcd(idf_elcds[0]);
+
+  ASSERT_TRUE(idf_elcd.getDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, false));
+  ASSERT_TRUE(idf_elcd.getDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, false).get());
+
+  EXPECT_EQ(10000, idf_elcd.getDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlChargePower, false).get());
+  EXPECT_EQ(15000, idf_elcd.getDouble(ElectricLoadCenter_DistributionFields::DesignStorageControlDischargePower, false).get());
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4495
 - Functional test: https://github.com/NREL/OpenStudio-resources/pull/157

For all storage operation schemes, forward translate:
- [x] Design Storage Control Charge Power
- [x] Design Storage Control Discharge Power
- [x] Storage Charge Power Fraction Schedule Name
- [x] Storage Discharge Power Fraction Schedule Name

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
