### PR TITLE
HotFix #4550 - Remove getExteriorFenestrationValue from public API

### DIFF
--- a/src/model/SubSurface.cpp
+++ b/src/model/SubSurface.cpp
@@ -1816,10 +1816,5 @@ namespace model {
     return getImpl<detail::SubSurface_Impl>()->assemblyVisibleTransmittance();
   }
 
-  /** Gets the fenestration value from the sql file **/
-  boost::optional<double> SubSurface::getExteriorFenestrationValue(std::string columnName) const {
-    return getImpl<detail::SubSurface_Impl>()->getExteriorFenestrationValue(columnName);
-  }
-
 }  // namespace model
 }  // namespace openstudio

--- a/src/model/SubSurface.hpp
+++ b/src/model/SubSurface.hpp
@@ -293,9 +293,6 @@ namespace model {
     /** @name Queries */
     //@{
 
-    /** Gets the fenestration value from the sql file **/
-    boost::optional<double> getExteriorFenestrationValue(std::string columnName) const;
-
    protected:
     /// @cond
     typedef detail::SubSurface_Impl ImplType;

--- a/src/utilities/sql/SqlFile.hpp
+++ b/src/utilities/sql/SqlFile.hpp
@@ -121,7 +121,7 @@ class UTILITIES_API SqlFile
   boost::optional<double> assemblySHGC(const std::string& subSurfaceName) const;
 
   // return an Assembly Visible Transmittance value for matching subSurfaceName (RowName)
-  boost::optional<double> assemblyVisibleTransmittance(const std::string& rowName) const;
+  boost::optional<double> assemblyVisibleTransmittance(const std::string& subSurfaceName) const;
 
   /// close the file
   bool close();


### PR DESCRIPTION
HotFix #4550 - Remove getExteriorFenestrationValue from public API

I missed this during the review, only realized when reviewing the OpenStudio-resources test