### PR TITLE
#Fix 4544 - CoilCoolingDX::clone crashes when called with another model

### DIFF
--- a/src/model/CoilCoolingDX.cpp
+++ b/src/model/CoilCoolingDX.cpp
@@ -121,7 +121,7 @@ namespace model {
       std::vector<ModelObject> result;
 
       // This is a ResourceObject, so it shouldn't really be a child except for OS App / IG
-      result.push_back(performanceObject());
+      // result.push_back(performanceObject());
 
       std::vector<AirflowNetworkEquivalentDuct> myAFNItems =
         getObject<ModelObject>().getModelObjectSources<AirflowNetworkEquivalentDuct>(AirflowNetworkEquivalentDuct::iddObjectType());

--- a/src/model/CoilCoolingDXCurveFitOperatingMode.cpp
+++ b/src/model/CoilCoolingDXCurveFitOperatingMode.cpp
@@ -85,8 +85,8 @@ namespace model {
 
     std::vector<ModelObject> CoilCoolingDXCurveFitOperatingMode_Impl::children() const {
       // These are ResourceObjects, so they shouldn't really be children except for OS App / IG
-      std::vector<ModelObject> result = subsetCastVector<ModelObject>(speeds());
-
+      // std::vector<ModelObject> result = subsetCastVector<ModelObject>(speeds());
+      std::vector<ModelObject> result;
       return result;
     }
 

--- a/src/model/CoilCoolingDXCurveFitPerformance.cpp
+++ b/src/model/CoilCoolingDXCurveFitPerformance.cpp
@@ -98,13 +98,13 @@ namespace model {
       std::vector<ModelObject> result;
 
       // These are ResourceObjects, so they shouldn't really be children except for OS App / IG
-      result.push_back(baseOperatingMode());
-      if (auto _mode = alternativeOperatingMode1()) {
-        result.push_back(_mode.get());
-      }
-      if (auto _mode = alternativeOperatingMode2()) {
-        result.push_back(_mode.get());
-      }
+      // result.push_back(baseOperatingMode());
+      // if (auto _mode = alternativeOperatingMode1()) {
+      //   result.push_back(_mode.get());
+      // }
+      // if (auto _mode = alternativeOperatingMode2()) {
+      //   result.push_back(_mode.get());
+      // }
 
       return result;
     }

--- a/src/model/test/CoilCoolingDX_GTest.cpp
+++ b/src/model/test/CoilCoolingDX_GTest.cpp
@@ -263,3 +263,29 @@ TEST_F(ModelFixture, CoilCoolingDX_cloneParent) {
   EXPECT_EQ(dx, unitary.coolingCoil().get());
   EXPECT_NE(dx, unitaryClone.coolingCoil().get());
 }
+
+TEST_F(ModelFixture, CoilCoolingDX_cloneOtherModel) {
+  Model model;
+
+  CoilCoolingDXCurveFitOperatingMode operatingMode(model);
+  CoilCoolingDXCurveFitPerformance performance(model, operatingMode);
+  CoilCoolingDX dx(model, performance);
+
+  EXPECT_EQ(performance, dx.performanceObject());
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDX>().size());
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDXCurveFitPerformance>().size());
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDXCurveFitOperatingMode>().size());
+
+  Model model2;
+  auto dxClone = dx.clone(model2).cast<CoilCoolingDX>();
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDX>().size());
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDXCurveFitPerformance>().size());
+  EXPECT_EQ(1u, model.getConcreteModelObjects<CoilCoolingDXCurveFitOperatingMode>().size());
+
+  EXPECT_EQ(1u, model2.getConcreteModelObjects<CoilCoolingDX>().size());
+  EXPECT_EQ(1u, model2.getConcreteModelObjects<CoilCoolingDXCurveFitPerformance>().size());
+  EXPECT_EQ(1u, model2.getConcreteModelObjects<CoilCoolingDXCurveFitOperatingMode>().size());
+
+  EXPECT_EQ(performance, dx.performanceObject());
+  EXPECT_NE(performance, dxClone.performanceObject());
+}


### PR DESCRIPTION
Pull request overview
---------------------

- #Fix 4544
- CoilCoolingDX::clone crashes when called with another model, because we have an issue where a component has a resourceobject which has a resource object, AND everyone lists them in the children() method.
- I went around in circles trying to make it work and retain it in the children method, but I decided not to, because really they shouldn't be listed

I don't think this qualifies as an "APIChange" because the API didn't change. It'll require downstream users to update their code (OSapp at least)

### Pull Request Author


 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x) Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
