### PR TITLE
Add color for Foundation boundary condition

### DIFF
--- a/src/model/GltfForwardTranslator.cpp
+++ b/src/model/GltfForwardTranslator.cpp
@@ -240,6 +240,7 @@ namespace model {
       {"Boundary_Outdoors_Wind", 9, 159, 162, 1, true},
       {"Boundary_Outdoors_SunWind", 68, 119, 161, 1, true},
       {"Boundary_Ground", 204, 183, 122, 1, true},
+      {"Boundary_Foundation", 117, 30, 122, 1, true},
       {"Boundary_Groundfcfactormethod", 153, 122, 30, 1, true},
       {"Boundary_Groundslabpreprocessoraverage", 255, 191, 0, 1, true},
       {"Boundary_Groundslabpreprocessorcore", 255, 182, 50, 1, true},

--- a/src/utilities/geometry/ThreeJS.cpp
+++ b/src/utilities/geometry/ThreeJS.cpp
@@ -192,6 +192,7 @@ std::vector<ThreeMaterial> makeStandardThreeMaterials() {
   result.push_back(makeThreeMaterial("Boundary_Outdoors_Wind", toThreeColor(9, 159, 162), 1, ThreeSide::DoubleSide));
   result.push_back(makeThreeMaterial("Boundary_Outdoors_SunWind", toThreeColor(68, 119, 161), 1, ThreeSide::DoubleSide));
   result.push_back(makeThreeMaterial("Boundary_Ground", toThreeColor(204, 183, 122), 1, ThreeSide::DoubleSide));
+  result.push_back(makeThreeMaterial("Boundary_Foundation", toThreeColor(117, 30, 122), 1, ThreeSide::DoubleSide));
   result.push_back(makeThreeMaterial("Boundary_Groundfcfactormethod", toThreeColor(153, 122, 30), 1, ThreeSide::DoubleSide));
   result.push_back(makeThreeMaterial("Boundary_Groundslabpreprocessoraverage", toThreeColor(255, 191, 0), 1, ThreeSide::DoubleSide));
   result.push_back(makeThreeMaterial("Boundary_Groundslabpreprocessorcore", toThreeColor(255, 182, 50), 1, ThreeSide::DoubleSide));


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes https://github.com/openstudiocoalition/OpenStudioApplication/issues/290
 - Related to https://github.com/NREL/openstudio-common-measures-gem/pull/97

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

Adds a rendering color for Foundation boundary conditions

### Pull Request Author
 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
