### PR TITLE
Bump OS ruby to use fPIC and zlib/minizip to 1.2.12 to match

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -75,7 +75,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
 
   if(BUILD_RUBY_BINDINGS OR BUILD_CLI)
     # Track NREL/stable in general, on a feature branch this could be temporarily switched to NREL/testing
-    set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/stable#c32f3c58530990684fdd9510bef676a3")
+    set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/testing#dcea3703b5dfaecfa5f0056d952ea5bd")
   endif()
 
   if(BUILD_BENCHMARK)
@@ -91,8 +91,8 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     "boost/1.73.0#4129a76c9b83c300fc103e36d1908792"
     "pugixml/1.10#64b3ebc897bb9d9854c8a2443bf112a8"
     "jsoncpp/1.9.3#073a6d3cb40911d7c8027bddb6ae7dbf"
-    "minizip/1.2.11#0658b664480f2a0755b88502743d5d0d" # This depends on zlib/1.2.11, and basically patches it
-    "zlib/1.2.11#683857dbd5377d65f26795d4023858f9"    # Also needed, so we can find zlib.h and co (+ pinning exactly is good)
+    "minizip/1.2.12#0b5296887a2558500d0323c6c94c8d02" # This depends on zlib/1.2.12, and basically patches it
+    "zlib/1.2.12#3b9e037ae1c615d045a06c67d88491ae" # Also needed, so we can find zlib.h and co (+ pinning exactly is good)
     "fmt/7.0.1#0580b1492b1dddb43b1768e68f25c43c"
     "sqlite3/3.32.3#914492672c458f8be511e3800c14c717"
     "cpprestsdk/2.10.16#d097ff9a8719d9d0ed34293c2ebd90ed"

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -31,7 +31,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
 
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-  conan_check(VERSION 1.43.0 REQUIRED)
+  conan_check(VERSION 1.48.0 REQUIRED)
 
   message(STATUS "openstudio: RUNNING CONAN")
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Bump OS ruby to use fPIC and zlib/minizip to 1.2.12 to match


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
