### PR TITLE
Fix build error due to GLTF refactor on Windows

### DIFF
--- a/src/gltf/GltfUtils.cpp
+++ b/src/gltf/GltfUtils.cpp
@@ -54,7 +54,7 @@ namespace gltf {
     std::vector<uint8_t> splitValueToBytes(T const& value) {
       std::vector<uint8_t> bytes;
       for (size_t i = 0; i < sizeof(value); ++i) {
-        uint8_t byte = value >> (i * 8);
+        uint8_t byte = static_cast<uint8_t>(value >> (i * 8));
         bytes.insert(bytes.begin(), byte);
       }
       return bytes;


### PR DESCRIPTION
Pull request overview
---------------------

`Warning C4267: 'initializing': conversion from 'size_t' to 'uint8_t',… possible loss of data`

https://ci.openstudio.net/blue/organizations/jenkins/openstudio-develop-nightly/detail/openstudio-develop-nightly/1549/pipeline/47#step-97-log-1147

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
