### PR TITLE
Enable centos7 for c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,7 +599,7 @@ if(UNIX)
     endif()
   elseif(LSB_RELEASE_ID_SHORT MATCHES "CentOS")
     # TODO: There aren't any redhat releases anymore, see PR #3145 too
-    set(ENERGYPLUS_EXPECTED_HASH b39f88c94e33b462cd1939df13b241d2)
+    set(ENERGYPLUS_EXPECTED_HASH ebf23ac4f54a6c4f9ac0da561de4196e)
     set(ENERGYPLUS_PLATFORM "Centos7-x86_64")
   else()
     if(LSB_RELEASE_VERSION_SHORT MATCHES "20.04")

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -50,7 +50,6 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
       set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/centos#ae043c41b4bec82e98ca765ce8b32a11")
     endif()
 
-    set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/centos#ae043c41b4bec82e98ca765ce8b32a11")
   else()
     conan_add_remote(NAME nrel INDEX 0 
       URL https://conan.openstudio.net/artifactory/api/conan/openstudio)
@@ -95,11 +94,6 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     set(CONAN_GTEST "gtest/1.11.0#8aca975046f1b60c660ee9d066764d69")
   else()
     set(CONAN_GTEST "")
-  endif()
-
-  if(BUILD_RUBY_BINDINGS OR BUILD_CLI)
-    # Track NREL/stable in general, on a feature branch this could be temporarily switched to NREL/testing
-    set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/stable#ae043c41b4bec82e98ca765ce8b32a11")
   endif()
 
 

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -36,9 +36,30 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
 
   # Add NREL remote and place it first in line, since we vendored dependencies to NREL's repo, they will be picked first
   # TJC 2021-04-27 bintray.com is decommissioned as of 2021-05-01. See commercialbuildings as replacement below.
-  conan_add_remote(
-    NAME nrel INDEX 0 URL
-    https://conan.openstudio.net/artifactory/api/conan/openstudio)
+  if(LSB_RELEASE_ID_SHORT MATCHES "CentOS")
+    # Use this specific remote where I uploaded the centos-build packages
+    # The os is still Linux, the compiler is still GCC. But the GLIBC used is **way older**
+    conan_add_remote(NAME openstudio-centos INDEX 0
+      URL https://conan.openstudio.net/artifactory/api/conan/openstudio-centos)
+ 
+    # Pass `-D_GLIBCXX_USE_CXX11_ABI=0` to make sure it detects libstdc++ and not libstdc++1
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+    # Centos uses a different channel recipe for ruby
+    if(BUILD_RUBY_BINDINGS OR BUILD_CLI)
+      # Track NREL/stable in general, on a feature branch this could be temporarily switched to NREL/testing
+      set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/centos#ae043c41b4bec82e98ca765ce8b32a11")
+    endif()
+
+    set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/centos#ae043c41b4bec82e98ca765ce8b32a11")
+  else()
+    conan_add_remote(NAME nrel INDEX 0 
+      URL https://conan.openstudio.net/artifactory/api/conan/openstudio)
+
+    if(BUILD_RUBY_BINDINGS OR BUILD_CLI)
+      # Track NREL/stable in general, on a feature branch this could be temporarily switched to NREL/testing
+      set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/stable#ae043c41b4bec82e98ca765ce8b32a11")
+     endif()
+  endif()
 
   # conan_add_remote(
   #   NAME bincrafters URL
@@ -81,15 +102,6 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     set(CONAN_RUBY "openstudio_ruby/2.7.2@nrel/stable#ae043c41b4bec82e98ca765ce8b32a11")
   endif()
 
-  if(LSB_RELEASE_ID_SHORT MATCHES "CentOS")
-    # Use this specific remote where I uploaded the centos-build packages
-    # The os is still Linux, the compiler is still GCC. But the GLIBC used is **way older**
-    #conan_add_remote(NAME openstudio-centos INDEX 0
-    #  URL https://conan.openstudio.net/artifactory/api/conan/openstudio-centos)
-
-    # Pass `-D_GLIBCXX_USE_CXX11_ABI=0` to make sure it detects libstdc++ and not libstdc++1
-    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-  endif()
 
   # Build ALL dependencies to avoid problems with the way too old CentOS GLIBC
   # Please read: `developer/conan/binary_incompatility_glibc.md`


### PR DESCRIPTION
Resolves https://github.com/NREL/OpenStudio/issues/4574

- Enabled options in cmake to build centos7 packages from conan remote https://conan.openstudio.net/artifactory/api/conan/openstudio-centos 
- Uploaded openstudio centos7 binaries compiled with gcc10 to openstudio-centos remote so c++20 will work. This is needed due to glibc issue. see reason [here](https://github.com/NREL/OpenStudio/blob/develop/developer/conan/binary_incompatility_glibc.md))
- Updated E+ package sha. 


