### PR TITLE
Fix #4120 - set boost's visibility to global/default instead of hidden

### DIFF
--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -41,7 +41,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     # The os is still Linux, the compiler is still GCC. But the GLIBC used is **way older**
     conan_add_remote(NAME openstudio-centos INDEX 0
       URL https://conan.openstudio.net/artifactory/api/conan/openstudio-centos)
- 
+
     # Pass `-D_GLIBCXX_USE_CXX11_ABI=0` to make sure it detects libstdc++ and not libstdc++1
     add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
     # Centos uses a different channel recipe for ruby
@@ -51,7 +51,7 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
     endif()
 
   else()
-    conan_add_remote(NAME nrel INDEX 0 
+    conan_add_remote(NAME nrel INDEX 0
       URL https://conan.openstudio.net/artifactory/api/conan/openstudio)
 
     if(BUILD_RUBY_BINDINGS OR BUILD_CLI)
@@ -83,6 +83,11 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   endif()
 
   # TODO:  list(APPEND CONAN_OPTIONS "fmt:header_only=True")
+
+  if(APPLE)
+    # #4120 - global is the 'default' visibility in gcc/clang
+    list(APPEND CONAN_OPTIONS "boost:visibility=global")
+  endif()
 
   # You do want to rebuild packages if there's a newer recipe in the remote (which applies mostly to our own openstudio_ruby where we don't
   # bump the actual package version when we make changes) than the binaries were built with

--- a/src/utilities/core/PathHelpers.cpp
+++ b/src/utilities/core/PathHelpers.cpp
@@ -375,7 +375,7 @@ bool copyDirectory(const path& source, const path& destination) {
   for (const auto& file : openstudio::filesystem::recursive_directory_files(source)) {
     try {
       openstudio::filesystem::create_directories((destination / file).parent_path());
-      openstudio::filesystem::copy_file(source / file, destination / file);
+      openstudio::filesystem::copy_file(source / file, destination / file, openstudio::filesystem::copy_option::overwrite_if_exists);
     } catch (const std::exception&) {
       return false;
     }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4120
 - These warnings are super annoying when developping on mac as they mud the waters so much it's hard to look at compiler errors
 - this will force local compilation of conan boost on macs as the ones we have on NREL's artifactory are from conan-center and all have visiblity=hidden
 
### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
