### PR TITLE
Fix #4754 - Cloning an object that uses a TableLookup into another model doesn't bring the ModelObjectList and IndependentVariables

### DIFF
--- a/src/model/TableLookup.cpp
+++ b/src/model/TableLookup.cpp
@@ -91,6 +91,17 @@ namespace model {
       return -9999.0;
     }
 
+    std::vector<ModelObject> TableLookup_Impl::children() const {
+      // #4754 - in the case where we clone an object that uses this TableLookup as a resource into another model,
+      // we need the ModelObjectList to be a child of this object, so that ResourceObject::getRecursiveResourceSubTrees finds it
+      // (and the variables it references in a recursive manner)
+      std::vector<ModelObject> result;
+      if (auto const varList_ = independentVariableList()) {
+        result.push_back(varList_.get());
+      }
+      return result;
+    }
+
     ModelObject TableLookup_Impl::clone(Model model) const {
 
       // Call the ModelObject_Impl instead of ParentObject_Impl because we deal with the ModelObjectList ourselves

--- a/src/model/TableLookup_Impl.hpp
+++ b/src/model/TableLookup_Impl.hpp
@@ -70,6 +70,8 @@ namespace model {
 
       virtual ModelObject clone(Model model) const override;
 
+      virtual std::vector<ModelObject> children() const override;
+
       virtual std::vector<openstudio::IdfObject> remove() override;
 
       //@}


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4754 


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
