### PR TITLE
Fix #4758 - Download component from BCL is broken in 3.5.0

### DIFF
--- a/src/utilities/core/PathHelpers.cpp
+++ b/src/utilities/core/PathHelpers.cpp
@@ -374,12 +374,17 @@ bool copyDirectory(const path& source, const path& destination) {
   // note : we are not using openstudio::filesystem::copy to copy recursively
   // because that copies the entire directory into the destination, not just the
   // contents of the directory
+
+  // Start by creating the destination directory if it doesn't exist
+  openstudio::filesystem::create_directories(destination);
+
   for (const auto& dirEnt : openstudio::filesystem::directory_iterator{source}) {
 
     const auto& srcFolderPath = dirEnt.path();
     const auto& relativeFolderPath = openstudio::filesystem::relative(srcFolderPath, source);
 
     try {
+      // copy with recursive will deal with creating subfolders as needed
       openstudio::filesystem::copy(srcFolderPath, destination / relativeFolderPath,
                                    openstudio::filesystem::copy_options::recursive | openstudio::filesystem::copy_options::overwrite_existing);
     } catch (const std::exception&) {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4758

```bash
rm -Rf ~/BCL/a25386cd-60e4-46bc-8b11-c755f379d916
Products/openstudio -- -e "r = OpenStudio::RemoteBCL.new; m = r.getMeasure('a25386cd-60e4-46bc-8b11-c755f379d916')"
```

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
