### PR TITLE
Fix #4761 - Cleanup temporary directory when doing *Schematron* XMLValidation

### DIFF
--- a/src/utilities/xml/XMLValidator.cpp
+++ b/src/utilities/xml/XMLValidator.cpp
@@ -198,12 +198,12 @@ XMLValidator::XMLValidator(const openstudio::path& schemaPath) : m_schemaPath(op
     logAndStore(Info, "Treating schema as a Schematron, converting to an XSLT StyleSheet.");
     // Let's use a temporary directory for this, so we avoid having two instances trying to write to the same file and we avoid issues where the
     // directory is write protected.
-    const auto tmpDir = openstudio::filesystem::create_temporary_directory("xmlvalidation");
-    if (tmpDir.empty()) {
-      LOG_AND_THROW(fmt::format("Failed to create a temporary directory for extracting the stylesheets need to transform the Schematron '{}'",
+    m_tempDir = openstudio::filesystem::create_temporary_directory("xmlvalidation");
+    if (m_tempDir->empty()) {
+      LOG_AND_THROW(fmt::format("Failed to create a temporary directory for extracting the stylesheets needed to transform the Schematron '{}'",
                                 toString(schemaPath)));
     }
-    m_schemaPath = schematronToXslt(m_schemaPath, tmpDir);
+    m_schemaPath = schematronToXslt(m_schemaPath, m_tempDir.get());
     logAndStore(Info, fmt::format("Transformed Schematron to an XSLT Stylesheet and saved it at {}.", toString(m_schemaPath)));
   } else {
     std::string logMessage = fmt::format("Schema path extension '{}' not supported.", toString(schemaPath.extension()));
@@ -212,16 +212,16 @@ XMLValidator::XMLValidator(const openstudio::path& schemaPath) : m_schemaPath(op
   }
 }
 
-// XMLValidator::~XMLValidator() {
-//   if (m_tempDir.empty()) {
-//     try {
-//       const auto count = openstudio::filesystem::remove_all(m_tempDir);
-//       LOG(Debug, "XMLValidator", "Removed temporary directory with " << count << " files");
-//     } catch (const std::exception& e) {
-//       LOG(Warn, "Error removing temporary directory at '" << toString(m_tempDir) << "', Description: " << e.what());
-//     }
-//   }
-// }
+XMLValidator::~XMLValidator() {
+  if (m_tempDir) {
+    try {
+      const auto count = openstudio::filesystem::remove_all(m_tempDir.get());
+      logAndStore(Debug, fmt::format("Removed temporary directory with {} files", count));
+    } catch (const std::exception& e) {
+      logAndStore(Warn, fmt::format("Error removing temporary directory at {}, Description: {}", toString(m_tempDir.get()), e.what()));
+    }
+  }
+}
 
 openstudio::path XMLValidator::schemaPath() const {
   return m_schemaPath;
@@ -264,9 +264,9 @@ bool XMLValidator::isValid() const {
 
 void XMLValidator::reset() {
 
-  m_logMessages.clear(),
+  m_logMessages.clear();
 
-    m_xmlPath = boost::none;
+  m_xmlPath = boost::none;
 
   m_fullValidationReport.clear();
 }

--- a/src/utilities/xml/XMLValidator.hpp
+++ b/src/utilities/xml/XMLValidator.hpp
@@ -69,6 +69,10 @@ class UTILITIES_API XMLValidator
    * - `*.xslt` => Schematron that is already transformed to an XSLT stylesheet */
   explicit XMLValidator(const openstudio::path& schemaPath);
   ~XMLValidator();
+  XMLValidator(const XMLValidator& other) = default;
+  XMLValidator(XMLValidator&& other) noexcept = default;
+  XMLValidator& operator=(const XMLValidator& other) = default;
+  XMLValidator& operator=(XMLValidator&& other) noexcept = default;
 
   static XMLValidator gbxmlValidator();
 

--- a/src/utilities/xml/XMLValidator.hpp
+++ b/src/utilities/xml/XMLValidator.hpp
@@ -68,6 +68,7 @@ class UTILITIES_API XMLValidator
    * - `*.xml` or `*.sct` => Schematron (convert to XSLT then validate)
    * - `*.xslt` => Schematron that is already transformed to an XSLT stylesheet */
   explicit XMLValidator(const openstudio::path& schemaPath);
+  ~XMLValidator();
 
   static XMLValidator gbxmlValidator();
 
@@ -115,6 +116,8 @@ class UTILITIES_API XMLValidator
 
   openstudio::path m_schemaPath;
   boost::optional<openstudio::path> m_xmlPath;
+
+  boost::optional<openstudio::path> m_tempDir;
 
   XMLValidatorType m_validatorType;
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4761


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
