### PR TITLE
Windows arg parsing

### DIFF
--- a/ruby/engine/openstudio_cli.rb
+++ b/ruby/engine/openstudio_cli.rb
@@ -272,6 +272,15 @@ rescue OptionParser::InvalidOption, OptionParser::MissingArgument
   raise "Error: Invalid CLI option, #{opts.help.chomp}"
 end
 
+# Method to clean the args. Windows cmd.exe treats single quotes as regular chars so we strip them if found.
+def clean_argv(argv)
+  argv.each_index do |i|
+    argv[i] = argv[i].gsub(/^'/, "")
+    argv[i] = argv[i].gsub(/'$/, "")
+  end
+  return argv
+end
+
 # This method will split the argv given into three parts: the flags to this command, the command, and the flags to
 # the command. For example:
 #     -v status -h -v
@@ -287,6 +296,8 @@ end
 # @return [Array] The split command as [main arguments, sub command, sub command arguments]
 #
 def split_main_and_subcommand(argv, command_list)
+
+  argv = clean_argv(argv)
   # Initialize return variables
   main_args   = nil
   sub_command = nil
@@ -298,9 +309,7 @@ def split_main_and_subcommand(argv, command_list)
   # We split the arguments into two: One set containing any flags before a word, and then the rest. The rest are what
   # get actually sent on to the command
   argv.each_index do |i|
-    # Handle args with single quotes due to running commands in Windows cmd.exe.
-    argv[i] = argv[i].gsub(/^'/, "")
-    argv[i] = argv[i].gsub(/'$/, "")
+ 
     if commands.index(argv[i])
       main_args   = argv[0, i]
       sub_command = argv[i]
@@ -738,6 +747,7 @@ class CLI
   # @return [Object] An instance of the CLI class with initialized globals
   #
   def initialize(argv)
+
     $main_args, $sub_command, $sub_args = split_main_and_subcommand(argv, command_list)
 
     if $main_args.include? '--verbose'

--- a/ruby/engine/openstudio_cli.rb
+++ b/ruby/engine/openstudio_cli.rb
@@ -296,8 +296,6 @@ end
 # @return [Array] The split command as [main arguments, sub command, sub command arguments]
 #
 def split_main_and_subcommand(argv, command_list)
-
-  argv = clean_argv(argv)
   # Initialize return variables
   main_args   = nil
   sub_command = nil
@@ -309,7 +307,6 @@ def split_main_and_subcommand(argv, command_list)
   # We split the arguments into two: One set containing any flags before a word, and then the rest. The rest are what
   # get actually sent on to the command
   argv.each_index do |i|
- 
     if commands.index(argv[i])
       main_args   = argv[0, i]
       sub_command = argv[i]
@@ -747,7 +744,7 @@ class CLI
   # @return [Object] An instance of the CLI class with initialized globals
   #
   def initialize(argv)
-
+    argv = clean_argv(argv)
     $main_args, $sub_command, $sub_args = split_main_and_subcommand(argv, command_list)
 
     if $main_args.include? '--verbose'

--- a/ruby/engine/openstudio_cli.rb
+++ b/ruby/engine/openstudio_cli.rb
@@ -298,6 +298,9 @@ def split_main_and_subcommand(argv, command_list)
   # We split the arguments into two: One set containing any flags before a word, and then the rest. The rest are what
   # get actually sent on to the command
   argv.each_index do |i|
+    # Handle args with single quotes due to running commands in Windows cmd.exe.
+    argv[i] = argv[i].gsub(/^'/, "")
+    argv[i] = argv[i].gsub(/'$/, "")
     if commands.index(argv[i])
       main_args   = argv[0, i]
       sub_command = argv[i]


### PR DESCRIPTION
This fixes an issue on Windows where **cmd.exe** treats single quotes in args as string literals. 

For example, running this on cmd.exe fails 

`C:\openstudio-3.5.0-rc1\bin\openstudio.exe run -w 'C:\openstudio-3.5.0-rc1\Examples\compact_osw\compact_ruby_only.osw'`

```
Error executing argv: ["run", "-w", "'C:\\openstudio-3.5.0-rc1\\Examples\\compact_osw\\compact_ruby_only.osw'"]
Error: Invalid argument @ realpath_rec - D:/OSN/build/'C: in eval:510:in `realpath'
eval:510:in `realpath'
:/ruby/2.7.0/gems/openstudio-workflow-2.3.1/lib/openstudio/workflow/run.rb:141:in `realpath'
:/ruby/2.7.0/gems/openstudio-workflow-2.3.1/lib/openstudio/workflow/run.rb:141:in `block in initialize'
:/ruby/2.7.0/gems/openstudio-workflow-2.3.1/lib/openstudio/workflow/registry.rb:67:in `register'
:/ruby/2.7.0/gems/openstudio-workflow-2.3.1/lib/openstudio/workflow/run.rb:141:in `initialize'
:/openstudio_cli.rb:1171:in `new'
:/openstudio_cli.rb:1171:in `execute'
:/openstudio_cli.rb:804:in `execute'
:/openstudio_cli.rb:1973:in `<main>'
eval:188:in `eval'
eval:188:in `require_embedded_absolute'
eval:173:in `block in require_embedded'
eval:167:in `each'
eval:167:in `require_embedded'
eval:126:in `require'
eval:3:in `<main>'
```

Running the same command in powershell runs fine, as like linux based systems,  wrapping characters in single quotation marks holds the literal value of each character _within_ the quotes. 

I'm not sure what changed between 3.4.0 and 3.5.0 to cause this as versions <= 3.4.0 didn't have this issue, but best guess is we updated a windows lib. For what it's worth, other cli tools running on **cmd.exe** run into the same problem. 

Adding a simple method to remove single quote chars if present makes this work as it did previously. This is important as we have some sys calls being invoked that wrap args as single quotes and use **cmd.exe** subprocess commands. e.g. https://github.com/NREL/openstudio-extension-gem/blob/develop/lib/openstudio/extension/runner.rb#L309 





 