### PR TITLE
Fix #4792 - autosized methods

### DIFF
--- a/src/model/AirLoopHVAC.cpp
+++ b/src/model/AirLoopHVAC.cpp
@@ -1975,6 +1975,16 @@ namespace model {
       return getAutosizedValue("Design Supply Air Flow Rate", "m3/s");
     }
 
+    // Not part of the applySizingValues
+    boost::optional<double> AirLoopHVAC_Impl::autosizedSumMinimumHeatingAirFlowRates() const {
+      return getAutosizedValue("Sum of Air Terminal Minimum Heating Flow Rates", "m3/s");
+    }
+
+    // Not part of the applySizingValues
+    boost::optional<double> AirLoopHVAC_Impl::autosizedSumAirTerminalMaxAirFlowRate() const {
+      return getAutosizedValue("Sum of Air Terminal Maximum Flow Rates", "m3/s");
+    }
+
     void AirLoopHVAC_Impl::autosize() {
       autosizeDesignSupplyAirFlowRate();
     }
@@ -2301,6 +2311,14 @@ namespace model {
 
   boost::optional<double> AirLoopHVAC::autosizedDesignSupplyAirFlowRate() const {
     return getImpl<detail::AirLoopHVAC_Impl>()->autosizedDesignSupplyAirFlowRate();
+  }
+
+  boost::optional<double> AirLoopHVAC::autosizedSumMinimumHeatingAirFlowRates() const {
+    return getImpl<detail::AirLoopHVAC_Impl>()->autosizedSumMinimumHeatingAirFlowRates();
+  }
+
+  boost::optional<double> AirLoopHVAC::autosizedSumAirTerminalMaxAirFlowRate() const {
+    return getImpl<detail::AirLoopHVAC_Impl>()->autosizedSumAirTerminalMaxAirFlowRate();
   }
 
   unsigned AirLoopHVAC::availabilityManagerPriority(const AvailabilityManager& availabilityManager) const {

--- a/src/model/AirLoopHVAC.hpp
+++ b/src/model/AirLoopHVAC.hpp
@@ -373,6 +373,12 @@ namespace model {
 
     boost::optional<double> autosizedDesignSupplyAirFlowRate() const;
 
+    // Not part of the applySizingValues
+    boost::optional<double> autosizedSumMinimumHeatingAirFlowRates() const;
+
+    // Not part of the applySizingValues
+    boost::optional<double> autosizedSumAirTerminalMaxAirFlowRate() const;
+
    protected:
     friend class Model;
 

--- a/src/model/AirLoopHVAC_Impl.hpp
+++ b/src/model/AirLoopHVAC_Impl.hpp
@@ -264,6 +264,12 @@ namespace model {
 
       boost::optional<double> autosizedDesignSupplyAirFlowRate() const;
 
+      // Not part of the applySizingValues
+      boost::optional<double> autosizedSumMinimumHeatingAirFlowRates() const;
+
+      // Not part of the applySizingValues
+      boost::optional<double> autosizedSumAirTerminalMaxAirFlowRate() const;
+
       virtual void autosize() override;
 
       virtual void applySizingValues() override;

--- a/src/model/AirTerminalSingleDuctVAVReheat.cpp
+++ b/src/model/AirTerminalSingleDuctVAVReheat.cpp
@@ -656,7 +656,7 @@ namespace model {
     }
 
     boost::optional<double> AirTerminalSingleDuctVAVReheat_Impl::autosizedMaximumFlowFractionDuringReheat() const {
-      return getAutosizedValue("Design Size Maximum Flow Fraction during Reheat", "typo_in_energyplus");
+      return getAutosizedValue("Design Size Maximum Flow Fraction during Reheat", "");
     }
 
     void AirTerminalSingleDuctVAVReheat_Impl::autosize() {

--- a/src/model/CoilCoolingDXVariableSpeed.cpp
+++ b/src/model/CoilCoolingDXVariableSpeed.cpp
@@ -642,15 +642,18 @@ namespace model {
     }
 
     boost::optional<double> CoilCoolingDXVariableSpeed_Impl::autosizedGrossRatedTotalCoolingCapacityAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W", "COIL:COOLING:DX:VARIABLESPEED");
     }
 
     boost::optional<double> CoilCoolingDXVariableSpeed_Impl::autosizedRatedAirFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:COOLING:DX:VARIABLESPEED");
     }
 
     boost::optional<double> CoilCoolingDXVariableSpeed_Impl::autosizedEvaporativeCondenserPumpRatedPowerConsumption() const {
-      return getAutosizedValue("Design Size Evaporative Condenser Pump Rated Power Consumption", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Evaporative Condenser Pump Rated Power Consumption", "W", "AS VS COOLING COIL");
     }
 
     void CoilCoolingDXVariableSpeed_Impl::autosize() {

--- a/src/model/CoilCoolingWater.cpp
+++ b/src/model/CoilCoolingWater.cpp
@@ -502,6 +502,11 @@ namespace model {
       return getAutosizedValue("Design Size Design Outlet Air Humidity Ratio", "kgWater/kgDryAir");
     }
 
+    boost::optional<double> CoilCoolingWater_Impl::autosizedDesignCoilLoad() const {
+      // EPLUS-SQL-INCONSISTENCY (?)
+      return getAutosizedValueFromInitializationSummary("Design Size Design Coil Load", "W");
+    }
+
     void CoilCoolingWater_Impl::autosize() {
       autosizeDesignWaterFlowRate();
       autosizeDesignAirFlowRate();
@@ -755,6 +760,10 @@ namespace model {
 
   boost::optional<double> CoilCoolingWater::autosizedDesignOutletAirHumidityRatio() const {
     return getImpl<detail::CoilCoolingWater_Impl>()->autosizedDesignOutletAirHumidityRatio();
+  }
+
+  boost::optional<double> CoilCoolingWater::autosizedDesignCoilLoad() const {
+    return getImpl<detail::CoilCoolingWater_Impl>()->autosizedDesignCoilLoad();
   }
 
 }  // namespace model

--- a/src/model/CoilCoolingWater.hpp
+++ b/src/model/CoilCoolingWater.hpp
@@ -221,6 +221,9 @@ namespace model {
 
     boost::optional<double> autosizedDesignOutletAirHumidityRatio() const;
 
+    // Not part of the applySizingValues
+    boost::optional<double> autosizedDesignCoilLoad() const;
+
     //@}
    protected:
     friend class Model;

--- a/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
@@ -439,19 +439,23 @@ namespace model {
       return boost::none;
     }
     boost::optional<double> CoilCoolingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedAirFlowRate() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:COOLING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     boost::optional<double> CoilCoolingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedWaterFlowRate() const {
-      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s", "COIL:COOLING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     boost::optional<double> CoilCoolingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedTotalCoolingCapacity() const {
-      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W", "COIL:COOLING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     boost::optional<double> CoilCoolingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedSensibleCoolingCapacity() const {
-      return getAutosizedValue("Design Size Rated Sensible Cooling Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Sensible Cooling Capacity", "W", "COIL:COOLING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     void CoilCoolingWaterToAirHeatPumpEquationFit_Impl::autosize() {

--- a/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -425,16 +425,19 @@ namespace model {
 
     boost::optional<double>
       CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedGrossRatedTotalCoolingCapacityAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Total Cooling Capacity", "W", "COIL:COOLING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     boost::optional<double> CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedRatedAirFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:COOLING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     boost::optional<double>
       CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedRatedWaterFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:COOLING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     void CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosize() {

--- a/src/model/CoilCoolingWater_Impl.hpp
+++ b/src/model/CoilCoolingWater_Impl.hpp
@@ -173,6 +173,9 @@ namespace model {
 
       boost::optional<double> autosizedDesignOutletAirHumidityRatio() const;
 
+      // Not part of the applySizingValues
+      boost::optional<double> autosizedDesignCoilLoad() const;
+
       virtual void autosize() override;
 
       virtual void applySizingValues() override;

--- a/src/model/CoilHeatingDXVariableSpeed.cpp
+++ b/src/model/CoilHeatingDXVariableSpeed.cpp
@@ -539,15 +539,18 @@ namespace model {
     }
 
     boost::optional<double> CoilHeatingDXVariableSpeed_Impl::autosizedRatedHeatingCapacityAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Nominal Heating Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Nominal Heating Capacity", "W", "COIL:HEATING:DX:VARIABLESPEED");
     }
 
     boost::optional<double> CoilHeatingDXVariableSpeed_Impl::autosizedRatedAirFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:HEATING:DX:VARIABLESPEED");
     }
 
     boost::optional<double> CoilHeatingDXVariableSpeed_Impl::autosizedResistiveDefrostHeaterCapacity() const {
-      return getAutosizedValue("Design Size Resistive Defrost Heater Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Resistive Defrost Heater Capacity", "W", "AS VS HEATING COIL");
     }
 
     void CoilHeatingDXVariableSpeed_Impl::autosize() {

--- a/src/model/CoilHeatingElectricMultiStageStageData.cpp
+++ b/src/model/CoilHeatingElectricMultiStageStageData.cpp
@@ -143,12 +143,11 @@ namespace model {
       if (!indexAndNameOpt) {
         return result;
       }
-      auto indexAndName = indexAndNameOpt.get();
-      int index = std::get<0>(indexAndName);
-      CoilHeatingElectricMultiStage parentCoil = std::get<1>(indexAndName);
-      std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
+      auto [index, parentCoil] = indexAndNameOpt.get();
+      const std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
 
-      return parentCoil.getAutosizedValue(sqlField, "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return parentCoil.getImpl<CoilHeatingElectricMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:ElectricMultiStage");
     }
 
     void CoilHeatingElectricMultiStageStageData_Impl::autosize() {

--- a/src/model/CoilHeatingGas.cpp
+++ b/src/model/CoilHeatingGas.cpp
@@ -530,7 +530,7 @@ namespace model {
     }
 
     boost::optional<double> CoilHeatingGas_Impl::autosizedNominalCapacity() const {
-      return getAutosizedValue("Design Size Nominal Capacity", "W");
+      return getAutosizedValue("Design Size Nominal Capacity", "W", "Coil:Heating:Fuel");
     }
 
     void CoilHeatingGas_Impl::autosize() {

--- a/src/model/CoilHeatingGasMultiStageStageData.cpp
+++ b/src/model/CoilHeatingGasMultiStageStageData.cpp
@@ -154,12 +154,11 @@ namespace model {
       if (!indexAndNameOpt) {
         return result;
       }
-      auto indexAndName = indexAndNameOpt.get();
-      int index = std::get<0>(indexAndName);
-      CoilHeatingGasMultiStage parentCoil = std::get<1>(indexAndName);
-      std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
+      auto [index, parentCoil] = indexAndNameOpt.get();
+      const std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
 
-      return parentCoil.getAutosizedValue(sqlField, "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return parentCoil.getImpl<CoilHeatingGasMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:GasMultiStage");
     }
 
     void CoilHeatingGasMultiStageStageData_Impl::autosize() {

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
@@ -348,15 +348,18 @@ namespace model {
     }
 
     boost::optional<double> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedAirFlowRate() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:HEATING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     boost::optional<double> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedWaterFlowRate() const {
-      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s", "COIL:HEATING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     boost::optional<double> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedHeatingCapacity() const {
-      return getAutosizedValue("Design Size Rated Heating Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Heating Capacity", "W", "COIL:HEATING:WATERTOAIRHEATPUMP:EQUATIONFIT");
     }
 
     void CoilHeatingWaterToAirHeatPumpEquationFit_Impl::autosize() {

--- a/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -379,16 +379,19 @@ namespace model {
 
     boost::optional<double>
       CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedRatedHeatingCapacityAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Nominal Heating Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Nominal Heating Capacity", "W", "COIL:HEATING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     boost::optional<double> CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedRatedAirFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Air Flow Rate", "m3/s", "COIL:HEATING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     boost::optional<double>
       CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosizedRatedWaterFlowRateAtSelectedNominalSpeedLevel() const {
-      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Water Flow Rate", "m3/s", "COIL:HEATING:WATERTOAIRHEATPUMP:VARIABLESPEEDEQUATIONFIT");
     }
 
     void CoilHeatingWaterToAirHeatPumpVariableSpeedEquationFit_Impl::autosize() {

--- a/src/model/CoilPerformanceDXCooling_Impl.hpp
+++ b/src/model/CoilPerformanceDXCooling_Impl.hpp
@@ -208,6 +208,8 @@ namespace model {
      private:
       REGISTER_LOGGER("openstudio.model.CoilPerformanceDXCooling");
 
+      boost::optional<double> getAutosizedValueCustom(std::string valueName, std::string units) const;
+
       boost::optional<Curve> optionalTotalCoolingCapacityFunctionofTemperatureCurve() const;
       boost::optional<Curve> optionalTotalCoolingCapacityFunctionofFlowFractionCurve() const;
       boost::optional<Curve> optionalEnergyInputRatioFunctionofTemperatureCurve() const;

--- a/src/model/CoilWaterHeatingAirToWaterHeatPump.cpp
+++ b/src/model/CoilWaterHeatingAirToWaterHeatPump.cpp
@@ -453,11 +453,13 @@ namespace model {
     }
 
     boost::optional<double> CoilWaterHeatingAirToWaterHeatPump_Impl::autosizedRatedEvaporatorAirFlowRate() const {
-      return getAutosizedValue("Design Size Rated Evaporator Air Flow Rate", "m3/s");
+      // This is an OS naming issue really, not an EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Evaporator Air Flow Rate", "m3/s", "Coil:WaterHeating:AirToWaterHeatPump:Pumped");
     }
 
     boost::optional<double> CoilWaterHeatingAirToWaterHeatPump_Impl::autosizedRatedCondenserWaterFlowRate() const {
-      return getAutosizedValue("Design Size Rated Condenser Water Flow Rate", "m3/s");
+      // This is an OS naming issue really, not an EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Rated Condenser Water Flow Rate", "m3/s", "Coil:WaterHeating:AirToWaterHeatPump:Pumped");
     }
 
     void CoilWaterHeatingAirToWaterHeatPump_Impl::autosize() {

--- a/src/model/FanComponentModel.cpp
+++ b/src/model/FanComponentModel.cpp
@@ -143,10 +143,6 @@ namespace model {
       return result;
     }
 
-    boost::optional<double> FanComponentModel_Impl::autosizedMaximumFlowRate() {
-      return getAutosizedValue("Design Size Maximum Flow Rate", "m3/s");
-    }
-
     boost::optional<double> FanComponentModel_Impl::minimumFlowRate() const {
       return getDouble(OS_Fan_ComponentModelFields::MinimumFlowRate, true);
     }
@@ -158,12 +154,6 @@ namespace model {
         result = openstudio::istringEqual(value.get(), "autosize");
       }
       return result;
-    }
-
-    boost::optional<double> FanComponentModel_Impl::autosizedMinimumFlowRate() {
-      // TODO: SQL doesn't contain it really but if it did, that'd be the name
-      // If includes "Design Size Maximum Flow Rate and "Design Fan Airflow" only
-      return getAutosizedValue("Design Size Minimum Flow Rate", "m3/s");
     }
 
     double FanComponentModel_Impl::fanSizingFactor() const {
@@ -215,10 +205,6 @@ namespace model {
       return result;
     }
 
-    boost::optional<double> FanComponentModel_Impl::autosizedMotorFanPulleyRatio() {
-      return getAutosizedValue("Drive Ratio", "typo_in_energyplus");
-    }
-
     boost::optional<double> FanComponentModel_Impl::beltMaximumTorque() const {
       return getDouble(OS_Fan_ComponentModelFields::BeltMaximumTorque, true);
     }
@@ -230,10 +216,6 @@ namespace model {
         result = openstudio::istringEqual(value.get(), "autosize");
       }
       return result;
-    }
-
-    boost::optional<double> FanComponentModel_Impl::autosizedBeltMaximumTorque() {
-      return getAutosizedValue("Design Belt Output Torque", "Nm");
     }
 
     double FanComponentModel_Impl::beltSizingFactor() const {
@@ -267,10 +249,6 @@ namespace model {
       return result;
     }
 
-    boost::optional<double> FanComponentModel_Impl::autosizedMaximumMotorOutputPower() {
-      return getAutosizedValue("Design Motor Output Power", "W");
-    }
-
     double FanComponentModel_Impl::motorSizingFactor() const {
       boost::optional<double> value = getDouble(OS_Fan_ComponentModelFields::MotorSizingFactor, true);
       OS_ASSERT(value);
@@ -300,10 +278,6 @@ namespace model {
         result = openstudio::istringEqual(value.get(), "autosize");
       }
       return result;
-    }
-
-    boost::optional<double> FanComponentModel_Impl::autosizedMaximumVFDOutputPower() {
-      return getAutosizedValue("Design VFD Output Power", "W");
     }
 
     double FanComponentModel_Impl::vFDSizingFactor() const {
@@ -691,6 +665,32 @@ namespace model {
       bool result = setString(OS_Fan_ComponentModelFields::EndUseSubcategory, endUseSubcategory);
       OS_ASSERT(result);
       return result;
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedMaximumFlowRate() {
+      return getAutosizedValue("Design Size Maximum Flow Rate", "m3/s");
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedMinimumFlowRate() {
+      // TODO: SQL doesn't contain it really but if it did, that'd be the name
+      // If includes "Design Size Maximum Flow Rate and "Design Fan Airflow" only
+      return getAutosizedValue("Design Size Minimum Flow Rate", "m3/s");
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedMotorFanPulleyRatio() {
+      return getAutosizedValue("Drive Ratio", "");
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedBeltMaximumTorque() {
+      return getAutosizedValue("Design Belt Output Torque", "Nm");
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedMaximumMotorOutputPower() {
+      return getAutosizedValue("Design Motor Output Power", "W");
+    }
+
+    boost::optional<double> FanComponentModel_Impl::autosizedMaximumVFDOutputPower() {
+      return getAutosizedValue("Design VFD Output Power", "W");
     }
 
     void FanComponentModel_Impl::autosize() {

--- a/src/model/FanComponentModel.cpp
+++ b/src/model/FanComponentModel.cpp
@@ -694,8 +694,8 @@ namespace model {
     }
 
     void FanComponentModel_Impl::autosize() {
-      autosizedMaximumFlowRate();
-      autosizedMinimumFlowRate();
+      autosizeMaximumFlowRate();
+      autosizeMinimumFlowRate();
       autosizeMotorFanPulleyRatio();
       autosizeBeltMaximumTorque();
       autosizeMaximumMotorOutputPower();

--- a/src/model/ModelObject.cpp
+++ b/src/model/ModelObject.cpp
@@ -64,6 +64,7 @@
 #include "../utilities/data/TimeSeries.hpp"
 
 #include <boost/algorithm/string.hpp>
+#include <fmt/core.h>
 
 using openstudio::Handle;
 using openstudio::HandleVector;
@@ -225,14 +226,19 @@ namespace model {
       return keyValue;
     }
 
-    /** Gets the autosized component value from the sql file **/
-    boost::optional<double> ModelObject_Impl::getAutosizedValue(const std::string& valueName, const std::string& unitString) const {
-      boost::optional<double> result;
+    boost::optional<double> ModelObject_Impl::getAutosizedValueFromInitializationSummary(const std::string& valueName,
+                                                                                         const std::string& units) const {
 
       // Get the object name
       if (!name()) {
         LOG(Warn, "This object does not have a name, cannot retrieve the autosized value '" + valueName + "'.");
-        return result;
+        return boost::none;
+      }
+
+      // Check that the model has a sql file
+      if (!model().sqlFile()) {
+        LOG(Warn, "This model has no sql file, cannot retrieve the autosized value '" + valueName + "'.");
+        return boost::none;
       }
 
       // Get the object name and transform to the way it is recorded
@@ -240,77 +246,9 @@ namespace model {
       std::string sqlName = name().get();
       boost::to_upper(sqlName);
 
-      // Get the object type and transform to the way it is recorded
-      // in the sql file
-      std::string sqlObjectType = iddObject().type().valueDescription();
-      boost::replace_all(sqlObjectType, "OS:", "");
-
-      // Special logic to deal with EnergyPlus inconsistencies
-      if (sqlObjectType == "Coil:Heating:Gas") {
-        sqlObjectType = "Coil:Heating:Fuel";
-      }
-
-      if (sqlObjectType == "CoilPerformance:DX:Cooling") {
-        // Get the parent object
-        boost::optional<CoilCoolingDXTwoStageWithHumidityControlMode> parentCoil;
-        auto coilTwoSpdHumCtrls = this->model().getConcreteModelObjects<CoilCoolingDXTwoStageWithHumidityControlMode>();
-        for (const auto& coilInModel : coilTwoSpdHumCtrls) {
-          // Check the coil performance objects in this coil to see if one of them is this object
-          auto coilPerf = coilInModel.normalModeStage1CoilPerformance();
-          if (coilPerf) {
-            if (coilPerf->handle() == this->handle()) {
-              parentCoil = coilInModel;
-              break;
-            }
-          }
-
-          coilPerf = coilInModel.normalModeStage1Plus2CoilPerformance();
-          if (coilPerf) {
-            if (coilPerf->handle() == this->handle()) {
-              parentCoil = coilInModel;
-              break;
-            }
-          }
-
-          coilPerf = coilInModel.dehumidificationMode1Stage1CoilPerformance();
-          if (coilPerf) {
-            if (coilPerf->handle() == this->handle()) {
-              parentCoil = coilInModel;
-              break;
-            }
-          }
-
-          coilPerf = coilInModel.dehumidificationMode1Stage1Plus2CoilPerformance();
-          if (coilPerf) {
-            if (coilPerf->handle() == this->handle()) {
-              parentCoil = coilInModel;
-              break;
-            }
-          }
-        }
-
-        if (!parentCoil) {
-          LOG(Warn, "The CoilPerformance:DX:Cooling object called " + sqlName
-                      + " does not have a parent CoilCoolingDXTwoStageWithHumidityControlMode, cannot retrieve the autosized value.");
-          return result;
-        }
-
-        std::string parSqlName = parentCoil->name().get();
-        boost::to_upper(parSqlName);
-        // Join the parent and child object names, like:
-        // COIL COOLING DX TWO STAGE WITH HUMIDITY CONTROL MODE 1:COIL PERFORMANCE DX COOLING 1
-        sqlName = parSqlName + std::string(":") + sqlName;
-      }
-
-      // Check that the model has a sql file
-      if (!model().sqlFile()) {
-        LOG(Warn, "This model has no sql file, cannot retrieve the autosized value '" + valueName + "'.");
-        return result;
-      }
-
       // Query the InitializationSummary -> Component Sizing table to get
       // the row names that contains information for this component.
-      std::string rowsQuery = R"(
+      const std::string rowsQuery = R"(
       SELECT RowName FROM TabularDataWithStrings
         WHERE ReportName = 'InitializationSummary'
         AND ReportForString = 'Entire Facility'
@@ -324,35 +262,35 @@ namespace model {
       // Warn if the query failed
       if (!rowNames) {
         LOG(Warn, "Could not find a component called '" + sqlName + "' in any rows of the InitializationSummary Component Sizing table.");
-        return result;
+        return boost::none;
       }
 
       // Query each row of the InitializationSummary -> Component Sizing table
       // that contains this component to get the desired value.
-      std::string valueNameAndUnits = valueName + std::string(" [") + unitString + std::string("]");
-      if (unitString.empty()) {
+      std::string valueNameAndUnits = valueName + std::string(" [") + units + std::string("]");
+      if (units.empty()) {
         valueNameAndUnits = valueName;
-      } else if (unitString == "typo_in_energyplus") {
+      } else if (units == "typo_in_energyplus") {
         valueNameAndUnits = valueName + std::string(" []");
       }
 
       for (const std::string& rowName : rowNames.get()) {
-        std::string rowCheckQuery = R"(
+        const std::string rowCheckQuery = R"(
         SELECT Value FROM TabularDataWithStrings
           WHERE ReportName = 'InitializationSummary'
           AND ReportForString = 'Entire Facility'
           AND TableName = 'Component Sizing Information'
           AND RowName = ?
           AND Value = ?;)";
-        boost::optional<std::string> rowValueName = model().sqlFile().get().execAndReturnFirstString(rowCheckQuery,
-                                                                                                     // bindArgs
-                                                                                                     rowName, valueNameAndUnits);
+        const boost::optional<std::string> rowValueName = model().sqlFile().get().execAndReturnFirstString(rowCheckQuery,
+                                                                                                           // bindArgs
+                                                                                                           rowName, valueNameAndUnits);
         // Check if the query succeeded
         if (!rowValueName) {
           continue;
         }
         // This is the right row
-        std::string valQuery = R"(
+        const std::string valQuery = R"(
         SELECT Value FROM TabularDataWithStrings
           WHERE ReportName = 'InitializationSummary'
           AND ReportForString = 'Entire Facility'
@@ -362,18 +300,64 @@ namespace model {
         boost::optional<double> val = model().sqlFile().get().execAndReturnFirstDouble(valQuery,
                                                                                        // bindArgs
                                                                                        rowName);
-        // Check if the query succeeded
+        // Check if the query succeeded and return if so
         if (val) {
-          result = val.get();
-          break;
+          return val;
         }
       }
 
-      if (!result) {
-        LOG(Debug, "The autosized value query for " + valueNameAndUnits + " of " + sqlName + " returned no value.");
+      LOG(Debug, "The autosized value query for " + valueNameAndUnits + " of " + sqlName + " returned no value.");
+      return boost::none;
+    }
+
+    /** Gets the autosized component value from the sql file **/
+    boost::optional<double> ModelObject_Impl::getAutosizedValue(const std::string& valueName, const std::string& units,
+                                                                std::string overrideCompType) const {
+
+      // Get the object name
+      if (!name()) {
+        LOG(Warn, "This object does not have a name, cannot retrieve the autosized value '" + valueName + "'.");
+        return boost::none;
       }
 
-      return result;
+      // Check that the model has a sql file
+      if (!model().sqlFile()) {
+        LOG(Warn, "This model has no sql file, cannot retrieve the autosized value '" + valueName + "'.");
+        return boost::none;
+      }
+
+      // Get the object name and transform to the way it is recorded
+      // in the sql file
+      std::string sqlName = name().get();
+      boost::to_upper(sqlName);
+
+      // Get the object type and transform to the way it is recorded in the sql file
+      if (overrideCompType.empty()) {
+        overrideCompType = iddObject().type().valueDescription();
+        boost::replace_all(overrideCompType, "OS:", "");
+      }
+
+      const std::string directQuery = R"sql(
+      SELECT Value FROM ComponentSizes
+        WHERE CompType = ?
+          AND CompName = ?
+          AND Description = ?
+          AND Units = ?;
+    )sql";
+      boost::optional<double> val = model().sqlFile().get().execAndReturnFirstDouble(directQuery,
+                                                                                     // bindArgs
+                                                                                     overrideCompType, sqlName, valueName, units);
+      if (!val) {
+        LOG(Debug, fmt::format(R"sql(The direct query failed:
+SELECT Value FROM ComponentSizes
+  WHERE CompType = '{}'
+    AND CompName = '{}'
+    AND Description = '{}'
+    AND Units = '{}';)sql",
+                               overrideCompType, sqlName, valueName, units));
+      }
+
+      return val;
     }
 
     //void ModelObject_Impl::connect(unsigned outletPort, ModelObject target, unsigned inletPort)

--- a/src/model/ModelObject.hpp
+++ b/src/model/ModelObject.hpp
@@ -263,7 +263,7 @@ namespace model {
     std::vector<ScheduleTypeKey> getScheduleTypeKeys(const Schedule& schedule) const;
 
     /** Gets the autosized component value from the sql file **/
-    boost::optional<double> getAutosizedValue(const std::string& valueName, const std::string& unitString) const;
+    boost::optional<double> getAutosizedValue(const std::string& valueName, const std::string& units) const;
 
     /** Return the names of the available ems actuators.
     */

--- a/src/model/ModelObject_Impl.hpp
+++ b/src/model/ModelObject_Impl.hpp
@@ -200,7 +200,7 @@ namespace model {
       //@}
 
       /** Gets the autosized component value from the sql file **/
-      boost::optional<double> getAutosizedValue(const std::string& valueName, const std::string& unitString) const;
+      boost::optional<double> getAutosizedValue(const std::string& valueName, const std::string& units, std::string overrideCompType = "") const;
 
      protected:
       ModelObject_Impl(const IdfObject& idfObject, Model_Impl* model, bool keepHandle);
@@ -221,10 +221,14 @@ namespace model {
       bool setBooleanFieldValue(unsigned index, const T& value);
 
       /** Sets index to point to schedule if schedule's ScheduleTypeLimits are compatible with the
-     *  ScheduleType in the ScheduleTypeRegistry for (className,scheduleDisplayName), or if
-     *  schedule's ScheduleTypeLimits have not yet been set (in which case the ScheduleTypeRegistry
-     *  is used to retrieve or create an appropriate one). */
+       *  ScheduleType in the ScheduleTypeRegistry for (className,scheduleDisplayName), or if
+       *  schedule's ScheduleTypeLimits have not yet been set (in which case the ScheduleTypeRegistry
+       *  is used to retrieve or create an appropriate one). */
       bool setSchedule(unsigned index, const std::string& className, const std::string& scheduleDisplayName, Schedule& schedule);
+
+      /** For stuff that's plain missing from ComponentSizes table in E+, so getAutosizedValue can't work.
+        * This method is slower as it executes a lot more queries (an average of 10, versus 1 for getAutosizedValue) */
+      boost::optional<double> getAutosizedValueFromInitializationSummary(const std::string& valueName, const std::string& units) const;
 
      private:
       REGISTER_LOGGER("openstudio.model.ModelObject");

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -2651,14 +2651,16 @@ namespace model {
       std::string sqlName = name().get();
       boost::to_upper(sqlName);
 
-      const std::string directQuery = R"sql(
-      SELECT ? FROM ZoneSizes
-        WHERE ZoneName = ?
-          AND LoadType = ?;
-    )sql";
+      const std::string directQuery = fmt::format(
+        R"sql(
+SELECT {} FROM ZoneSizes
+  WHERE ZoneName = ?
+    AND LoadType = ?;
+      )sql",
+        columnName);
       boost::optional<double> val = model().sqlFile().get().execAndReturnFirstDouble(directQuery,
                                                                                      // bindArgs
-                                                                                     columnName, sqlName, loadType);
+                                                                                     sqlName, loadType);
       if (!val) {
         LOG(Debug, fmt::format(R"sql(The direct query failed:
 SELECT {} FROM ZoneSizes

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -114,28 +114,22 @@
 #include "ScheduleTypeLimits.hpp"
 #include "ScheduleTypeRegistry.hpp"
 
-#include <algorithm>
-#include <utilities/idd/IddFactory.hxx>
-
-#include <utilities/idd/OS_ThermalZone_FieldEnums.hxx>
-#include <utilities/idd/IddEnums.hxx>
-
+#include "../utilities/core/Assert.hpp"
 #include "../utilities/core/ContainersMove.hpp"
-
 #include "../utilities/geometry/Transformation.hpp"
 #include "../utilities/geometry/Geometry.hpp"
 #include "../utilities/geometry/Point3d.hpp"
 #include "../utilities/geometry/Vector3d.hpp"
-
-#include "../utilities/units/Unit.hpp"
-
 #include "../utilities/math/FloatCompare.hpp"
-
-#include "../utilities/core/Assert.hpp"
-
 #include "../utilities/sql/SqlFile.hpp"
 
+#include <utilities/idd/IddFactory.hxx>
+#include <utilities/idd/OS_ThermalZone_FieldEnums.hxx>
+#include <utilities/idd/IddEnums.hxx>
+
 #include <fmt/format.h>
+
+#include <algorithm>
 
 namespace openstudio {
 namespace model {
@@ -2698,7 +2692,7 @@ SELECT {} FROM ZoneSizes
       auto coolingFlow_ = autosizedCoolingDesignAirFlowRate();
       auto heatingFlow_ = autosizedHeatingDesignAirFlowRate();
       if (coolingFlow_ && heatingFlow_) {
-        return coolingFlow_.get() + heatingFlow_.get();
+        return std::max(coolingFlow_.get(), heatingFlow_.get());
       }
       return boost::none;
     }

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -135,6 +135,8 @@
 
 #include "../utilities/sql/SqlFile.hpp"
 
+#include <fmt/format.h>
+
 namespace openstudio {
 namespace model {
 
@@ -2631,6 +2633,79 @@ namespace model {
       return zoneProp;
     }
 
+    boost::optional<double> ThermalZone_Impl::getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const {
+      // Check that the model has a sql file
+      if (!model().sqlFile()) {
+        LOG(Warn,
+            "This model has no sql file, cannot retrieve the ZoneSizes autosized value '" << columnName << "' with loadType '" << loadType << "'.");
+        return boost::none;
+      }
+
+      if ((loadType != "Cooling") && (loadType != "Heating")) {
+        LOG(Warn, "Cannot retrieve the ZoneSizes autosized value '" << columnName << ", Invalid loadType, must be one of ['Cooling', 'Heating']");
+        return boost::none;
+      }
+
+      // Get the object name and transform to the way it is recorded
+      // in the sql file
+      std::string sqlName = name().get();
+      boost::to_upper(sqlName);
+
+      const std::string directQuery = R"sql(
+      SELECT ? FROM ZoneSizes
+        WHERE ZoneName = ?
+          AND LoadType = ?;
+    )sql";
+      boost::optional<double> val = model().sqlFile().get().execAndReturnFirstDouble(directQuery,
+                                                                                     // bindArgs
+                                                                                     columnName, sqlName, loadType);
+      if (!val) {
+        LOG(Debug, fmt::format(R"sql(The direct query failed:
+SELECT {} FROM ZoneSizes
+  WHERE ZoneName = '{}'
+    AND LoadType = '{}';)sql",
+                               columnName, sqlName, loadType));
+      }
+
+      return val;
+    }
+
+    // SQL Queries
+    boost::optional<double> ThermalZone_Impl::autosizedMaximumOutdoorAirFlowRate() const {
+      //TODO: I don't think this is available anywhere actually
+      return boost::none;
+    }
+
+    boost::optional<double> ThermalZone_Impl::autosizedMinimumOutdoorAirFlowRate() const {
+      // The same value is passed for both cooling and heating, so no need to check both
+      return getAutosizedValueFromZoneSizes("CalcOutsideAirFlow", "Cooling");
+    }
+
+    boost::optional<double> ThermalZone_Impl::autosizedCoolingDesignAirFlowRate() const {
+      return getAutosizedValueFromZoneSizes("UserDesFlow", "Cooling");
+    }
+
+    boost::optional<double> ThermalZone_Impl::autosizedHeatingDesignAirFlowRate() const {
+      return getAutosizedValueFromZoneSizes("UserDesFlow", "Heating");
+    }
+
+    boost::optional<double> ThermalZone_Impl::coolingDesignLoad() const {
+      return getAutosizedValueFromZoneSizes("UserDesLoad", "Cooling");
+    }
+
+    boost::optional<double> ThermalZone_Impl::heatingDesignLoad() const {
+      return getAutosizedValueFromZoneSizes("UserDesLoad", "Heating");
+    }
+
+    boost::optional<double> ThermalZone_Impl::designAirFlowRate() const {
+      auto coolingFlow_ = autosizedCoolingDesignAirFlowRate();
+      auto heatingFlow_ = autosizedHeatingDesignAirFlowRate();
+      if (coolingFlow_ && heatingFlow_) {
+        return coolingFlow_.get() + heatingFlow_.get();
+      }
+      return boost::none;
+    }
+
   }  // namespace detail
 
   ThermalZone::ThermalZone(const Model& model) : HVACComponent(ThermalZone::iddObjectType(), model) {
@@ -3257,6 +3332,39 @@ namespace model {
   std::ostream& operator<<(std::ostream& out, const openstudio::model::TransitionZone& transitionZone) {
     out << "thermal zone name=" << transitionZone.thermalZone().name().get() << ", length=" << transitionZone.length();
     return out;
+  }
+
+  // SQL Queries
+  boost::optional<double> ThermalZone::getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const {
+    return getImpl<detail::ThermalZone_Impl>()->getAutosizedValueFromZoneSizes(columnName, loadType);
+  }
+
+  boost::optional<double> ThermalZone::autosizedMaximumOutdoorAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedMaximumOutdoorAirFlowRate();
+  }
+
+  boost::optional<double> ThermalZone::autosizedMinimumOutdoorAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedMinimumOutdoorAirFlowRate();
+  }
+
+  boost::optional<double> ThermalZone::autosizedCoolingDesignAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedCoolingDesignAirFlowRate();
+  }
+
+  boost::optional<double> ThermalZone::autosizedHeatingDesignAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedHeatingDesignAirFlowRate();
+  }
+
+  boost::optional<double> ThermalZone::coolingDesignLoad() const {
+    return getImpl<detail::ThermalZone_Impl>()->coolingDesignLoad();
+  }
+
+  boost::optional<double> ThermalZone::designAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->designAirFlowRate();
+  }
+
+  boost::optional<double> ThermalZone::heatingDesignLoad() const {
+    return getImpl<detail::ThermalZone_Impl>()->heatingDesignLoad();
   }
 
 }  // namespace model

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -2673,11 +2673,6 @@ SELECT {} FROM ZoneSizes
     }
 
     // SQL Queries
-    boost::optional<double> ThermalZone_Impl::autosizedMaximumOutdoorAirFlowRate() const {
-      //TODO: I don't think this is available anywhere actually
-      return boost::none;
-    }
-
     boost::optional<double> ThermalZone_Impl::autosizedMinimumOutdoorAirFlowRate() const {
       // The same value is passed for both cooling and heating, so no need to check both
       return getAutosizedValueFromZoneSizes("CalcOutsideAirFlow", "Cooling");
@@ -3339,10 +3334,6 @@ SELECT {} FROM ZoneSizes
   // SQL Queries
   boost::optional<double> ThermalZone::getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const {
     return getImpl<detail::ThermalZone_Impl>()->getAutosizedValueFromZoneSizes(columnName, loadType);
-  }
-
-  boost::optional<double> ThermalZone::autosizedMaximumOutdoorAirFlowRate() const {
-    return getImpl<detail::ThermalZone_Impl>()->autosizedMaximumOutdoorAirFlowRate();
   }
 
   boost::optional<double> ThermalZone::autosizedMinimumOutdoorAirFlowRate() const {

--- a/src/model/ThermalZone.cpp
+++ b/src/model/ThermalZone.cpp
@@ -2686,15 +2686,15 @@ SELECT {} FROM ZoneSizes
       return getAutosizedValueFromZoneSizes("UserDesFlow", "Heating");
     }
 
-    boost::optional<double> ThermalZone_Impl::coolingDesignLoad() const {
+    boost::optional<double> ThermalZone_Impl::autosizedCoolingDesignLoad() const {
       return getAutosizedValueFromZoneSizes("UserDesLoad", "Cooling");
     }
 
-    boost::optional<double> ThermalZone_Impl::heatingDesignLoad() const {
+    boost::optional<double> ThermalZone_Impl::autosizedHeatingDesignLoad() const {
       return getAutosizedValueFromZoneSizes("UserDesLoad", "Heating");
     }
 
-    boost::optional<double> ThermalZone_Impl::designAirFlowRate() const {
+    boost::optional<double> ThermalZone_Impl::autosizedDesignAirFlowRate() const {
       auto coolingFlow_ = autosizedCoolingDesignAirFlowRate();
       auto heatingFlow_ = autosizedHeatingDesignAirFlowRate();
       if (coolingFlow_ && heatingFlow_) {
@@ -3348,16 +3348,16 @@ SELECT {} FROM ZoneSizes
     return getImpl<detail::ThermalZone_Impl>()->autosizedHeatingDesignAirFlowRate();
   }
 
-  boost::optional<double> ThermalZone::coolingDesignLoad() const {
-    return getImpl<detail::ThermalZone_Impl>()->coolingDesignLoad();
+  boost::optional<double> ThermalZone::autosizedCoolingDesignLoad() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedCoolingDesignLoad();
   }
 
-  boost::optional<double> ThermalZone::designAirFlowRate() const {
-    return getImpl<detail::ThermalZone_Impl>()->designAirFlowRate();
+  boost::optional<double> ThermalZone::autosizedDesignAirFlowRate() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedDesignAirFlowRate();
   }
 
-  boost::optional<double> ThermalZone::heatingDesignLoad() const {
-    return getImpl<detail::ThermalZone_Impl>()->heatingDesignLoad();
+  boost::optional<double> ThermalZone::autosizedHeatingDesignLoad() const {
+    return getImpl<detail::ThermalZone_Impl>()->autosizedHeatingDesignLoad();
   }
 
 }  // namespace model

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -549,7 +549,6 @@ namespace model {
     // SQL Queries
     boost::optional<double> getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const;
 
-    boost::optional<double> autosizedMaximumOutdoorAirFlowRate() const;
     boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
     boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
     boost::optional<double> autosizedHeatingDesignAirFlowRate() const;

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -553,6 +553,7 @@ namespace model {
     boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
     boost::optional<double> autosizedHeatingDesignAirFlowRate() const;
     boost::optional<double> autosizedCoolingDesignLoad() const;
+    // The max of autosizedCoolingDesignAirFlowRate and autosizedHeatingDesignAirFlowRate if both are found
     boost::optional<double> autosizedDesignAirFlowRate() const;
     boost::optional<double> autosizedHeatingDesignLoad() const;
 

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -546,6 +546,17 @@ namespace model {
 
     std::vector<AirLoopHVAC> airLoopHVACs() const;
 
+    // SQL Queries
+    boost::optional<double> getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const;
+
+    boost::optional<double> autosizedMaximumOutdoorAirFlowRate() const;
+    boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
+    boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
+    boost::optional<double> autosizedHeatingDesignAirFlowRate() const;
+    boost::optional<double> coolingDesignLoad() const;
+    boost::optional<double> designAirFlowRate() const;
+    boost::optional<double> heatingDesignLoad() const;
+
     //@}
    protected:
     /// @cond

--- a/src/model/ThermalZone.hpp
+++ b/src/model/ThermalZone.hpp
@@ -552,9 +552,9 @@ namespace model {
     boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
     boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
     boost::optional<double> autosizedHeatingDesignAirFlowRate() const;
-    boost::optional<double> coolingDesignLoad() const;
-    boost::optional<double> designAirFlowRate() const;
-    boost::optional<double> heatingDesignLoad() const;
+    boost::optional<double> autosizedCoolingDesignLoad() const;
+    boost::optional<double> autosizedDesignAirFlowRate() const;
+    boost::optional<double> autosizedHeatingDesignLoad() const;
 
     //@}
    protected:

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -451,9 +451,9 @@ namespace model {
       boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
       boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
       boost::optional<double> autosizedHeatingDesignAirFlowRate() const;
-      boost::optional<double> coolingDesignLoad() const;
-      boost::optional<double> designAirFlowRate() const;
-      boost::optional<double> heatingDesignLoad() const;
+      boost::optional<double> autosizedCoolingDesignLoad() const;
+      boost::optional<double> autosizedDesignAirFlowRate() const;
+      boost::optional<double> autosizedHeatingDesignLoad() const;
 
      protected:
      private:

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -448,7 +448,6 @@ namespace model {
       // SQL Queries
       boost::optional<double> getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const;
 
-      boost::optional<double> autosizedMaximumOutdoorAirFlowRate() const;
       boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
       boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
       boost::optional<double> autosizedHeatingDesignAirFlowRate() const;

--- a/src/model/ThermalZone_Impl.hpp
+++ b/src/model/ThermalZone_Impl.hpp
@@ -445,6 +445,17 @@ namespace model {
 
       std::vector<AirLoopHVAC> airLoopHVACs() const;
 
+      // SQL Queries
+      boost::optional<double> getAutosizedValueFromZoneSizes(const std::string& columnName, const std::string& loadType) const;
+
+      boost::optional<double> autosizedMaximumOutdoorAirFlowRate() const;
+      boost::optional<double> autosizedMinimumOutdoorAirFlowRate() const;
+      boost::optional<double> autosizedCoolingDesignAirFlowRate() const;
+      boost::optional<double> autosizedHeatingDesignAirFlowRate() const;
+      boost::optional<double> coolingDesignLoad() const;
+      boost::optional<double> designAirFlowRate() const;
+      boost::optional<double> heatingDesignLoad() const;
+
      protected:
      private:
       REGISTER_LOGGER("openstudio.model.ThermalZone");

--- a/src/model/ZoneHVACBaseboardConvectiveElectric.cpp
+++ b/src/model/ZoneHVACBaseboardConvectiveElectric.cpp
@@ -211,7 +211,8 @@ namespace model {
     }
 
     boost::optional<double> ZoneHVACBaseboardConvectiveElectric_Impl::autosizedNominalCapacity() const {
-      return getAutosizedValue("Design Size Heating Design Capacity", "W");
+      // EPLUS-SQL-INCONSISTENCY
+      return getAutosizedValue("Design Size Heating Design Capacity", "W", "ZONEHVAC:BASEBOARD:CONVECTIVE:ELECTRIC");
     }
 
     void ZoneHVACBaseboardConvectiveElectric_Impl::autosize() {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4792
- Companion PR: https://github.com/NREL/OpenStudio-resources/pull/189
- At 00d74a51e6cd548d26fad3e4f81480448fe3a876, this is just refactoring to use ComponentSizes instead

### Pull Request Author

 - [x] Model API Changes / Additions
 - [x] Model API methods are tested: https://github.com/NREL/OpenStudio-resources/pull/189
 - [x] All new and existing tests passes


**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
