### PR TITLE
Fix #4815 - Adjust `ForwardTranslatorOptions::string()` for backward compat with openstudio-workflow-gem

### DIFF
--- a/src/utilities/filetypes/ForwardTranslatorOptions.cpp
+++ b/src/utilities/filetypes/ForwardTranslatorOptions.cpp
@@ -253,11 +253,15 @@ namespace detail {
 
   std::string ForwardTranslatorOptions_Impl::string() const {
 
+    const Json::Value data = this->json();
+    if (data.isNull()) {
+      return "";
+    }
     // Write to string
     Json::StreamWriterBuilder wbuilder;
     // mimic the old StyledWriter behavior:
     wbuilder["indentation"] = "   ";
-    std::string result = Json::writeString(wbuilder, json());
+    std::string result = Json::writeString(wbuilder, data);
 
     return result;
   }

--- a/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
+++ b/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
@@ -1170,3 +1170,9 @@ TEST(Filetypes, RunOptions_ForwardTranslate_BackwardCompatibility) {
   EXPECT_EQ("my_ruby_file.rb", workflow2->runOptions()->customOutputAdapter()->customFileName());
   EXPECT_EQ("MyOutputAdapter", workflow2->runOptions()->customOutputAdapter()->className());
 }
+
+TEST(Filetypes, RunOptions_NoFtOptions) {
+  // Test for #4815
+  const RunOptions options;
+  EXPECT_EQ("", options.forwardTranslateOptions());
+}


### PR DESCRIPTION
Pull request overview
---------------------

- Fix #4815
-  `ForwardTranslatorOptions::string()` was returning `"null"`, set to empty

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
