### PR TITLE
Fix #4834 - CLI chops inner single quote inside argument since 3.5.1

### DIFF
--- a/ruby/engine/openstudio_cli.rb
+++ b/ruby/engine/openstudio_cli.rb
@@ -275,8 +275,11 @@ end
 # Method to clean the args. Windows cmd.exe treats single quotes as regular chars so we strip them if found.
 def clean_argv(argv)
   argv.each_index do |i|
-    argv[i] = argv[i].gsub(/^'/, "")
-    argv[i] = argv[i].gsub(/'$/, "")
+    # puts "Argument #{i}=<#{argv[i]}>"
+    if argv[i].start_with?("'") and argv[i].end_with?("'")
+      argv[i] = argv[i][1..-2]
+      # puts " Cleaned #{i}=<#{argv[i]}>"
+    end
   end
   return argv
 end
@@ -639,7 +642,7 @@ def parse_main_args(main_args)
           $logger.info "Bundling without group '#{g}'"
         else
           keep_groups << g
-      end
+        end
       end
 
       $logger.info "Bundling with groups [#{keep_groups.join(',')}]"
@@ -1708,8 +1711,6 @@ class ExecuteRubyScript
     $logger.info "ExecuteRubyScript, sub_argv = #{sub_argv}"
 
     require 'pathname'
-
-    options = {}
 
     opts = OptionParser.new do |o|
       o.banner = 'Usage: openstudio execute_ruby_script file [arguments]'

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -186,11 +186,31 @@ if(BUILD_TESTING)
     PASS_REGULAR_EXPRESSION "Hello from -x, at National Renewable Energy Laboratory"
   )
 
+  add_test(NAME OpenStudioCLI.Run_RubyOnly
+    COMMAND $<TARGET_FILE:openstudio> run -w compact_ruby_only.osw
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/"
+  )
+  set_tests_properties(OpenStudioCLI.Run_RubyOnly PROPERTIES RESOURCE_LOCK "compact_osw")
+
   add_test(NAME OpenStudioCLI.Labs.Run_RubyOnly
     COMMAND $<TARGET_FILE:openstudio> labs run -w compact_ruby_only.osw
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/"
   )
   set_tests_properties(OpenStudioCLI.Labs.Run_RubyOnly PROPERTIES RESOURCE_LOCK "compact_osw")
+
+
+  add_test(NAME OpenStudioCLI.Run_RubyOnly.absolute_path
+    COMMAND $<TARGET_FILE:openstudio> run -w "'${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/compact_ruby_only.osw'"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/"
+  )
+  set_tests_properties(OpenStudioCLI.Run_RubyOnly.absolute_path PROPERTIES RESOURCE_LOCK "compact_osw")
+
+  add_test(NAME OpenStudioCLI.Labs.Run_RubyOnly.absolute_path
+    COMMAND $<TARGET_FILE:openstudio> labs run -w "'${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/compact_ruby_only.osw'"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/"
+  )
+  set_tests_properties(OpenStudioCLI.Labs.Run_RubyOnly.absolute_path PROPERTIES RESOURCE_LOCK "compact_osw")
+
 
   add_test(NAME OpenStudioCLI.Labs.Run_PythonOnly
     COMMAND $<TARGET_FILE:openstudio> labs run -w compact_python_only.osw

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -114,6 +114,14 @@ if(BUILD_TESTING)
     COMMAND $<TARGET_FILE:openstudio> labs -e "puts(OpenStudio::Model::Model.new())"
   )
 
+  add_test(NAME OpenStudioCLI.ruby_execute_line_no_chop_single_quote
+    COMMAND $<TARGET_FILE:openstudio> -e "puts 'hello world'"
+  )
+
+  add_test(NAME OpenStudioCLI.Labs.ruby_execute_line_no_chop_single_quote
+    COMMAND $<TARGET_FILE:openstudio> labs -e "puts 'hello world'"
+  )
+
   add_test(NAME OpenStudioCLI.Labs.ruby_execute_line.embedded_gem
     COMMAND $<TARGET_FILE:openstudio> labs -e "require 'minitest'"
   )

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -37,7 +37,16 @@ int main(int argc, char* argv[]) {
   int result = 0;
 
   std::vector<std::string> args(argv, std::next(argv, static_cast<std::ptrdiff_t>(argc)));
-  std::for_each(args.begin(), args.end(), [](auto& s) { openstudio::ascii_trim(s); });
+  // fmt::print("Original arguments: {}\n", args);
+  std::for_each(args.begin(), args.end(), [](auto& s) {
+    openstudio::ascii_trim(s);
+    // Windows cmd.exe treats single quotes as regular chars so we strip them if found (cf #4779 and #4834)
+    if (s.starts_with('\'') && s.ends_with('\'')) {
+      s.erase(std::prev(s.end()));
+      s.erase(s.begin());
+    }
+  });
+  // fmt::print("Cleaned arguments: {}\n", args);
   // erase the first element, which is the name of the program
   const std::string programName = std::move(args.front());
   args.erase(args.begin());


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4834

### Pull Request Author

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
