### PR TITLE
[developer issue] Fix VersionTranslator use after move (in develop only)

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslatePlantLoop.cpp
@@ -152,7 +152,7 @@ namespace energyplus {
 
   IdfObject ForwardTranslator::populateBranch(IdfObject& branchIdfObject, std::vector<ModelObject>& modelObjects, Loop& loop, bool isSupplyBranch) {
     if (!modelObjects.empty()) {
-      int i = 0;
+      [[maybe_unused]] int i = 0;
 
       boost::optional<Node> prevNode_;
 

--- a/src/gltf/GltfUserData.cpp
+++ b/src/gltf/GltfUserData.cpp
@@ -195,15 +195,12 @@ namespace gltf {
         m_thermalZoneName = thermalZone->nameString();
         m_thermalZoneMaterialName = "ThermalZone_" + thermalZone->nameString();
         std::vector<model::AirLoopHVAC> airLoopHVACs = thermalZone->airLoopHVACs();
-        int count = 0;
         for (const auto& airLoopHVAC : thermalZone->airLoopHVACs()) {
           m_airLoopHVACHandles.emplace_back(openstudio::removeBraces(airLoopHVAC.handle()));
 
           m_airLoopHVACNames.emplace_back(airLoopHVAC.nameString());
 
           m_airLoopHVACMaterialNames.emplace_back(getObjectGLTFMaterialName(airLoopHVAC));
-
-          count++;
         }
       }
 

--- a/src/model/PlantEquipmentOperationRangeBasedScheme.cpp
+++ b/src/model/PlantEquipmentOperationRangeBasedScheme.cpp
@@ -264,7 +264,7 @@ namespace model {
         return false;
       }
 
-      unsigned i = 0;
+      [[maybe_unused]] unsigned i = 0;
       for (auto& eg : extensibleGroups()) {
         const auto& t_upperLimit = eg.getDouble(LOADRANGEFIELDS_UPPERLIMIT);
         OS_ASSERT(t_upperLimit);

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -3629,9 +3629,6 @@ namespace osversion {
           }
         }
 
-        ss << newObject;
-        m_refactored.emplace_back(std::move(object), std::move(newObject));
-
         iddObject = idd_2_4_2.getObject("OS:AdditionalProperties");
         IdfObject additionalProperties(iddObject.get());
         additionalProperties.setString(0, toString(createUUID()));
@@ -3644,6 +3641,8 @@ namespace osversion {
           }
         }
 
+        ss << newObject;
+        m_refactored.emplace_back(std::move(object), std::move(newObject));
         m_new.push_back(additionalProperties);
         ss << additionalProperties;
 
@@ -5022,7 +5021,6 @@ namespace osversion {
         newObject.setDouble(15, -25.0);
 
         ss << newObject;
-        m_refactored.emplace_back(std::move(object), std::move(newObject));
         m_refactored.emplace_back(std::move(object), std::move(newObject));
 
       } else if (iddname == "OS:Coil:Cooling:DX:MultiSpeed") {

--- a/src/utilities/idf/IdfFile.cpp
+++ b/src/utilities/idf/IdfFile.cpp
@@ -523,12 +523,12 @@ bool IdfFile::save(const openstudio::path& p, bool overwrite) {
 
 bool IdfFile::m_load(std::istream& is, ProgressBar* progressBar, bool versionOnly) {
 
-  int lineNum = 0;         // Idf line number
-  int objectNum = 0;       // number of objects, first is #1
-  std::string line;        // temp string to help with reading
-  boost::smatch matches;   // matches to regular expressions
-  std::string comment;     // keep running comment
-  bool firstBlock = true;  // to capture first comment block as the header
+  [[maybe_unused]] int lineNum = 0;  // Idf line number
+  int objectNum = 0;                 // number of objects, first is #1
+  std::string line;                  // temp string to help with reading
+  boost::smatch matches;             // matches to regular expressions
+  std::string comment;               // keep running comment
+  bool firstBlock = true;            // to capture first comment block as the header
 
   if (progressBar) {
     is.seekg(0, std::ios_base::end);

--- a/src/utilities/idf/ImfFile.cpp
+++ b/src/utilities/idf/ImfFile.cpp
@@ -176,10 +176,10 @@ bool ImfFile::save(const openstudio::path& p, bool overwrite) {
 bool ImfFile::m_load(std::istream& is) {
 
   // keep track of line number in the Idf
-  int lineNum = 0;
+  [[maybe_unused]] int lineNum = 0;
 
   // number of object in the Idf, 1 is first object
-  int objectNum = 0;
+  [[maybe_unused]] int objectNum = 0;
 
   // temp string to read file
   std::string line;
@@ -191,7 +191,7 @@ bool ImfFile::m_load(std::istream& is) {
   std::string comment;
 
   // keep track of the current section
-  std::string section = "";
+  std::string section;
 
   // get CommentOnly IddObject
   OptionalIddObject commentOnlyIddObject;

--- a/src/utilities/idf/Workspace.cpp
+++ b/src/utilities/idf/Workspace.cpp
@@ -964,7 +964,7 @@ namespace detail {
     // blank Workspace---directly create and add objects
     OS_ASSERT(newObjects.empty());
     OS_ASSERT(oldNewHandleMap.empty());
-    unsigned i(0);
+    [[maybe_unused]] unsigned i = 0;
     for (const WorkspaceObject& object : objects) {
       newObjects.push_back(this->createObject(object.getImpl<WorkspaceObject_Impl>(), false));
       oldNewHandleMap.insert(HandleMap::value_type(object.handle(), newObjects.back()->handle()));


### PR DESCRIPTION
Pull request overview
---------------------

- Hotfix #4532 
- There are no released versions that included the defect
- The OS resources test_ems_osm works with this fix.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
