### PR TITLE
Fix #4853 - RemoteBCLTest2

### DIFF
--- a/src/utilities/bcl/test/BCL_GTest.cpp
+++ b/src/utilities/bcl/test/BCL_GTest.cpp
@@ -206,8 +206,9 @@ TEST_F(BCLFixture, RemoteBCLTest2) {
 
   RemoteBCL remoteBCL;
 
-  // get all constructions, via empty first arg and tid
-  std::vector<BCLSearchResult> responses = remoteBCL.searchComponentLibrary("", 127);
+  // get all constructions, via non-empty first arg and tid. As of 2023-04-05, some new constructions such as
+  // 'Generic-Casement-Fiberglass-DoubleLowE-Air-AlumSpacer-1' are missing the "OpenStudio Type" because these are IDF constructions
+  std::vector<BCLSearchResult> responses = remoteBCL.searchComponentLibrary("Dbl", 127);
   ASSERT_GT(responses.size(), 0u);
 
   bool success = remoteBCL.downloadComponent(responses[0].uid());
@@ -269,7 +270,7 @@ TEST_F(BCLFixture, RemoteBCLTest2) {
       break;
     }
   }
-  ASSERT_FALSE(openstudioType.empty());
+  ASSERT_FALSE(openstudioType.empty()) << "Failed for Component.name='" << component->name() << "', uid='" << component->uid() << "' ";
 
   // load the component
   std::vector<std::string> oscFiles = component->files("osc");


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4853

https://github.com/LBNL-ETA/LBNL-BCL-Windows/tree/main/lib/components recently added components such as `Generic-Casement-Fiberglass-DoubleLowE-Air-AlumSpacer-1` which do not have an "OpenStudio Type" attribute (probably because these are purely IDFs, not an OSC), and they get picked up first in line now as of a March 30 I think when the gem repo got added to the BCL.

This searchs for "Dbl" so it picks up a proper OSC with an OpenStudio Type assigned.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
