### PR TITLE
Fix #4824 - Use a unique_path in create_temporary_directory to avoid collision

### DIFF
--- a/src/utilities/core/FilesystemHelpers.cpp
+++ b/src/utilities/core/FilesystemHelpers.cpp
@@ -32,6 +32,8 @@
 #include "Path.hpp"
 #include "Assert.hpp"
 
+#include <fmt/format.h>
+
 namespace openstudio {
 namespace filesystem {
   std::vector<char> read(openstudio::filesystem::ifstream& t_file) {
@@ -164,17 +166,15 @@ namespace filesystem {
     static std::atomic<unsigned int> count = 0;
     constexpr auto allowed_attempts = 1000;
 
-    const auto temp_dir = openstudio::filesystem::temp_directory_path();
+    const auto base_temp_dir = openstudio::filesystem::temp_directory_path();
+    // std::filesystem::unique_path doesn't exist, if moving to std::filesystem, use emoveBraces(createUUID)
+    auto upath = boost::filesystem::unique_path();
+    const auto temp_dir = base_temp_dir / fmt::format("{}-{}-{}-", basename.string(), upath.string(), std::time(nullptr));
 
-    int attempts{0};
-
-    while (attempts < allowed_attempts) {
+    while (count < allowed_attempts) {
       // concat number to path basename, without adding a new path element
-      auto filename = basename;
-      filename += openstudio::toPath("-" + std::to_string(std::time(nullptr)) + "-" + std::to_string(count++));
-      auto full_pathname = temp_dir / filename;
-      // full_path_name = {temp_path}/{base_name}-{count++}
-
+      auto full_pathname = temp_dir;
+      full_pathname += std::to_string(count++);
       try {
         if (openstudio::filesystem::create_directories(full_pathname)) {
           // if the path was created, then we know it was created for us


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4824
 - Use a unique_path in create_temporary_directory (random generated)

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
