### PR TITLE
Fix #4911 - Avoid extra warning message in ShadingControl

### DIFF
--- a/src/model/ShadingControl.cpp
+++ b/src/model/ShadingControl.cpp
@@ -406,7 +406,7 @@ namespace model {
 
     void ShadingControl_Impl::resetSetpoint2() {
       std::string shadingControlType = this->shadingControlType();
-      if (ShadingControl_Impl::isControlTypeValueNeedingSetpoint1(shadingControlType)) {
+      if (ShadingControl_Impl::isControlTypeValueNeedingSetpoint2(shadingControlType)) {
         LOG(Warn,
             briefDescription() << " has a Shading Control Type '" << shadingControlType << "' which does require a Setpoint2, not resetting it");
       } else {

--- a/src/model/ShadingControl.cpp
+++ b/src/model/ShadingControl.cpp
@@ -239,41 +239,29 @@ namespace model {
     }
 
     bool ShadingControl_Impl::setShadingControlType(const std::string& shadingControlType) {
-      std::string oldControlType = this->shadingControlType();
-      bool result = setString(OS_ShadingControlFields::ShadingControlType, shadingControlType);
+      const bool result = setString(OS_ShadingControlFields::ShadingControlType, shadingControlType);
       if (result) {
         if (!ShadingControl_Impl::isControlTypeValueNeedingSetpoint1(shadingControlType)) {
-          // Not calling reset to avoid double check on whether it's required
-          // resetSetpoint();
-          LOG(Info,
-              briefDescription() << " Shading Control Type was changed to '" << shadingControlType << " which does not require a Setpoint, reseting");
-          bool test = setString(OS_ShadingControlFields::Setpoint, "");
+          // Not calling resetSetpoint to avoid double check on whether it's required
+          LOG(Info, briefDescription() << " Shading Control Type was changed to '" << shadingControlType
+                                       << " which does not require a Setpoint, resetting it.");
+          const bool test = setString(OS_ShadingControlFields::Setpoint, "");
           OS_ASSERT(test);
         }
         if (!ShadingControl_Impl::isControlTypeValueNeedingSetpoint2(shadingControlType)) {
-          // Not calling reset to avoid double check on whether it's required
-          // resetSetpoint2();
+          // Not calling resetSetpoint2 to avoid double check on whether it's required
           LOG(Info, briefDescription() << " Shading Control Type was changed to '" << shadingControlType
-                                       << " which does not require a Setpoint2, reseting");
-          bool test = setString(OS_ShadingControlFields::Setpoint2, "");
+                                       << " which does not require a Setpoint2, resetting it.");
+          const bool test = setString(OS_ShadingControlFields::Setpoint2, "");
           OS_ASSERT(test);
         }
         if (!ShadingControl_Impl::isControlTypeValueAllowingSchedule(shadingControlType)) {
-          LOG(Info,
-              briefDescription() << " Shading Control Type was changed to '" << shadingControlType << " which does not allow a Schedule, reseting");
+          LOG(Info, briefDescription() << " Shading Control Type was changed to '" << shadingControlType
+                                       << " which does not allow a Schedule, resetting it.");
           bool test = setString(OS_ShadingControlFields::ScheduleName, "");
           OS_ASSERT(test);
           test = setString(OS_ShadingControlFields::ShadingControlIsScheduled, "No");
           OS_ASSERT(test);
-        }
-
-        // TODO: do we want to force remove this stuff like it did resetSetpoint before? Units/quantity might be oranges and apples when switching
-        // types, but they could be compatible, and it may be very confusing at least for interface users that are playing with a dropdown to see
-        // schedulesand setpoints disapear
-        if (!openstudio::istringEqual(oldControlType, shadingControlType)) {
-          resetSetpoint();  // For backward compatibility
-          // resetSetpoint2();
-          // resetSchedule();
         }
       }
       return result;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #4911
 - Avoid extra warning message in ShadingControl

FYI @brgix

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
