### PR TITLE
Add a swig out typemap for Json::Value + openstudio::path typemap in/out for Python + add toJSON() for Workfow files and BCLMeasure

### DIFF
--- a/ruby/test/epJSON_Test.rb
+++ b/ruby/test/epJSON_Test.rb
@@ -25,16 +25,16 @@ class EpJSON_Test < MiniTest::Unit::TestCase
 
 
   def common_asserts(json, ep_version)
-    assert(json["Version"])
-    assert(Gem::Version.new(json["Version"]["Version 1"]["version_identifier"]) == ep_version)
-    assert(json["Building"])
-    assert(json["Building"]["Building 1"]["north_axis"] == 0.0)
+    assert(json[:Version])
+    assert(Gem::Version.new(json[:Version][:"Version 1"][:version_identifier]) == ep_version)
+    assert(json[:Building])
+    assert(json[:Building][:"Building 1"][:north_axis] == 0.0)
   end
 
   def test_epJSON_String
 
     json_str = OpenStudio::EPJSON::toJSONString(@idfFile);
-    json = JSON.parse(json_str)
+    json = JSON.parse(json_str, symbolize_names: true)
 
     common_asserts(json, @ep_version)
   end

--- a/src/epjson/epJSON.i
+++ b/src/epjson/epJSON.i
@@ -9,9 +9,11 @@
 #define UTILITIES_API
 #define EPJSON_API
 
-// Ignore stuff that takes/returns Json::Value
-%ignore openstudio::epJSON::toJSON;
+// You're better off just loading the json directly in the target language, so ignore
 %ignore openstudio::epJSON::loadJSON;
+#ifdef SWIGCSHARP
+%ignore openstudio::epJSON::toJSON;
+#endif
 
 %include <utilities/core/CommonInclude.i>
 %import <utilities/core/CommonImport.i>
@@ -26,25 +28,4 @@
 
 %include <epjson/epJSONTranslator.hpp>
 
-#if defined SWIGRUBY
-  // This isn't super clean and there might be a better way with typemaps in SWIG rather than using a String in between,
-  // but still helpful I think: we redefine toJSON that will return a native ruby hash. 'json' is part of ruby stdlib since at least ruby 2.5.5
-  %init %{
-    rb_eval_string("OpenStudio::EPJSON.module_eval { define_method(:toJSON) { |arg, schemaPath = nil| json_str = schemaPath.nil? ? self.toJSONString(arg) : self.toJSONString(arg, schemaPath); require 'json'; JSON.load(json_str);  }; module_function(:toJSON) }");
- %}
-#endif
-
-#if defined SWIGPYTHON
-
-  // Let's use monkey-patching via unbound functions
-  // Edit: not even needed here
-  %pythoncode %{
-# Manually added: Lazy-load the json module (python std lib) and return a dict via toJSONString
-def toJSON(*args) -> dict:
-    import json
-    return json.loads(toJSONString(*args))
-  %}
-#endif
-
 #endif // EPJSON_I
-

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -402,6 +402,7 @@ set(${target_name}_swig_src
   core/UUID.i
   core/UnzipFile.i
   core/ZipFile.i
+  core/jsoncpp.i
   core/ruby/LanguageSpecific.i
   core/python/LanguageSpecific.i
   core/csharp/LanguageSpecific.i

--- a/src/utilities/bcl/BCLFileReference.cpp
+++ b/src/utilities/bcl/BCLFileReference.cpp
@@ -8,6 +8,7 @@
 #include "../core/StringHelpers.hpp"
 
 #include <pugixml.hpp>
+#include <json/json.h>
 
 namespace openstudio {
 
@@ -158,6 +159,35 @@ void BCLFileReference::writeValues(pugi::xml_node& element) const {
   subelement = element.append_child("checksum");
   text = subelement.text();
   text.set(m_checksum.c_str());
+}
+
+Json::Value BCLFileReference::toJSON() const {
+  Json::Value root;
+  if (m_usageType == "script" && !m_softwareProgram.empty() && !m_softwareProgramVersion.empty()) {
+    auto& versionElement = root["version"];
+
+    versionElement["software_program"] = m_softwareProgram;
+    versionElement["identifier"] = m_softwareProgramVersion;
+
+    if (m_minCompatibleVersion) {
+      versionElement["min_compatible"] = m_minCompatibleVersion->str();
+    }
+
+    if (m_maxCompatibleVersion) {
+      versionElement["max_compatible"] = m_maxCompatibleVersion->str();
+    }
+  }
+
+  root["filename"] = fileName();
+  root["filetype"] = fileType();
+  root["usage_type"] = m_usageType;
+  root["checksum"] = m_checksum;
+
+  return root;
+}
+
+std::string BCLFileReference::toJSONString() const {
+  return toJSON().toStyledString();
 }
 
 bool BCLFileReference::checkForUpdate() {

--- a/src/utilities/bcl/BCLFileReference.hpp
+++ b/src/utilities/bcl/BCLFileReference.hpp
@@ -14,6 +14,10 @@ namespace pugi {
 class xml_node;
 }
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 /** BCLFileReference is a class for tracking files that come with BCL components and measures.
@@ -89,6 +93,9 @@ class UTILITIES_API BCLFileReference
   //@{
 
   void writeValues(pugi::xml_node& element) const;
+
+  Json::Value toJSON() const;
+  std::string toJSONString() const;
 
   /// Check if the file has been updated and return if so.  Will update checksum.
   bool checkForUpdate();

--- a/src/utilities/bcl/BCLMeasure.cpp
+++ b/src/utilities/bcl/BCLMeasure.cpp
@@ -30,6 +30,8 @@
 #include <string_view>
 #include <vector>
 
+#include <json/json.h>
+
 namespace openstudio {
 
 /*****************************************************************************************************************************************************
@@ -1180,6 +1182,14 @@ boost::optional<BCLMeasure> BCLMeasure::clone(const openstudio::path& newDir) co
 
 std::string BCLMeasure::xmlString() const {
   return m_bclXML.toString();
+}
+
+Json::Value BCLMeasure::toJSON() const {
+  return m_bclXML.toJSON();
+}
+
+std::string BCLMeasure::toJSONString() const {
+  return m_bclXML.toJSONString();
 }
 
 }  // namespace openstudio

--- a/src/utilities/bcl/BCLMeasure.hpp
+++ b/src/utilities/bcl/BCLMeasure.hpp
@@ -16,6 +16,10 @@
 
 #include <vector>
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 class FileReferenceType;
@@ -243,6 +247,9 @@ class UTILITIES_API BCLMeasure
 
   /// get all measures in an input directory
   static std::vector<BCLMeasure> getMeasuresInDir(const openstudio::path& dir);
+
+  Json::Value toJSON() const;
+  std::string toJSONString() const;
 
   //@}
  private:

--- a/src/utilities/bcl/BCLMeasureArgument.cpp
+++ b/src/utilities/bcl/BCLMeasureArgument.cpp
@@ -8,6 +8,7 @@
 #include "../core/Assert.hpp"
 
 #include <pugixml.hpp>
+#include <json/json.h>
 
 namespace openstudio {
 
@@ -208,6 +209,55 @@ void BCLMeasureArgument::writeValues(pugi::xml_node& element) const {
     text = subElement.text();
     text.set(m_maxValue->c_str());
   }
+}
+
+Json::Value BCLMeasureArgument::toJSON() const {
+  Json::Value root;
+
+  root["name"] = m_name;
+  root["display_name"] = m_displayName;
+
+  if (m_description) {
+    root["description"] = *m_description;
+  }
+
+  root["type"] = m_type;
+
+  if (m_units) {
+    root["units"] = *m_units;
+  }
+
+  root["required"] = m_required;
+  root["model_dependent"] = m_modelDependent;
+
+  if (m_defaultValue) {
+    root["default_value"] = *m_defaultValue;
+  }
+
+  const size_t n = m_choiceValues.size();
+  OS_ASSERT(n == m_choiceDisplayNames.size());
+  if (n > 0) {
+    auto& choices = root["choices"];
+    for (size_t i = 0; i < n; ++i) {
+      auto& choice = choices["choice"];
+      choice["value"] = m_choiceValues[i];
+      choice["display_name"] = m_choiceDisplayNames[i];
+    }
+  }
+
+  if (m_minValue) {
+    root["min_value"] = *m_minValue;
+  }
+
+  if (m_maxValue) {
+    root["max_value"] = *m_maxValue;
+  }
+
+  return root;
+}
+
+std::string BCLMeasureArgument::toJSONString() const {
+  return toJSON().toStyledString();
 }
 
 bool BCLMeasureArgument::operator==(const BCLMeasureArgument& other) const {

--- a/src/utilities/bcl/BCLMeasureArgument.hpp
+++ b/src/utilities/bcl/BCLMeasureArgument.hpp
@@ -15,6 +15,10 @@ namespace pugi {
 class xml_node;
 }
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 /** BCLMeasureArgument is a class representing an argument of a measure.  This class does not hold the particular
@@ -46,6 +50,9 @@ class UTILITIES_API BCLMeasureArgument
   boost::optional<std::string> maxValue() const;
 
   void writeValues(pugi::xml_node& element) const;
+
+  Json::Value toJSON() const;
+  std::string toJSONString() const;
 
   bool operator==(const BCLMeasureArgument& other) const;
 

--- a/src/utilities/bcl/BCLMeasureOutput.cpp
+++ b/src/utilities/bcl/BCLMeasureOutput.cpp
@@ -19,14 +19,19 @@ BCLMeasureOutput::BCLMeasureOutput(const pugi::xml_node& element) {
 
   m_displayName = element.child("display_name").text().as_string();
 
-  m_shortName = element.child("short_name").text().as_string();
-  ;
+  if (auto child_ = element.child("short_name")) {
+    m_shortName = child_.text().as_string();
+  }
 
-  m_description = element.child("description").text().as_string();
+  if (auto child_ = element.child("description")) {
+    m_description = child_.text().as_string();
+  }
 
   m_type = element.child("type").text().as_string();
 
-  m_units = element.child("units").text().as_string();
+  if (auto child_ = element.child("units")) {
+    m_units = child_.text().as_string();
+  }
 
   const std::string test = element.child("model_dependent").text().as_string();
   m_modelDependent = false;

--- a/src/utilities/bcl/BCLMeasureOutput.cpp
+++ b/src/utilities/bcl/BCLMeasureOutput.cpp
@@ -8,6 +8,7 @@
 #include "../core/Assert.hpp"
 
 #include <pugixml.hpp>
+#include <json/json.h>
 
 namespace openstudio {
 
@@ -107,6 +108,36 @@ void BCLMeasureOutput::writeValues(pugi::xml_node& element) const {
   subelement = element.append_child("model_dependent");
   text = subelement.text();
   text.set(m_modelDependent ? "true" : "false");
+}
+
+Json::Value BCLMeasureOutput::toJSON() const {
+  Json::Value root;
+
+  root["name"] = m_name;
+
+  root["display_name"] = m_displayName;
+
+  if (m_shortName) {
+    root["short_name"] = *m_shortName;
+  }
+
+  if (m_description) {
+    root["description"] = *m_description;
+  }
+
+  root["type"] = m_type;
+
+  if (m_units) {
+    root["units"] = *m_units;
+  }
+
+  root["model_dependent"] = m_modelDependent;
+
+  return root;
+}
+
+std::string BCLMeasureOutput::toJSONString() const {
+  return toJSON().toStyledString();
 }
 
 bool BCLMeasureOutput::operator==(const BCLMeasureOutput& other) const {

--- a/src/utilities/bcl/BCLMeasureOutput.hpp
+++ b/src/utilities/bcl/BCLMeasureOutput.hpp
@@ -15,6 +15,10 @@ namespace pugi {
 class xml_node;
 }
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 /** BCLMeasureOutput is a class representing an output of a measure.  This class does not hold the particular
@@ -39,6 +43,9 @@ class UTILITIES_API BCLMeasureOutput
   bool modelDependent() const;
 
   void writeValues(pugi::xml_node& element) const;
+
+  Json::Value toJSON() const;
+  std::string toJSONString() const;
 
   bool operator==(const BCLMeasureOutput& other) const;
 

--- a/src/utilities/bcl/BCLXML.cpp
+++ b/src/utilities/bcl/BCLXML.cpp
@@ -11,7 +11,9 @@
 #include "../time/DateTime.hpp"
 #include "../xml/XMLValidator.hpp"
 
+#include <json/value.h>
 #include <pugixml.hpp>
+#include <json/json.h>
 
 #include <algorithm>
 #include <sstream>
@@ -727,6 +729,94 @@ pugi::xml_document BCLXML::toXML() const {
   }
 
   return doc;
+}
+
+Json::Value BCLXML::toJSON() const {
+
+  Json::Value root;
+
+  if (m_bclXMLType == BCLXMLType::ComponentXML) {
+    root["type"] = "component";
+  } else if (m_bclXMLType == BCLXMLType::MeasureXML) {
+    root["type"] = "measure";
+  } else {
+    LOG_AND_THROW("Unknown BCLXMLType '" << m_bclXMLType.valueName() << "'.");
+  }
+
+  root["schema_version"] = BCLXML::currentSchemaVersion().str();
+
+  if (m_error) {
+    root["error"] = escapeString(*m_error);
+  }
+  root["name"] = escapeString(m_name);
+
+  root["uid"] = m_uid;
+  root["version_id"] = m_versionId;
+  if (boost::optional<DateTime> versionMod_ = versionModified()) {
+    root["version_modified"] = versionMod_->toISO8601();
+  }
+  root["xml_checksum"] = m_xmlChecksum;
+
+  if (m_bclXMLType == BCLXMLType::MeasureXML) {
+    root["class_name"] = m_className;
+  }
+
+  root["display_name"] = m_displayName;
+  root["description"] = m_description;
+  if (m_bclXMLType == BCLXMLType::MeasureXML) {
+
+    root["modeler_description"] = m_modelerDescription;
+
+    {
+      auto& arguments = root["arguments"];
+      for (const BCLMeasureArgument& argument : m_arguments) {
+        arguments.append(argument.toJSON());
+      }
+    }
+
+    {
+      auto& outputs = root["outputs"];
+      for (const BCLMeasureOutput& output : m_outputs) {
+        outputs.append(output.toJSON());
+      }
+    }
+  }
+
+  // TODO: write provenances
+  // root["provenances"] = Json::Value(Json::arrayValue);
+
+  // write tags
+  // provenances isn't written so element above is not used... so ignore it here
+  // cppcheck-suppress redundantAssignment
+  auto& tags = root["tags"];
+  for (const std::string& tag : m_tags) {
+    tags.append(tag);
+  }
+
+  // TODO: why isn't this using Attribute::toXml (which appears unused anywhere and could be repurposed to work exactly as intended)?!
+
+  // write attributes
+  auto& attributes = root["attributes"];
+  for (const Attribute& attribute : m_attributes) {
+    attributes.append(attribute.toJSON(true));
+  }
+
+  // write files
+  {
+    auto& files = root["files"];
+    // Fix for #4748 - sort files
+    auto sortedFiles = m_files;
+    std::sort(sortedFiles.begin(), sortedFiles.end());
+    for (const BCLFileReference& file : sortedFiles) {
+      files.append(file.toJSON());
+    }
+  }
+
+  return root;
+}
+
+std::string BCLXML::toJSONString() const {
+  return toJSON().toStyledString();
 }
 
 bool BCLXML::save() const {

--- a/src/utilities/bcl/BCLXML.hpp
+++ b/src/utilities/bcl/BCLXML.hpp
@@ -24,6 +24,10 @@ namespace pugi {
 class xml_document;
 }  // namespace pugi
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 class BCLComponent;
@@ -186,6 +190,9 @@ class UTILITIES_API BCLXML
   /// if any xml fields (other than uid, version id, or xml checksum) have changed
   /// The xml file must still be saved to disk to preserve the new versionID
   bool checkForUpdatesXML();
+
+  Json::Value toJSON() const;
+  std::string toJSONString() const;
 
   //@}
  protected:

--- a/src/utilities/bcl/LocalBCL.i
+++ b/src/utilities/bcl/LocalBCL.i
@@ -32,6 +32,8 @@
   #include <utilities/units/SIUnit.hpp>
   #include <utilities/units/ThermUnit.hpp>
   #include <utilities/units/WhUnit.hpp>
+
+  #include <json/value.h>
 %}
 
 %ignore componentDownloaded;

--- a/src/utilities/core/Core.i
+++ b/src/utilities/core/Core.i
@@ -61,6 +61,7 @@
 %include <utilities/core/Optional.hpp>
 %include <utilities/core/UnzipFile.i>
 %include <utilities/core/ZipFile.i>
+%include <utilities/core/jsoncpp.i>
 
 // DLM@20110107: this is causing issues for C#
 #if defined(SWIGRUBY) || defined(SWIGJAVASCRIPT)

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -296,30 +296,23 @@ namespace openstudio {
 
   #ifdef SWIGPYTHON
 
-    %fragment("commonpath", "header") {
-        PyObject * importPathCls() {
+    %fragment("SWIG_openstudio_path", "header") {
+        SWIGINTERN PyObject * importPathCls() {
             PyObject * pymodule = PyImport_ImportModule("pathlib");
             PyObject * cls = PyObject_GetAttrString(pymodule, "Path");
             Py_DECREF(pymodule);
             return cls;
         }
 
-        bool isPathInstance(PyObject * obj) {
+        SWIGINTERN bool isPathInstance(PyObject * obj) {
             PyObject * cls = importPathCls();
             bool is_instance =  PyObject_IsInstance(obj, cls);
             Py_DECREF(cls);
             return is_instance;
         }
-
-        const char * pathToStr(PyObject * obj) {
-            PyObject * str_obj = PyObject_Str(obj);     // New reference
-            const char * s = PyUnicode_AsUTF8(str_obj); // This stores the UTF-8 representation buffer within str_obj
-            // Py_DECREF(str_obj);                      // So we don't decref here
-            return s;
-        }
     }
 
-    %typemap(in, fragment="commonpath") (path) {
+    %typemap(in, fragment="SWIG_openstudio_path") (path) {
 
       // check if input is a path already
       void *vptr = 0;
@@ -341,14 +334,16 @@ namespace openstudio {
         std::string s(PyString_AsString($input));
         $1 = openstudio::toPath(s);
       } else if (isPathInstance($input)) {
-        const char * s = pathToStr($input);
+        PyObject * str_obj = PyObject_Str($input);   // New reference
+        const char * s = PyUnicode_AsUTF8(str_obj);  // This stores the UTF-8 representation buffer within str_obj
         $1 = openstudio::toPath(s);
+        Py_DECREF(str_obj);
       } else {
         SWIG_exception_fail(SWIG_ArgError(res), "Wrong input type for openstudio::path");
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="commonpath") (path) {
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") (path) {
       bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
       if (stringOrPathlibType){
@@ -361,7 +356,7 @@ namespace openstudio {
 
     // no need for freearg typemap since new did not get called
 
-    %typemap(out, fragment="commonpath") path {
+    %typemap(out, fragment="SWIG_openstudio_path") path {
         const std::string s = $1.string();
 
         PyObject * cls = importPathCls();
@@ -377,7 +372,7 @@ namespace openstudio {
     %apply path { const path };
 
     // handle const path& separately
-    %typemap(in, fragment="commonpath") (const path&) {
+    %typemap(in, fragment="SWIG_openstudio_path") (const path&) {
       $1=NULL;
 
       // check if input is a path already
@@ -400,14 +395,16 @@ namespace openstudio {
         std::string s(PyString_AsString($input));
         $1 = new openstudio::path(openstudio::toPath(s));
       } else if (isPathInstance($input)) {
-        const char * s = pathToStr($input);
+        PyObject * str_obj = PyObject_Str($input);   // New reference
+        const char * s = PyUnicode_AsUTF8(str_obj);
         $1 = new openstudio::path(openstudio::toPath(s));
+        Py_DECREF(str_obj);
       } else {
         SWIG_exception_fail(SWIG_ArgError(res), "Wrong input type for openstudio::path const &");
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="commonpath") (const path&) {
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") (const path&) {
       bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
       if (stringOrPathlibType) {

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -361,6 +361,18 @@ namespace openstudio {
 
     // no need for freearg typemap since new did not get called
 
+    %typemap(out, fragment="commonpath") path {
+        const std::string s = $1.string();
+
+        PyObject * cls = importPathCls();
+
+        PyObject* args = Py_BuildValue("(s)", s.data());
+        $result = PyObject_CallObject(cls, args);
+
+        Py_DECREF(cls);
+        Py_DECREF(args);
+    }
+
     // handle const path like path
     %apply path { const path };
 
@@ -411,7 +423,7 @@ namespace openstudio {
         delete $1;
       }
     }
-  #endif
+  #endif  // SWIGPYTHON
 
 } // openstudio
 

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -295,7 +295,31 @@ namespace openstudio {
   #endif
 
   #ifdef SWIGPYTHON
-    %typemap(in) (path) {
+
+    %fragment("commonpath", "header") {
+        PyObject * importPathCls() {
+            PyObject * pymodule = PyImport_ImportModule("pathlib");
+            PyObject * cls = PyObject_GetAttrString(pymodule, "Path");
+            Py_DECREF(pymodule);
+            return cls;
+        }
+
+        bool isPathInstance(PyObject * obj) {
+            PyObject * cls = importPathCls();
+            bool is_instance =  PyObject_IsInstance(obj, cls);
+            Py_DECREF(cls);
+            return is_instance;
+        }
+
+        const char * pathToStr(PyObject * obj) {
+            PyObject * str_obj = PyObject_Str(obj);     // New reference
+            const char * s = PyUnicode_AsUTF8(str_obj); // This stores the UTF-8 representation buffer within str_obj
+            // Py_DECREF(str_obj);                      // So we don't decref here
+            return s;
+        }
+    }
+
+    %typemap(in, fragment="commonpath") (path) {
 
       // check if input is a path already
       void *vptr = 0;
@@ -306,7 +330,7 @@ namespace openstudio {
           openstudio::path * p = reinterpret_cast< openstudio::path * >(vptr);
           $1 = openstudio::path(*p);
         }else{
-          SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path const &");
+          SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path");
         }
       } else if(PyUnicode_Check($input)) {
         // Python 3
@@ -316,20 +340,23 @@ namespace openstudio {
         // Python2, PyString_Check does PyBytes_Check
         std::string s(PyString_AsString($input));
         $1 = openstudio::toPath(s);
+      } else if (isPathInstance($input)) {
+        const char * s = pathToStr($input);
+        $1 = openstudio::toPath(s);
       } else {
-        SWIG_exception_fail(SWIG_ArgError(res), "Wrong input type for openstudio::path const &");
+        SWIG_exception_fail(SWIG_ArgError(res), "Wrong input type for openstudio::path");
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) (path) {
-      bool stringType = PyString_Check($input) || PyUnicode_Check($input);
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="commonpath") (path) {
+      bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
-      if (!stringType){
+      if (stringOrPathlibType){
         void *vptr = 0;
         int res = SWIG_ConvertPtr($input, &vptr, $&1_descriptor, 0);
         pathType = (SWIG_IsOK(res) && (vptr != 0));
       }
-      $1 = (stringType || pathType) ? 1 : 0;
+      $1 = (stringOrPathlibType || pathType) ? 1 : 0;
     }
 
     // no need for freearg typemap since new did not get called
@@ -338,7 +365,7 @@ namespace openstudio {
     %apply path { const path };
 
     // handle const path& separately
-    %typemap(in) (const path&) {
+    %typemap(in, fragment="commonpath") (const path&) {
       $1=NULL;
 
       // check if input is a path already
@@ -360,20 +387,23 @@ namespace openstudio {
         // Python2, PyString_Check does PyBytes_Check
         std::string s(PyString_AsString($input));
         $1 = new openstudio::path(openstudio::toPath(s));
+      } else if (isPathInstance($input)) {
+        const char * s = pathToStr($input);
+        $1 = new openstudio::path(openstudio::toPath(s));
       } else {
         SWIG_exception_fail(SWIG_ArgError(res), "Wrong input type for openstudio::path const &");
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING) (const path&) {
-      bool stringType = PyString_Check($input) || PyUnicode_Check($input);
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="commonpath") (const path&) {
+      bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
-      if (!stringType){
+      if (stringOrPathlibType) {
         void *vptr = 0;
         int res = SWIG_ConvertPtr($input, &vptr, $1_descriptor, 0);
         pathType = (SWIG_IsOK(res) && (vptr != 0));
       }
-      $1 = (stringType || pathType) ? 1 : 0;
+      $1 = (stringOrPathlibType || pathType) ? 1 : 0;
     }
 
     %typemap(freearg) (const path&) {

--- a/src/utilities/core/jsoncpp.i
+++ b/src/utilities/core/jsoncpp.i
@@ -1,0 +1,90 @@
+#ifndef JSONCPP_I
+#define JSONCPP_I
+
+%{
+  #include <json/value.h>
+%}
+
+#if defined SWIGPYTHON
+%fragment("JsonToDict","header", fragment="SWIG_FromCharPtrAndSize") {
+  inline PyObject* SWIG_From_JsonValue(const Json::Value& value) {
+
+      if (value.isBool()) {
+        return value.asBool() ? Py_True : Py_False;
+      } else if (value.isIntegral()) {
+          return PyLong_FromLongLong(value.asInt64());
+      } else if (value.isNumeric()) {
+         return PyFloat_FromDouble(value.asDouble());
+      } else if (value.isString()) {
+         // return PyUnicode_FromString(value.asCString());
+         const auto str = value.asString();
+         return SWIG_FromCharPtrAndSize(str.data(), str.size());
+      } else if (value.isArray()) {
+          PyObject* result = PyList_New(value.size());
+          Py_ssize_t idx = 0;
+          for( const auto& arrayElement : value) {
+              // TODO: this should do a recursive call to convert n (which is Json::Value) to a python type...
+              auto val = SWIG_From_JsonValue(arrayElement);
+              // PyList_Append(result, val);
+              PyList_SetItem(result, idx++, val);
+          }
+          return result;
+
+      } else if (value.isObject()) {
+          PyObject* result = PyDict_New();
+          for( const auto& id : value.getMemberNames()) {
+              // TODO: this should do a recursive call to convert *$1[id] (which is a Json::Value) to a python type...
+              auto val = SWIG_From_JsonValue(value[id]);
+              PyDict_SetItemString(result, id.c_str(), val);
+              Py_DECREF(val);
+          }
+          return result;
+      }
+
+      return PyDict_New();
+  }
+}
+
+%typemap(out, fragment="JsonToDict") Json::Value {
+  $result = SWIG_From_JsonValue($1);
+}
+#endif
+
+#if defined SWIGRUBY
+%fragment("JsonToDict","header", fragment="SWIG_FromCharPtrAndSize") {
+  inline VALUE SWIG_From_JsonValue(const Json::Value& value) {
+
+      if (value.isBool()) {
+        return value.asBool() ? Qtrue : Qfalse;
+      } else if (value.isIntegral()) {
+          return INT2NUM(value.asInt64());
+      } else if (value.isNumeric()) {
+         return DOUBLE2NUM(value.asDouble());
+      } else if (value.isString()) {
+         const auto str = value.asString();
+         return SWIG_FromCharPtrAndSize(str.data(), str.size());
+      } else if (value.isArray()) {
+          VALUE result = rb_ary_new2(value.size());
+          for( const auto& arrayElement : value) {
+              rb_ary_push(result, SWIG_From_JsonValue(arrayElement));
+          }
+          return result;
+
+      } else if (value.isObject()) {
+          VALUE result = rb_hash_new();
+          for( const auto& id : value.getMemberNames()) {
+              rb_hash_aset(result, ID2SYM(rb_intern(id.data())), SWIG_From_JsonValue(value[id]));
+          }
+          return result;
+      }
+
+      return rb_hash_new();
+  }
+}
+
+%typemap(out, fragment="JsonToDict") Json::Value {
+  $result = SWIG_From_JsonValue($1);
+}
+#endif
+
+#endif // JSONCPP_I

--- a/src/utilities/core/jsoncpp.i
+++ b/src/utilities/core/jsoncpp.i
@@ -1,9 +1,13 @@
 #ifndef JSONCPP_I
 #define JSONCPP_I
 
+#if defined SWIGCSHARP
+%ignore openstudio::*::toJSON() const;
+#else
 %{
   #include <json/value.h>
 %}
+#endif
 
 #if defined SWIGPYTHON
 %fragment("JsonToDict","header", fragment="SWIG_FromCharPtrAndSize") {

--- a/src/utilities/core/python/LanguageSpecific.i
+++ b/src/utilities/core/python/LanguageSpecific.i
@@ -14,4 +14,43 @@
 #endif
 %}
 
+%fragment("JsonToDict","header", fragment="SWIG_FromCharPtrAndSize") {
+  PyObject* SWIG_From_JsonValue(const Json::Value& value) {
+
+      if (value.isBool()) {
+        return value.asBool() ? Py_True : Py_False;
+      } else if (value.isIntegral()) {
+          return PyLong_FromLongLong(value.asInt64());
+      } else if (value.isNumeric()) {
+         return PyFloat_FromDouble(value.asDouble());
+      } else if (value.isString()) {
+         // return PyUnicode_FromString(value.asCString());
+         const auto str = value.asString();
+         return SWIG_FromCharPtrAndSize(str.data(), str.size());
+      } else if (value.isArray()) {
+          PyObject* result = PyList_New(value.size());
+          Py_ssize_t idx = 0;
+          for( const auto& arrayElement : value) {
+              auto val = SWIG_From_JsonValue(arrayElement);
+              PyList_SetItem(result, idx++, val); // This steals the reference so no decref
+          }
+          return result;
+
+      } else if (value.isObject()) {
+          PyObject* result = PyDict_New();
+          for( const auto& id : value.getMemberNames()) {
+              auto val = SWIG_From_JsonValue(value[id]);
+              PyDict_SetItemString(result, id.c_str(), val);  // Does **not** steal so decref
+              Py_DECREF(val);
+          }
+          return result;
+      }
+
+      return PyDict_New();
+  }
+}
+%typemap(out, fragment="JsonToDict") Json::Value {
+  $result = SWIG_From_JsonValue($1);
+}
+
 #endif

--- a/src/utilities/core/python/LanguageSpecific.i
+++ b/src/utilities/core/python/LanguageSpecific.i
@@ -14,43 +14,4 @@
 #endif
 %}
 
-%fragment("JsonToDict","header", fragment="SWIG_FromCharPtrAndSize") {
-  PyObject* SWIG_From_JsonValue(const Json::Value& value) {
-
-      if (value.isBool()) {
-        return value.asBool() ? Py_True : Py_False;
-      } else if (value.isIntegral()) {
-          return PyLong_FromLongLong(value.asInt64());
-      } else if (value.isNumeric()) {
-         return PyFloat_FromDouble(value.asDouble());
-      } else if (value.isString()) {
-         // return PyUnicode_FromString(value.asCString());
-         const auto str = value.asString();
-         return SWIG_FromCharPtrAndSize(str.data(), str.size());
-      } else if (value.isArray()) {
-          PyObject* result = PyList_New(value.size());
-          Py_ssize_t idx = 0;
-          for( const auto& arrayElement : value) {
-              auto val = SWIG_From_JsonValue(arrayElement);
-              PyList_SetItem(result, idx++, val); // This steals the reference so no decref
-          }
-          return result;
-
-      } else if (value.isObject()) {
-          PyObject* result = PyDict_New();
-          for( const auto& id : value.getMemberNames()) {
-              auto val = SWIG_From_JsonValue(value[id]);
-              PyDict_SetItemString(result, id.c_str(), val);  // Does **not** steal so decref
-              Py_DECREF(val);
-          }
-          return result;
-      }
-
-      return PyDict_New();
-  }
-}
-%typemap(out, fragment="JsonToDict") Json::Value {
-  $result = SWIG_From_JsonValue($1);
-}
-
 #endif

--- a/src/utilities/core/ruby/LanguageSpecific.i
+++ b/src/utilities/core/ruby/LanguageSpecific.i
@@ -204,38 +204,4 @@ namespace boost {
 
 %rename(multiplyEqual) operator *=;
 
-
-%fragment("JsonToDict", "header", fragment="SWIG_FromCharPtrAndSize") {
-    VALUE SWIG_From_JsonValue(const Json::Value& value) {
-        if (value.isBool()) {
-            return value.asBool() ? Qtrue : Qfalse;
-        } else if (value.isIntegral()) {
-            return INT2NUM(value.asInt64());
-        } else if (value.isNumeric()) {
-            return DOUBLE2NUM(value.asDouble());
-        } else if (value.isString()) {
-            const auto str = value.asString();
-            return SWIG_FromCharPtrAndSize(str.data(), str.size());
-        } else if (value.isArray()) {
-            VALUE result = rb_ary_new2(value.size());
-            for( const auto& arrayElement : value) {
-                rb_ary_push(result, SWIG_From_JsonValue(arrayElement));
-            }
-            return result;
-
-        } else if (value.isObject()) {
-            VALUE result = rb_hash_new();
-            for( const auto& id : value.getMemberNames()) {
-                rb_hash_aset(result, ID2SYM(rb_intern(id.data())), SWIG_From_JsonValue(value[id]));
-            }
-            return result;
-        }
-
-        return rb_hash_new();
-    }
-}
-%typemap(out, fragment="JsonToDict") Json::Value {
-  $result = SWIG_From_JsonValue($1);
-}
-
 #endif // UTILITIES_RUBY_LANGUAGESPECIFIC_I

--- a/src/utilities/data/Attribute.cpp
+++ b/src/utilities/data/Attribute.cpp
@@ -608,7 +608,10 @@ namespace detail {
 
     Json::Value root;
     root["name"] = m_name;
-    root["display_name"] = displayName(true).get();
+    if (auto displayName_ = displayName(false)) {
+      root["display_name"] = std::move(*displayName_);
+    }
+    // root["display_name"] = displayName(true).get();
 
     if (!short_version) {
       root["uuid"] = openstudio::removeBraces(m_uuid);

--- a/src/utilities/data/Attribute.hpp
+++ b/src/utilities/data/Attribute.hpp
@@ -23,6 +23,10 @@ class xml_document;
 class xml_node;
 }  // namespace pugi
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 class Attribute;
@@ -295,6 +299,10 @@ class UTILITIES_API Attribute
     }
     return result;
   }
+
+  // short_version: if false, will include the uuid, versionuuid and source (if any)
+  Json::Value toJSON(bool short_version = true) const;
+  std::string toJSONString() const;
 
  protected:
   UTILITIES_API friend std::ostream& operator<<(std::ostream& os, const Attribute& attribute);

--- a/src/utilities/data/Attribute.i
+++ b/src/utilities/data/Attribute.i
@@ -4,6 +4,8 @@
 %{
   #include <utilities/data/Attribute.hpp>
   #include <utilities/data/Attribute_Impl.hpp>
+
+  #include <json/value.h>
 %}
 
 // create an instantiation of the optional class

--- a/src/utilities/data/Attribute_Impl.hpp
+++ b/src/utilities/data/Attribute_Impl.hpp
@@ -19,6 +19,10 @@ class xml_document;
 class xml_node;
 }  // namespace pugi
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 namespace detail {
 
@@ -158,6 +162,9 @@ namespace detail {
 
     /// write object and all children to xml
     pugi::xml_document toXml() const;
+
+    // short_version: if false, will include the uuid, versionuuid and source (if any)
+    Json::Value toJSON(bool short_version) const;
 
     /// comparison
     bool operator==(const Attribute& other) const;

--- a/src/utilities/filetypes/ForwardTranslatorOptions.cpp
+++ b/src/utilities/filetypes/ForwardTranslatorOptions.cpp
@@ -193,7 +193,7 @@ namespace detail {
     }
   }
 
-  Json::Value ForwardTranslatorOptions_Impl::json() const {
+  Json::Value ForwardTranslatorOptions_Impl::toJSON() const {
     Json::Value value;
 
     if (!m_is_runcontrolspecialdays_defaulted) {
@@ -229,7 +229,7 @@ namespace detail {
 
   std::string ForwardTranslatorOptions_Impl::string() const {
 
-    const Json::Value data = this->json();
+    const Json::Value data = this->toJSON();
     if (data.isNull()) {
       return "";
     }
@@ -296,8 +296,8 @@ ForwardTranslatorOptions ForwardTranslatorOptions::fromJSON(const Json::Value& v
   return result;
 }
 
-Json::Value ForwardTranslatorOptions::json() const {
-  return m_impl->json();
+Json::Value ForwardTranslatorOptions::toJSON() const {
+  return m_impl->toJSON();
 }
 
 std::string ForwardTranslatorOptions::string() const {

--- a/src/utilities/filetypes/ForwardTranslatorOptions.hpp
+++ b/src/utilities/filetypes/ForwardTranslatorOptions.hpp
@@ -38,6 +38,8 @@ class UTILITIES_API ForwardTranslatorOptions
   /// Construct from JSON formatted string
   static boost::optional<ForwardTranslatorOptions> fromString(const std::string& s);
 
+  Json::Value toJSON() const;
+
   /// Serialize to JSON formatted string
   std::string string() const;
 
@@ -83,7 +85,6 @@ class UTILITIES_API ForwardTranslatorOptions
   static std::vector<ForwardTranslatorOptionKeyMethod> forwardTranslatorOptionKeyMethods();
 
  protected:
-  Json::Value json() const;
   static ForwardTranslatorOptions fromJSON(const Json::Value& value);
 
   // get the impl

--- a/src/utilities/filetypes/ForwardTranslatorOptions_Impl.hpp
+++ b/src/utilities/filetypes/ForwardTranslatorOptions_Impl.hpp
@@ -28,7 +28,7 @@ namespace detail {
     void reset();
 
     std::string string() const;
-    Json::Value json() const;
+    Json::Value toJSON() const;
 
     bool keepRunControlSpecialDays() const;
     bool isKeepRunControlSpecialDaysDefaulted() const;

--- a/src/utilities/filetypes/RunOptions.cpp
+++ b/src/utilities/filetypes/RunOptions.cpp
@@ -12,6 +12,7 @@
 
 #include <json/json.h>
 
+#include <json/value.h>
 #include <memory>
 #include <string>
 
@@ -22,62 +23,50 @@ namespace detail {
     this->onChange.nano_emit();
   }
 
-  std::string RunOptions_Impl::string() const {
-    Json::Value value;
+  Json::Value RunOptions_Impl::toJSON() const {
+    Json::Value root;
 
     // TODO: Why is this only writing if not default? I find it weird
     if (m_debug) {
-      value["debug"] = m_debug;
+      root["debug"] = m_debug;
     }
 
     if (m_epjson) {
-      value["epjson"] = m_epjson;
+      root["epjson"] = m_epjson;
     }
 
     if (m_fast) {
-      value["fast"] = m_fast;
+      root["fast"] = m_fast;
     }
 
     if (m_preserveRunDir) {
-      value["preserve_run_dir"] = m_preserveRunDir;
+      root["preserve_run_dir"] = m_preserveRunDir;
     }
 
     if (m_skipExpandObjects) {
-      value["skip_expand_objects"] = m_skipExpandObjects;
+      root["skip_expand_objects"] = m_skipExpandObjects;
     }
 
     if (m_skipEnergyPlusPreprocess) {
-      value["skip_energyplus_preprocess"] = m_skipEnergyPlusPreprocess;
+      root["skip_energyplus_preprocess"] = m_skipEnergyPlusPreprocess;
     }
 
     if (m_customOutputAdapter) {
-      Json::Value outputAdapter;
-      outputAdapter["custom_file_name"] = m_customOutputAdapter->customFileName();
-      outputAdapter["class_name"] = m_customOutputAdapter->className();
-
-      Json::CharReaderBuilder rbuilder;
-      std::istringstream ss(m_customOutputAdapter->options());
-      std::string formattedErrors;
-      Json::Value options;
-      bool parsingSuccessful = Json::parseFromStream(rbuilder, ss, &options, &formattedErrors);
-      if (parsingSuccessful) {
-        outputAdapter["options"] = options;
-      } else {
-        LOG(Warn, "Couldn't parse CustomOutputAdapter's options='" << m_customOutputAdapter->options() << "'. Error: '" << formattedErrors << "'.");
-      }
-
-      value["output_adapter"] = outputAdapter;
+      root["output_adapter"] = m_customOutputAdapter->toJSON();
     }
 
-    if (auto ft_opt = m_forwardTranslatorOptions.json()) {
-      value["ft_options"] = ft_opt;
+    if (auto ft_opt = m_forwardTranslatorOptions.toJSON()) {
+      root["ft_options"] = ft_opt;
     }
+    return root;
+  }
 
+  std::string RunOptions_Impl::string() const {
     // Write to string
     Json::StreamWriterBuilder wbuilder;
     // mimic the old StyledWriter behavior:
     wbuilder["indentation"] = "   ";
-    std::string result = Json::writeString(wbuilder, value);
+    std::string result = Json::writeString(wbuilder, toJSON());
 
     return result;
   }
@@ -219,8 +208,24 @@ namespace detail {
 
 }  // namespace detail
 
-CustomOutputAdapter::CustomOutputAdapter(const std::string& customFileName, const std::string& className, const std::string& options)
-  : m_customFileName(customFileName), m_className(className), m_options(options) {}
+CustomOutputAdapter CustomOutputAdapter::fromString(std::string customFileName, std::string className, const std::string& options) {
+
+  if (options.empty()) {
+    return CustomOutputAdapter(std::move(customFileName), std::move(className));
+  }
+  const Json::CharReaderBuilder rbuilder;
+  std::istringstream ss(options);
+  std::string formattedErrors;
+  Json::Value parsedOptions;
+  const bool parsingSuccessful = Json::parseFromStream(rbuilder, ss, &parsedOptions, &formattedErrors);
+  if (!parsingSuccessful) {
+    parsedOptions = Json::Value(Json::nullValue);
+  }
+  return CustomOutputAdapter(std::move(customFileName), std::move(className), std::move(parsedOptions));
+}
+
+CustomOutputAdapter::CustomOutputAdapter(std::string customFileName, std::string className, Json::Value options)
+  : m_customFileName(std::move(customFileName)), m_className(std::move(className)), m_options(std::move(options)) {}
 
 std::string CustomOutputAdapter::customFileName() const {
   return m_customFileName;
@@ -231,7 +236,27 @@ std::string CustomOutputAdapter::className() const {
 }
 
 std::string CustomOutputAdapter::options() const {
+  if (m_options.isNull()) {
+    return "";
+  }
+
+  // Write to string
+  Json::StreamWriterBuilder wbuilder;
+  // mimic the old StyledWriter behavior:
+  wbuilder["indentation"] = "   ";
+  return Json::writeString(wbuilder, m_options);
+}
+
+Json::Value CustomOutputAdapter::optionsJSON() const {
   return m_options;
+}
+
+Json::Value CustomOutputAdapter::toJSON() const {
+  Json::Value outputAdapter;
+  outputAdapter["custom_file_name"] = m_customFileName;
+  outputAdapter["class_name"] = m_className;
+  outputAdapter["options"] = m_options;
+  return outputAdapter;
 }
 
 RunOptions::RunOptions() : m_impl(std::make_shared<detail::RunOptions_Impl>()) {
@@ -285,13 +310,7 @@ boost::optional<RunOptions> RunOptions::fromString(const std::string& s) {
       std::string customFileName = outputAdapter["custom_file_name"].asString();
       std::string className = outputAdapter["class_name"].asString();
       Json::Value options = outputAdapter["options"];
-
-      Json::StreamWriterBuilder wbuilder;
-      // mimic the old StyledWriter behavior:
-      wbuilder["indentation"] = "   ";
-      std::string optionString = Json::writeString(wbuilder, options);
-
-      CustomOutputAdapter coa(customFileName, className, optionString);
+      const CustomOutputAdapter coa(std::move(customFileName), std::move(className), std::move(options));
       result.setCustomOutputAdapter(coa);
     }
   }
@@ -301,6 +320,10 @@ boost::optional<RunOptions> RunOptions::fromString(const std::string& s) {
   }
 
   return result;
+}
+
+Json::Value RunOptions::toJSON() const {
+  return getImpl<detail::RunOptions_Impl>()->toJSON();
 }
 
 std::string RunOptions::string() const {

--- a/src/utilities/filetypes/RunOptions.hpp
+++ b/src/utilities/filetypes/RunOptions.hpp
@@ -11,9 +11,7 @@
 #include "../core/Logger.hpp"
 #include "../core/Deprecated.hpp"
 
-namespace Json {
-class Value;
-}
+#include <json/json.h>
 
 namespace openstudio {
 
@@ -28,15 +26,23 @@ namespace detail {
 class UTILITIES_API CustomOutputAdapter
 {
  public:
-  CustomOutputAdapter(const std::string& customFileName, const std::string& className, const std::string& options);
+  // Couldn't add both ctors, it's ambiguous... so retaining existing as a static factory fromString
+  static CustomOutputAdapter fromString(std::string customFileName, std::string className, const std::string& options);
+  explicit CustomOutputAdapter(std::string customFileName, std::string className, Json::Value options = Json::nullValue);
+
   std::string customFileName() const;
   std::string className() const;
   std::string options() const;
+  Json::Value optionsJSON() const;
+
+  Json::Value toJSON() const;
 
  private:
+  REGISTER_LOGGER("openstudio.CustomOutputAdapter");
+
   std::string m_customFileName;
   std::string m_className;
-  std::string m_options;
+  Json::Value m_options;
 };
 
 /** Base class for defining a run options for a OpenStudio Workflow. */
@@ -50,6 +56,8 @@ class UTILITIES_API RunOptions
 
   /// Construct from JSON formatted string
   static boost::optional<RunOptions> fromString(const std::string& s);
+
+  Json::Value toJSON() const;
 
   /// Serialize to JSON formatted string
   std::string string() const;

--- a/src/utilities/filetypes/RunOptions_Impl.hpp
+++ b/src/utilities/filetypes/RunOptions_Impl.hpp
@@ -28,6 +28,7 @@ namespace detail {
    public:
     RunOptions_Impl() = default;
 
+    Json::Value toJSON() const;
     std::string string() const;
 
     bool debug() const;

--- a/src/utilities/filetypes/StandardsJSON.cpp
+++ b/src/utilities/filetypes/StandardsJSON.cpp
@@ -9,6 +9,9 @@
 #include "../core/Json.hpp"
 #include <json/json.h>
 
+#include <memory>
+#include <utility>
+
 namespace openstudio {
 namespace detail {
 
@@ -70,15 +73,14 @@ namespace detail {
     return true;
   }
 
-  std::string StandardsJSON_Impl::string() const {
-    Json::StreamWriterBuilder wbuilder;
-    const std::string output = Json::writeString(wbuilder, m_standardsRoot);
-    return output;
+  Json::Value StandardsJSON_Impl::toJSON() const {
+    return m_standardsRoot;
   }
 
-  StandardsJSON StandardsJSON_Impl::clone() const {
-    StandardsJSON result(this->string());
-    return result;
+  std::string StandardsJSON_Impl::string() const {
+    const Json::StreamWriterBuilder wbuilder;
+    std::string output = Json::writeString(wbuilder, m_standardsRoot);
+    return output;
   }
 
   boost::optional<Json::Value> StandardsJSON_Impl::getPrimaryKey(const std::string& primaryKey) const {
@@ -97,11 +99,11 @@ namespace detail {
 
 }  // namespace detail
 
-StandardsJSON::StandardsJSON() : m_impl(std::shared_ptr<detail::StandardsJSON_Impl>(new detail::StandardsJSON_Impl())) {}
+StandardsJSON::StandardsJSON() : m_impl(std::make_shared<detail::StandardsJSON_Impl>()) {}
 
-StandardsJSON::StandardsJSON(const std::string& s) : m_impl(std::shared_ptr<detail::StandardsJSON_Impl>(new detail::StandardsJSON_Impl(s))) {}
+StandardsJSON::StandardsJSON(const std::string& s) : m_impl(std::make_shared<detail::StandardsJSON_Impl>(s)) {}
 
-StandardsJSON::StandardsJSON(std::shared_ptr<detail::StandardsJSON_Impl> impl) : m_impl(impl) {}
+StandardsJSON::StandardsJSON(std::shared_ptr<detail::StandardsJSON_Impl> impl) : m_impl(std::move(impl)) {}
 
 boost::optional<StandardsJSON> StandardsJSON::load(const std::string& s) {
   boost::optional<StandardsJSON> result;
@@ -112,12 +114,16 @@ boost::optional<StandardsJSON> StandardsJSON::load(const std::string& s) {
   return result;
 }
 
+Json::Value StandardsJSON::toJSON() const {
+  return getImpl<detail::StandardsJSON_Impl>()->toJSON();
+}
+
 std::string StandardsJSON::string() const {
   return getImpl<detail::StandardsJSON_Impl>()->string();
 }
 
 StandardsJSON StandardsJSON::clone() const {
-  return getImpl<detail::StandardsJSON_Impl>()->clone();
+  return {std::make_shared<detail::StandardsJSON_Impl>(*m_impl)};
 }
 
 boost::optional<Json::Value> StandardsJSON::getPrimaryKey(const std::string& primaryKey) const {

--- a/src/utilities/filetypes/StandardsJSON.hpp
+++ b/src/utilities/filetypes/StandardsJSON.hpp
@@ -33,6 +33,8 @@ class UTILITIES_API StandardsJSON
   /** Clones this StandardsJSON into a separate one. */
   StandardsJSON clone() const;
 
+  Json::Value toJSON() const;
+
   /** Get the json as a string. */
   std::string string() const;
 

--- a/src/utilities/filetypes/StandardsJSON_Impl.hpp
+++ b/src/utilities/filetypes/StandardsJSON_Impl.hpp
@@ -28,7 +28,7 @@ namespace detail {
 
     StandardsJSON_Impl(const std::string& s);
 
-    StandardsJSON clone() const;
+    Json::Value toJSON() const;
 
     std::string string() const;
 

--- a/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/src/utilities/filetypes/WorkflowJSON.cpp
@@ -125,7 +125,7 @@ namespace detail {
     Json::StreamWriterBuilder wbuilder;
     // mimic the old StyledWriter behavior:
     wbuilder["indentation"] = "   ";
-    std::string result = Json::writeString(wbuilder, toJSON());
+    std::string result = Json::writeString(wbuilder, toJSON(includeHash));
 
     return result;
   }

--- a/src/utilities/filetypes/WorkflowJSON.hpp
+++ b/src/utilities/filetypes/WorkflowJSON.hpp
@@ -50,6 +50,8 @@ class UTILITIES_API WorkflowJSON
   /** Attempt to load a WorkflowJSON from path */
   static boost::optional<WorkflowJSON> load(const openstudio::path& p);
 
+  Json::Value toJSON(bool includeHash = true) const;
+
   /** Get the workflow as a string. */
   std::string string(bool includeHash = true) const;
 

--- a/src/utilities/filetypes/WorkflowJSON_Impl.hpp
+++ b/src/utilities/filetypes/WorkflowJSON_Impl.hpp
@@ -34,7 +34,11 @@ namespace detail {
 
     WorkflowJSON_Impl(const openstudio::path& p);
 
+    // Note: I'm keeping this one because I don't want to bother writting the copy/move constructors and assignment operators to handle the connection
+    // of the nano signals
     WorkflowJSON clone() const;
+
+    Json::Value toJSON(bool includeHash = true) const;
 
     std::string string(bool includeHash = true) const;
 

--- a/src/utilities/filetypes/WorkflowStep.cpp
+++ b/src/utilities/filetypes/WorkflowStep.cpp
@@ -17,6 +17,15 @@ namespace detail {
     return m_result;
   }
 
+  std::string WorkflowStep_Impl::string() const {
+    Json::StreamWriterBuilder wbuilder;
+    // mimic the old StyledWriter behavior:
+    wbuilder["indentation"] = "   ";
+    std::string resultString = Json::writeString(wbuilder, toJSON());
+
+    return resultString;
+  }
+
   void WorkflowStep_Impl::setResult(const WorkflowStepResult& result) {
     m_result = result;
     onUpdate();
@@ -33,27 +42,24 @@ namespace detail {
 
   MeasureStep_Impl::MeasureStep_Impl(const std::string& measureDirName) : m_measureDirName(measureDirName) {}
 
-  std::string MeasureStep_Impl::string() const {
-    Json::Value result;
-    result["measure_dir_name"] = m_measureDirName;
+  Json::Value MeasureStep_Impl::toJSON() const {
+    Json::Value root;
+    root["measure_dir_name"] = m_measureDirName;
 
     if (m_name) {
-      result["name"] = m_name.get();
+      root["name"] = m_name.get();
     }
 
     if (m_description) {
-      result["description"] = m_description.get();
+      root["description"] = m_description.get();
     }
 
     if (m_modelerDescription) {
-      result["modeler_description"] = m_modelerDescription.get();
+      root["modeler_description"] = m_modelerDescription.get();
     }
 
     Json::Value arguments(Json::objectValue);
-    for (const auto& argument : m_arguments) {
-      std::string name = argument.first;
-      Variant value = argument.second;
-
+    for (const auto& [name, value] : m_arguments) {
       if (value.variantType() == VariantType::String) {
         arguments[name] = value.valueAsString();
       } else if (value.variantType() == VariantType::Double) {
@@ -64,30 +70,13 @@ namespace detail {
         arguments[name] = value.valueAsBoolean();
       }
     }
-    result["arguments"] = arguments;
+    root["arguments"] = arguments;
 
-    boost::optional<WorkflowStepResult> workflowStepResult = this->result();
-    if (workflowStepResult) {
-
-      // We let it fail but with a warning (this shouldn't ever happen really)
-      Json::CharReaderBuilder rbuilder;
-      std::istringstream ss(workflowStepResult->string());
-      std::string formattedErrors;
-      Json::Value value;
-      bool parsingSuccessful = Json::parseFromStream(rbuilder, ss, &value, &formattedErrors);
-      if (parsingSuccessful) {
-        result["result"] = value;
-      } else {
-        LOG(Warn, "Couldn't parse workflowStepResult s='" << workflowStepResult->string() << "'. Error: '" << formattedErrors << "'.");
-      }
+    if (boost::optional<WorkflowStepResult> workflowStepResult_ = this->result()) {
+      root["result"] = workflowStepResult_->toJSON();
     }
 
-    Json::StreamWriterBuilder wbuilder;
-    // mimic the old StyledWriter behavior:
-    wbuilder["indentation"] = "   ";
-    std::string resultString = Json::writeString(wbuilder, result);
-
-    return resultString;
+    return root;
   }
 
   std::string MeasureStep_Impl::measureDirName() const {
@@ -264,6 +253,10 @@ boost::optional<WorkflowStep> WorkflowStep::fromString(const std::string& s) {
 
 std::string WorkflowStep::string() const {
   return getImpl<detail::WorkflowStep_Impl>()->string();
+}
+
+Json::Value WorkflowStep::toJSON() const {
+  return getImpl<detail::WorkflowStep_Impl>()->toJSON();
 }
 
 boost::optional<WorkflowStepResult> WorkflowStep::result() const {

--- a/src/utilities/filetypes/WorkflowStep.hpp
+++ b/src/utilities/filetypes/WorkflowStep.hpp
@@ -35,6 +35,8 @@ class UTILITIES_API WorkflowStep
   /// Serialize to JSON formatted string
   std::string string() const;
 
+  Json::Value toJSON() const;
+
   /// Returns the optional WorkflowStepResult
   boost::optional<WorkflowStepResult> result() const;
 

--- a/src/utilities/filetypes/WorkflowStepResult.cpp
+++ b/src/utilities/filetypes/WorkflowStepResult.cpp
@@ -17,33 +17,36 @@ namespace detail {
 
   WorkflowStepValue_Impl::WorkflowStepValue_Impl(const std::string& name, const Variant& value) : m_name(name), m_value(value) {}
 
-  std::string WorkflowStepValue_Impl::string() const {
-    Json::Value value(Json::objectValue);
-    value["name"] = m_name;
+  Json::Value WorkflowStepValue_Impl::toJSON() const {
+    Json::Value root(Json::objectValue);
+    root["name"] = m_name;
 
     if (m_displayName) {
-      value["display_name"] = *m_displayName;
+      root["display_name"] = *m_displayName;
     }
 
     if (m_units) {
-      value["units"] = *m_units;
+      root["units"] = *m_units;
     }
 
     if (m_value.variantType() == VariantType::String) {
-      value["value"] = m_value.valueAsString();
+      root["value"] = m_value.valueAsString();
     } else if (m_value.variantType() == VariantType::Double) {
-      value["value"] = m_value.valueAsDouble();
+      root["value"] = m_value.valueAsDouble();
     } else if (m_value.variantType() == VariantType::Integer) {
-      value["value"] = m_value.valueAsInteger();
+      root["value"] = m_value.valueAsInteger();
     } else if (m_value.variantType() == VariantType::Boolean) {
-      value["value"] = m_value.valueAsBoolean();
+      root["value"] = m_value.valueAsBoolean();
     }
+    return root;
+  }
 
+  std::string WorkflowStepValue_Impl::string() const {
     // Write to string
     Json::StreamWriterBuilder wbuilder;
     // mimic the old StyledWriter behavior:
     wbuilder["indentation"] = "   ";
-    std::string result = Json::writeString(wbuilder, value);
+    std::string result = Json::writeString(wbuilder, toJSON());
 
     return result;
   }
@@ -109,69 +112,70 @@ namespace detail {
 
   WorkflowStepResult_Impl::WorkflowStepResult_Impl() = default;
 
-  std::string WorkflowStepResult_Impl::string() const {
-    Json::Value value(Json::objectValue);
+  Json::Value WorkflowStepResult_Impl::toJSON() const {
+
+    Json::Value root(Json::objectValue);
     bool complete = false;
 
     if (startedAt()) {
-      value["started_at"] = startedAt()->toISO8601();
+      root["started_at"] = startedAt()->toISO8601();
     }
 
     if (completedAt()) {
       complete = true;
-      value["completed_at"] = completedAt()->toISO8601();
+      root["completed_at"] = completedAt()->toISO8601();
     }
 
     if (m_measureType) {
-      value["measure_type"] = m_measureType->valueName();
+      root["measure_type"] = m_measureType->valueName();
     }
 
     if (m_measureName) {
-      value["measure_name"] = m_measureName.get();
+      root["measure_name"] = m_measureName.get();
     }
 
     if (m_measureId) {
-      value["measure_uid"] = m_measureId.get();
+      root["measure_uid"] = m_measureId.get();
     }
 
     if (m_measureVersionId) {
-      value["measure_version_id"] = m_measureVersionId.get();
+      root["measure_version_id"] = m_measureVersionId.get();
     }
 
     if (m_measureVersionModified) {
-      value["measure_version_modified"] = m_measureVersionModified.get();
+      root["measure_version_modified"] = m_measureVersionModified.get();
     }
 
     if (m_measureXmlChecksum) {
-      value["measure_xml_checksum"] = m_measureXmlChecksum.get();
+      root["measure_xml_checksum"] = m_measureXmlChecksum.get();
     }
 
     if (m_measureClassName) {
-      value["measure_class_name"] = m_measureClassName.get();
+      root["measure_class_name"] = m_measureClassName.get();
     }
 
     if (m_measureDisplayName) {
-      value["measure_display_name"] = m_measureDisplayName.get();
+      root["measure_display_name"] = m_measureDisplayName.get();
     }
 
     if (m_measureTaxonomy) {
-      value["measure_taxonomy"] = m_measureTaxonomy.get();
+      root["measure_taxonomy"] = m_measureTaxonomy.get();
     }
 
     if (complete) {
       if (stepResult()) {
-        value["step_result"] = stepResult()->valueName();
+        root["step_result"] = stepResult()->valueName();
       } else {
         // error
       }
     }
 
     if (stepInitialCondition()) {
-      value["step_initial_condition"] = stepInitialCondition().get();
+      root["step_initial_condition"] = stepInitialCondition().get();
     }
 
     if (stepFinalCondition()) {
-      value["step_final_condition"] = stepFinalCondition().get();
+      root["step_final_condition"] = stepFinalCondition().get();
     }
 
     if (complete || (!stepErrors().empty())) {
@@ -179,7 +183,7 @@ namespace detail {
       for (const auto& stepError : stepErrors()) {
         errors.append(stepError);
       }
-      value["step_errors"] = errors;
+      root["step_errors"] = errors;
     }
 
     if (complete || (!stepWarnings().empty())) {
@@ -187,7 +191,7 @@ namespace detail {
       for (const auto& stepWarning : stepWarnings()) {
         warnings.append(stepWarning);
       }
-      value["step_warnings"] = warnings;
+      root["step_warnings"] = warnings;
     }
 
     if (complete || (!stepInfo().empty())) {
@@ -195,27 +199,15 @@ namespace detail {
       for (const auto& stepI : stepInfo()) {
         info.append(stepI);
       }
-      value["step_info"] = info;
+      root["step_info"] = info;
     }
 
     if (complete || (!stepValues().empty())) {
       Json::Value values(Json::arrayValue);
       for (const auto& stepValue : stepValues()) {
-
-        // We let it fail but with a warning (this shouldn't ever happen really)
-        Json::CharReaderBuilder rbuilder;
-        std::istringstream ss(stepValue.string());
-        std::string formattedErrors;
-        // cppcheck-suppress shadowVariable
-        Json::Value value;
-        bool parsingSuccessful = Json::parseFromStream(rbuilder, ss, &value, &formattedErrors);
-        if (parsingSuccessful) {
-          values.append(value);
-        } else {
-          LOG(Warn, "Couldn't parse WorkflowStepValue s='" << stepValue.string() << "'. Error: '" << formattedErrors << "'.");
-        }
+        values.append(stepValue.toJSON());
       }
-      value["step_values"] = values;
+      root["step_values"] = values;
     }
 
     if (complete || (!stepFiles().empty())) {
@@ -223,22 +215,26 @@ namespace detail {
       for (const auto& stepFile : stepFiles()) {
         files.append(toString(stepFile));
       }
-      value["step_files"] = files;
+      root["step_files"] = files;
     }
 
     if (stdOut()) {
-      value["stdout"] = stdOut().get();
+      root["stdout"] = stdOut().get();
     }
 
     if (stdErr()) {
-      value["stderr"] = stdErr().get();
+      root["stderr"] = stdErr().get();
     }
 
+    return root;
+  }
+
+  std::string WorkflowStepResult_Impl::string() const {
     // Write to string
     Json::StreamWriterBuilder wbuilder;
     // mimic the old StyledWriter behavior:
     wbuilder["indentation"] = "   ";
-    std::string result = Json::writeString(wbuilder, value);
+    std::string result = Json::writeString(wbuilder, toJSON());
 
     return result;
   }
@@ -697,6 +693,10 @@ std::string WorkflowStepValue::string() const {
   return getImpl<detail::WorkflowStepValue_Impl>()->string();
 }
 
+Json::Value WorkflowStepValue::toJSON() const {
+  return getImpl<detail::WorkflowStepValue_Impl>()->toJSON();
+}
+
 std::string WorkflowStepValue::name() const {
   return getImpl<detail::WorkflowStepValue_Impl>()->name();
 }
@@ -917,6 +917,10 @@ boost::optional<WorkflowStepResult> WorkflowStepResult::fromString(const std::st
 
 std::string WorkflowStepResult::string() const {
   return getImpl<detail::WorkflowStepResult_Impl>()->string();
+}
+
+Json::Value WorkflowStepResult::toJSON() const {
+  return getImpl<detail::WorkflowStepResult_Impl>()->toJSON();
 }
 
 boost::optional<DateTime> WorkflowStepResult::startedAt() const {

--- a/src/utilities/filetypes/WorkflowStepResult.hpp
+++ b/src/utilities/filetypes/WorkflowStepResult.hpp
@@ -13,6 +13,10 @@
 #include "../core/Path.hpp"
 #include "../data/Variant.hpp"
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 
 namespace detail {
@@ -66,6 +70,8 @@ class UTILITIES_API WorkflowStepValue
 
   /// Construct from JSON formatted string
   static boost::optional<WorkflowStepValue> fromString(const std::string& s);
+
+  Json::Value toJSON() const;
 
   /// Serialize to JSON formatted string
   std::string string() const;
@@ -146,6 +152,8 @@ class UTILITIES_API WorkflowStepResult
 
   /// Construct from JSON formatted string
   static boost::optional<WorkflowStepResult> fromString(const std::string& s);
+
+  Json::Value toJSON() const;
 
   /// Serialize to JSON formatted string
   std::string string() const;

--- a/src/utilities/filetypes/WorkflowStepResult_Impl.hpp
+++ b/src/utilities/filetypes/WorkflowStepResult_Impl.hpp
@@ -15,6 +15,10 @@
 #include "../time/DateTime.hpp"
 #include "../bcl/BCLMeasure.hpp"
 
+namespace Json {
+class Value;
+}
+
 namespace openstudio {
 namespace detail {
 
@@ -22,6 +26,8 @@ namespace detail {
   {
    public:
     WorkflowStepValue_Impl(const std::string& name, const Variant& value);
+
+    Json::Value toJSON() const;
 
     std::string string() const;
 
@@ -74,6 +80,8 @@ namespace detail {
   {
    public:
     WorkflowStepResult_Impl();
+
+    Json::Value toJSON() const;
 
     std::string string() const;
 

--- a/src/utilities/filetypes/WorkflowStep_Impl.hpp
+++ b/src/utilities/filetypes/WorkflowStep_Impl.hpp
@@ -29,7 +29,8 @@ namespace detail {
 
     virtual ~WorkflowStep_Impl() = default;
 
-    virtual std::string string() const = 0;
+    std::string string() const;
+    virtual Json::Value toJSON() const = 0;
 
     boost::optional<WorkflowStepResult> result() const;
 
@@ -55,7 +56,7 @@ namespace detail {
    public:
     MeasureStep_Impl(const std::string& measureDirName);
 
-    virtual std::string string() const override;
+    virtual Json::Value toJSON() const override;
 
     std::string measureDirName() const;
     bool setMeasureDirName(const std::string& measureDirName);

--- a/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
+++ b/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
@@ -1050,7 +1050,7 @@ TEST(Filetypes, RunOptions) {
 
   EXPECT_FALSE(workflow.runOptions());
 
-  CustomOutputAdapter adapter("my_ruby_file.rb", "MyOutputAdapter", "{}");
+  CustomOutputAdapter adapter("my_ruby_file.rb", "MyOutputAdapter");
 
   RunOptions options;
   options.setDebug(true);
@@ -1063,6 +1063,8 @@ TEST(Filetypes, RunOptions) {
   ASSERT_TRUE(workflow.runOptions()->customOutputAdapter());
   EXPECT_EQ("my_ruby_file.rb", workflow.runOptions()->customOutputAdapter()->customFileName());
   EXPECT_EQ("MyOutputAdapter", workflow.runOptions()->customOutputAdapter()->className());
+  EXPECT_TRUE(workflow.runOptions()->customOutputAdapter()->options().empty());
+  EXPECT_TRUE(workflow.runOptions()->customOutputAdapter()->optionsJSON().isNull());
 
   std::string s = workflow.string();
 


### PR DESCRIPTION
Pull request overview
---------------------

- Converts the Json::Value
    - Ruby: to a hash, with symbols as keys (not sure that's what we really want or not)
    - Python: a dict.
    - CSharp: ignored (for now at least) 

Context: As part of the rewrite of Measure Manager to C++, I'm going to be using Json::Value outputs a lot more than currently. I'm just trying to isolate changes for easier review.

Test code:

ruby:

```shell
Products/openstudio labs -e "m = OpenStudio::Model::Model.new; ft = OpenStudio::EnergyPlus::ForwardTranslator.new; ft.setExcludeLCCObjects(true); w = ft.translateModel(m); d = OpenStudio::EPJSON::toJSON(w); puts d.class; require 'json'; puts JSON.pretty_generate(d)"
```

python:

```shell
Products/openstudio labs -c "m = openstudio.model.Model(); z = openstudio.model.ThermalZone(m); ft = openstudio.energyplus.ForwardTranslator(); ft.setExcludeLCCObjects(True); w = ft.translateModel(m); d = openstudio.epjson.toJSON(w); print(type(d)); import json; print(json.dumps(d, indent=2))"
```


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
