### PR TITLE
More detailed data documentation

### DIFF
--- a/src/utilities/mainpage.hpp
+++ b/src/utilities/mainpage.hpp
@@ -57,8 +57,11 @@ namespace openstudio {
  *
  *  Structures for storing data such as \link Vector.hpp vectors\endlink,
  *  \link Matrix.hpp matrices\endlink, and \link TimeSeries time series\endlink. The Attribute
- *  class is used for reporting measures in particular; class EndUses and the enumeration classes in
- *  DataEnums.hpp are also of interest.
+ *  class provides a way for storing data additional values attached to objects,
+ *  and is useful for reporting measures in particular. EndUses and associated enumeration
+ *  classes EndUseType, EndUseCategoryType, and EndUseFuelType are helpful to break out energy use in reporting.
+ *  FuelType, AppGFuelType, and ComponentType are useful to determine fuel and component sources
+ *  for standards code. These and other enumerations are listed in DataEnums.hpp.
  *
  *  \section filetypes_sec Filetypes
  *


### PR DESCRIPTION
Fixes #4947 

This is a minor change to the data paragraph in the mainpage documentation. It makes loose reference to the DataEnums.hpp, but doesn't link to some important data enumerations,

The links to Vector.hpp, Matrix.hpp, and DataEnums.hpp appear broken, and this PR does not fix those.

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
