### PR TITLE
CoilHeatingWaterToAirHeatPumpEquationFit: new Part Load Fraction Correlation Curve field

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -20106,10 +20106,16 @@ OS:Coil:Heating:WaterToAirHeatPump:EquationFit,
        \required-field
        \type object-list
        \object-list QuadvariateFunctions
-  A8;  \field Heating Power Consumption Curve Name
+  A8,  \field Heating Power Consumption Curve Name
        \required-field
        \type object-list
        \object-list QuadvariateFunctions
+  A9;  \field Part Load Fraction Correlation Curve
+       \note quadratic curve = a + b*PLR + c*PLR**2
+       \note cubic curve = a + b*PLR + c*PLR**2 + d*PLR**3
+       \note PLR = part load ratio (heat load/steady state capacity)
+       \type object-list
+       \object-list UnivariateFunctions
 
 OS:Coil:Heating:DX:MultiSpeed,
        \extensible:1

--- a/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateCoilHeatingWaterToAirHeatPumpEquationFit.cpp
@@ -12,6 +12,8 @@
 #include "../../model/CoilHeatingWaterToAirHeatPumpEquationFit.hpp"
 #include "../../model/CoilHeatingWaterToAirHeatPumpEquationFit_Impl.hpp"
 #include "../../model/CurveQuadLinear.hpp"
+#include "../../model/Curve.hpp"
+#include "../../model/Curve_Impl.hpp"
 
 #include "../../utilities/core/Logger.hpp"
 #include "../../utilities/core/Assert.hpp"
@@ -121,6 +123,13 @@ namespace energyplus {
       auto curve = modelObject.heatingPowerConsumptionCurve();
       if (auto _curve = translateAndMapModelObject(curve)) {
         idfObject.setString(Coil_Heating_WaterToAirHeatPump_EquationFitFields::HeatingPowerConsumptionCurveName, _curve->nameString());
+      }
+    }
+
+    // Part Load Fraction Correlation Curve Name
+    if (auto optCurve = modelObject.partLoadFractionCorrelationCurve()) {
+      if (auto _curve = translateAndMapModelObject(optCurve.get())) {
+        idfObject.setString(Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurveName, _curve->name().get());
       }
     }
 

--- a/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
+++ b/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
@@ -20,6 +20,7 @@
 #include "../../model/PortList.hpp"
 #include "../../model/Node.hpp"
 #include "../../model/PlantLoop.hpp"
+#include "../../model/CurveQuadratic.hpp"
 
 #include <utilities/idd/ZoneHVAC_WaterToAirHeatPump_FieldEnums.hxx>
 #include <utilities/idd/Coil_Cooling_WaterToAirHeatPump_EquationFit_FieldEnums.hxx>
@@ -49,6 +50,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ZoneHVACWaterToAirHeatPump) {
   sch.setName("HP AvailSch");
   CoilHeatingWaterToAirHeatPumpEquationFit htg_coil(m);
   htg_coil.setName("HP HC");
+  CurveQuadratic partLoadFractionCorrelationCurve(model);
+  htg_coil.setPartLoadFractionCorrelationCurve(partLoadFractionCorrelationCurve);
   CoilCoolingWaterToAirHeatPumpEquationFit clg_coil(m);
   clg_coil.setName("HP CC");
   FanOnOff fan(m);
@@ -294,6 +297,10 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ZoneHVACWaterToAirHeatPump) {
         idf_heatingCoil.getTarget(Coil_Heating_WaterToAirHeatPump_EquationFitFields::HeatingPowerConsumptionCurveName));
       ASSERT_TRUE(woCurve2);
       EXPECT_EQ(woCurve2->iddObject().type(), IddObjectType::Curve_QuadLinear);
+      boost::optional<WorkspaceObject> woCurve3(
+        idf_heatingCoil.getTarget(Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurveName));
+      ASSERT_TRUE(woCurve3);
+      EXPECT_EQ(woCurve3->iddObject().type(), IddObjectType::Curve_Quadratic);
     }
 
     {

--- a/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
+++ b/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
@@ -50,7 +50,7 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ZoneHVACWaterToAirHeatPump) {
   sch.setName("HP AvailSch");
   CoilHeatingWaterToAirHeatPumpEquationFit htg_coil(m);
   htg_coil.setName("HP HC");
-  CurveQuadratic partLoadFractionCorrelationCurve(model);
+  CurveQuadratic partLoadFractionCorrelationCurve(m);
   htg_coil.setPartLoadFractionCorrelationCurve(partLoadFractionCorrelationCurve);
   CoilCoolingWaterToAirHeatPumpEquationFit clg_coil(m);
   clg_coil.setName("HP CC");

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
@@ -759,15 +759,15 @@ namespace model {
   }
 
   boost::optional<Curve> CoilHeatingWaterToAirHeatPumpEquationFit::partLoadFractionCorrelationCurve() const {
-    return getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->partLoadFractionCorrelationCurve();
+    return getImpl<detail::CoilHeatingWaterToAirHeatPumpEquationFit_Impl>()->partLoadFractionCorrelationCurve();
   }
 
   bool CoilHeatingWaterToAirHeatPumpEquationFit::setPartLoadFractionCorrelationCurve(const Curve& curve) {
-    return getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->setPartLoadFractionCorrelationCurve(curve);
+    return getImpl<detail::CoilHeatingWaterToAirHeatPumpEquationFit_Impl>()->setPartLoadFractionCorrelationCurve(curve);
   }
 
   void CoilHeatingWaterToAirHeatPumpEquationFit::resetPartLoadFractionCorrelationCurve() {
-    getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->resetPartLoadFractionCorrelationCurve();
+    getImpl<detail::CoilHeatingWaterToAirHeatPumpEquationFit_Impl>()->resetPartLoadFractionCorrelationCurve();
   }
 
   /// @endcond

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
@@ -16,6 +16,8 @@
 #include "Model.hpp"
 #include "CurveQuadLinear.hpp"
 #include "CurveQuadLinear_Impl.hpp"
+#include "Curve.hpp"
+#include "Curve_Impl.hpp"
 
 #include <utilities/idd/OS_Coil_Heating_WaterToAirHeatPump_EquationFit_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
@@ -323,6 +325,21 @@ namespace model {
       bool result =
         setPointer(OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::HeatingPowerConsumptionCurveName, heatingPowerConsumptionCurve.handle());
       return result;
+    }
+
+    boost::optional<Curve> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::partLoadFractionCorrelationCurve() const {
+      return getObject<ModelObject>().getModelObjectTarget<Curve>(OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurve);
+    }
+
+    bool CoilHeatingWaterToAirHeatPumpEquationFit_Impl::setPartLoadFractionCorrelationCurve(const Curve& curve) {
+      bool result = setPointer(OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurve, curve.handle());
+      OS_ASSERT(result);
+      return result;
+    }
+
+    void CoilHeatingWaterToAirHeatPumpEquationFit_Impl::resetPartLoadFractionCorrelationCurve() {
+      bool result = setString(OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurve, "");
+      OS_ASSERT(result);
     }
 
     boost::optional<double> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::autosizedRatedAirFlowRate() const {
@@ -738,6 +755,18 @@ namespace model {
     DEPRECATED_AT_MSG(3, 2, 0, "Use CoilHeatingWaterToAirHeatPumpEquationFit::heatingPowerConsumptionCurve().setCoefficient5z(double) instead.");
     CurveQuadLinear curve = getImpl<detail::CoilHeatingWaterToAirHeatPumpEquationFit_Impl>()->heatingPowerConsumptionCurve();
     return curve.setCoefficient5z(heatingPowerConsumptionCoefficient5);
+  }
+
+  boost::optional<Curve> CoilHeatingWaterToAirHeatPumpEquationFit::partLoadFractionCorrelationCurve() const {
+    return getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->partLoadFractionCorrelationCurve();
+  }
+
+  bool CoilHeatingWaterToAirHeatPumpEquationFit::setPartLoadFractionCorrelationCurve(const Curve& curve) {
+    return getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->setPartLoadFractionCorrelationCurve(curve);
+  }
+
+  void CoilHeatingWaterToAirHeatPumpEquationFit::resetPartLoadFractionCorrelationCurve() {
+    getImpl<detail::CoilCoolingDXCurveFitSpeed_Impl>()->resetPartLoadFractionCorrelationCurve();
   }
 
   /// @endcond

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.cpp
@@ -328,7 +328,8 @@ namespace model {
     }
 
     boost::optional<Curve> CoilHeatingWaterToAirHeatPumpEquationFit_Impl::partLoadFractionCorrelationCurve() const {
-      return getObject<ModelObject>().getModelObjectTarget<Curve>(OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurve);
+      return getObject<ModelObject>().getModelObjectTarget<Curve>(
+        OS_Coil_Heating_WaterToAirHeatPump_EquationFitFields::PartLoadFractionCorrelationCurve);
     }
 
     bool CoilHeatingWaterToAirHeatPumpEquationFit_Impl::setPartLoadFractionCorrelationCurve(const Curve& curve) {

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.hpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit.hpp
@@ -16,6 +16,7 @@ namespace openstudio {
 namespace model {
 
   class CurveQuadLinear;
+  class Curve;
 
   namespace detail {
 
@@ -94,6 +95,8 @@ namespace model {
     OS_DEPRECATED(3, 2, 0) double heatingPowerConsumptionCoefficient4() const;
     OS_DEPRECATED(3, 2, 0) double heatingPowerConsumptionCoefficient5() const;
 
+    boost::optional<Curve> partLoadFractionCorrelationCurve() const;
+
     //@}
     /** @name Setters */
     //@{
@@ -147,6 +150,10 @@ namespace model {
     OS_DEPRECATED(3, 2, 0) bool setHeatingPowerConsumptionCoefficient3(double heatingPowerConsumptionCoefficient3);
     OS_DEPRECATED(3, 2, 0) bool setHeatingPowerConsumptionCoefficient4(double heatingPowerConsumptionCoefficient4);
     OS_DEPRECATED(3, 2, 0) bool setHeatingPowerConsumptionCoefficient5(double heatingPowerConsumptionCoefficient5);
+
+    bool setPartLoadFractionCorrelationCurve(const Curve& curve);
+
+    void resetPartLoadFractionCorrelationCurve();
 
     //@}
     /** @name Other */

--- a/src/model/CoilHeatingWaterToAirHeatPumpEquationFit_Impl.hpp
+++ b/src/model/CoilHeatingWaterToAirHeatPumpEquationFit_Impl.hpp
@@ -13,6 +13,7 @@ namespace openstudio {
 namespace model {
 
   class CurveQuadLinear;
+  class Curve;
 
   namespace detail {
 
@@ -91,6 +92,8 @@ namespace model {
 
       CurveQuadLinear heatingPowerConsumptionCurve() const;
 
+      boost::optional<Curve> partLoadFractionCorrelationCurve() const;
+
       boost::optional<double> autosizedRatedAirFlowRate() const;
 
       boost::optional<double> autosizedRatedWaterFlowRate() const;
@@ -142,6 +145,10 @@ namespace model {
       bool setHeatingCapacityCurve(const CurveQuadLinear& heatingCapacityCurve);
 
       bool setHeatingPowerConsumptionCurve(const CurveQuadLinear& heatingPowerConsumptionCurve);
+
+      bool setPartLoadFractionCorrelationCurve(const Curve& curve);
+
+      void resetPartLoadFractionCorrelationCurve();
 
       //@}
       /** @name Other */

--- a/src/model/test/CoilHeatingWaterToAirHeatPumpEquationFit_GTest.cpp
+++ b/src/model/test/CoilHeatingWaterToAirHeatPumpEquationFit_GTest.cpp
@@ -9,6 +9,8 @@
 
 #include "../CoilHeatingWaterToAirHeatPumpEquationFit.hpp"
 #include "../CoilHeatingWaterToAirHeatPumpEquationFit_Impl.hpp"
+#include "../CurveQuadratic.hpp"
+#include "../CurveQuadratic_Impl.hpp"
 
 using namespace openstudio;
 using namespace openstudio::model;

--- a/src/model/test/CoilHeatingWaterToAirHeatPumpEquationFit_GTest.cpp
+++ b/src/model/test/CoilHeatingWaterToAirHeatPumpEquationFit_GTest.cpp
@@ -79,4 +79,12 @@ TEST_F(ModelFixture, CoilHeatingWaterToAirHeatPumpEquationFit_Test) {
   EXPECT_EQ(1.0, coilHeatingWaterToAirHPEquationFit.ratioofRatedHeatingCapacitytoRatedCoolingCapacity());
   EXPECT_TRUE(coilHeatingWaterToAirHPEquationFit.setRatioofRatedHeatingCapacitytoRatedCoolingCapacity(1.2));
   EXPECT_EQ(1.2, coilHeatingWaterToAirHPEquationFit.ratioofRatedHeatingCapacitytoRatedCoolingCapacity());
+
+  // test part load fraction correlation curve
+  EXPECT_FALSE(coilHeatingWaterToAirHPEquationFit.partLoadFractionCorrelationCurve());
+  CurveQuadratic partLoadFractionCorrelationCurve(model);
+  coilHeatingWaterToAirHPEquationFit.setPartLoadFractionCorrelationCurve(partLoadFractionCorrelationCurve);
+  EXPECT_TRUE(coilHeatingWaterToAirHPEquationFit.partLoadFractionCorrelationCurve());
+  coilHeatingWaterToAirHPEquationFit.resetPartLoadFractionCorrelationCurve();
+  EXPECT_FALSE(coilHeatingWaterToAirHPEquationFit.partLoadFractionCorrelationCurve());
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Support new "Part Load Fraction Correlation Curve" field for `Coil:Heating:WaterToAirHeatPump:EquationFit`.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
