### PR TITLE
Fix #4926 - WindowPropertyFrameAndDivider: "Outside Reveal Depth" not forward translated 

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateSubSurface.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateSubSurface.cpp
@@ -43,8 +43,17 @@ namespace energyplus {
 
     idfObject.setString(FenestrationSurface_DetailedFields::Name, modelObject.name().get());
 
-    openstudio::Vector3d offset(0, 0, 0);
     idfObject.clearExtensibleGroups();
+
+    openstudio::Vector3d offset(0, 0, 0);
+    boost::optional<WindowPropertyFrameAndDivider> frameAndDivider = modelObject.windowPropertyFrameAndDivider();
+    if (frameAndDivider) {
+      if (!frameAndDivider->isOutsideRevealDepthDefaulted()) {
+        offset = -frameAndDivider->outsideRevealDepth() * modelObject.outwardNormal();
+      }
+      idfObject.setString(FenestrationSurface_DetailedFields::FrameandDividerName, frameAndDivider->name().get());
+    }
+
     for (const Point3d& point : modelObject.vertices()) {
       IdfExtensibleGroup group = idfObject.pushExtensibleGroup();
       if (group.empty()) {
@@ -53,7 +62,7 @@ namespace energyplus {
         return boost::none;
       }
 
-      Point3d newPoint = point + offset;
+      const Point3d newPoint = point + offset;
 
       group.setDouble(0, newPoint.x());
       group.setDouble(1, newPoint.y());
@@ -135,14 +144,6 @@ namespace energyplus {
     boost::optional<double> viewFactortoGround = modelObject.viewFactortoGround();
     if (viewFactortoGround) {
       idfObject.setDouble(FenestrationSurface_DetailedFields::ViewFactortoGround, *viewFactortoGround);
-    }
-
-    boost::optional<WindowPropertyFrameAndDivider> frameAndDivider = modelObject.windowPropertyFrameAndDivider();
-    if (frameAndDivider) {
-      if (!frameAndDivider->isOutsideRevealDepthDefaulted()) {
-        offset = -frameAndDivider->outsideRevealDepth() * modelObject.outwardNormal();
-      }
-      idfObject.setString(FenestrationSurface_DetailedFields::FrameandDividerName, frameAndDivider->name().get());
     }
 
     if (!modelObject.isMultiplierDefaulted()) {

--- a/src/energyplus/Test/WindowPropertyFrameAndDivider_GTest.cpp
+++ b/src/energyplus/Test/WindowPropertyFrameAndDivider_GTest.cpp
@@ -90,7 +90,6 @@ TEST_F(EnergyPlusFixture, WindowPropertyFrameAndDivider) {
   EXPECT_TRUE(subSurface2.setWindowPropertyFrameAndDivider(frameAndDivider));
   ASSERT_TRUE(subSurface2.windowPropertyFrameAndDivider());
 
-  model.save("WindowPropertyFrameAndDivider.osm", true);
 
   ForwardTranslator forwardTranslator;
   auto workspace = forwardTranslator.translateModel(model);


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4926

@brgix FYI

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
