### PR TITLE
#4957 - Some copy constructors aren't declared in SWIG 

### DIFF
--- a/src/utilities/geometry/Geometry.i
+++ b/src/utilities/geometry/Geometry.i
@@ -169,6 +169,14 @@
   }
 }
 
+%extend openstudio::Surface3d {
+  std::string __str__() const {
+    std::ostringstream os;
+    os << *self;
+    return os.str();
+  }
+}
+
 %extend openstudio::Transformation {
 
   std::string __str__() const {

--- a/src/utilities/geometry/Plane.hpp
+++ b/src/utilities/geometry/Plane.hpp
@@ -33,12 +33,12 @@ class UTILITIES_API Plane
   /// throws openstudio::Exception if cannot compute plane for these points.
   Plane(const std::vector<Point3d>& points);
 
-  // Copy and move operators are implicitly declared (Rule of 1)
+  // Copy and move operators are implicitly declared (Rule of 1), but we want the copy ctor for SWIG so we have to define all of them
   // There's no need to check if the length of the normal is zero since we never allow another plane to not satisfy this condition
-  // Plane(const Plane& other) = default;
-  // Plane(Plane&& other) = default;
-  // Plane& operator=(const Plane&) = default;
-  // Plane& operator=(Plane&&) = default;
+  Plane(const Plane& other) = default;
+  Plane(Plane&& other) noexcept = default;
+  Plane& operator=(const Plane&) = default;
+  Plane& operator=(Plane&&) noexcept = default;
   // ~Plane() noexcept = default;
 
   /// get the outward normal of this plane

--- a/src/utilities/geometry/Point3d.hpp
+++ b/src/utilities/geometry/Point3d.hpp
@@ -27,11 +27,11 @@ class UTILITIES_API Point3d
   /// constructor with x, y, z
   Point3d(double x, double y, double z);
 
-  // Copy and move operators are implicitly declared
-  // Point3d(const Point3d& other) = default;
-  // Point3d(Point3d&& other) = default;
-  // Point3d& operator=(const Point3d&) = default;
-  // Point3d& operator=(Point3d&&) = default;
+  // Copy and move operators are implicitly declared, but we want the copy ctor for SWIG so we have to define all of them
+  Point3d(const Point3d& other) = default;
+  Point3d(Point3d&& other) noexcept = default;
+  Point3d& operator=(const Point3d&) = default;
+  Point3d& operator=(Point3d&&) noexcept = default;
   // ~Point3d() noexcept = default;
 
   /// get x

--- a/src/utilities/geometry/Polygon3d.hpp
+++ b/src/utilities/geometry/Polygon3d.hpp
@@ -27,11 +27,11 @@ class UTILITIES_API Polygon3d
   // Constructs a polygon with an outer path and one or more inner paths
   Polygon3d(const Point3dVector& outerPath, const Point3dVectorVector& innerPaths);
 
-  // Copy and move operators are implicitly declared (Rule of 1)
-  // Polygon3d(const Polygon3d& other) = default;
-  // Polygon3d(Polygon3d&& other) = default;
-  // Polygon3d& operator=(const Polygon3d&) = default;
-  // Polygon3d& operator=(Polygon3d&&) = default;
+  // Copy and move operators are implicitly declared (Rule of 1), but we want the copy ctor for SWIG so we have to define all of them
+  Polygon3d(const Polygon3d& other) = default;
+  Polygon3d(Polygon3d&& other) noexcept = default;
+  Polygon3d& operator=(const Polygon3d&) = default;
+  Polygon3d& operator=(Polygon3d&&) noexcept = default;
   // ~Polygon3d() noexcept = default;
 
   // Assigns an outer path for the polygon

--- a/src/utilities/geometry/Polyhedron.cpp
+++ b/src/utilities/geometry/Polyhedron.cpp
@@ -492,4 +492,8 @@ double Polyhedron::calcDivergenceTheoremVolume() const {
   return volume;
 }
 
+std::vector<Surface3d> Polyhedron::surface3ds() const {
+  return m_surfaces;
+}
+
 }  // namespace openstudio

--- a/src/utilities/geometry/Polyhedron.cpp
+++ b/src/utilities/geometry/Polyhedron.cpp
@@ -118,7 +118,7 @@ Surface3d::Surface3d(std::vector<Point3d> t_vertices, std::string t_name, size_t
       itnext = std::begin(vertices);
     }
 
-    edges.emplace_back(*it, *itnext, t_name, t_surfNum);
+    edges.emplace_back(*it, *itnext, name, surfNum);
   }
 }
 

--- a/src/utilities/geometry/Polyhedron.cpp
+++ b/src/utilities/geometry/Polyhedron.cpp
@@ -104,8 +104,8 @@ Vector3d Surface3dEdge::asVector() const {
 }
 
 std::ostream& operator<<(std::ostream& os, const Surface3dEdge& edge) {
-  os << "Surface3dEdge: start=" << edge.start() << ", end=" << edge.end() << ", count=" << edge.count()
-     << ", firstSurface=" << edge.firstSurfaceName();
+  os << "Surface3dEdge: start=" << edge.start() << ", end=" << edge.end() << ", count=" << edge.count() << ", firstSurface='"
+     << edge.firstSurfaceName() << "'";
   return os;
 }
 
@@ -120,6 +120,19 @@ Surface3d::Surface3d(std::vector<Point3d> t_vertices, std::string t_name, size_t
 
     edges.emplace_back(*it, *itnext, name, surfNum);
   }
+}
+
+std::ostream& operator<<(std::ostream& os, const Surface3d& surface3d) {
+  os << "Surface3d ";
+  if (!surface3d.name.empty()) {
+    os << "'" << surface3d.name << "' ";
+  }
+  os << "= [\n";
+  for (const auto& pt : surface3d.vertices) {
+    os << "  " << pt << ",\n";
+  }
+  os << "]";
+  return os;
 }
 
 bool Surface3d::operator<(const Surface3d& rhs) const {

--- a/src/utilities/geometry/Polyhedron.hpp
+++ b/src/utilities/geometry/Polyhedron.hpp
@@ -138,6 +138,8 @@ class UTILITIES_API Polyhedron
     * proportion of conflicted edges / total number of edges */
   std::vector<Surface3d> findSurfacesWithIncorrectOrientation() const;
 
+  std::vector<Surface3d> surface3ds() const;
+
  protected:
   void performEdgeMatching();
   void resetEdgeMatching();

--- a/src/utilities/geometry/Polyhedron.hpp
+++ b/src/utilities/geometry/Polyhedron.hpp
@@ -166,6 +166,7 @@ using PolyhedronVector = std::vector<Polyhedron>;
 
 /// ostream operator
 UTILITIES_API std::ostream& operator<<(std::ostream& os, const Surface3dEdge& edge);
+UTILITIES_API std::ostream& operator<<(std::ostream& os, const Surface3d& surface3d);
 
 }  // namespace openstudio
 

--- a/src/utilities/geometry/Transformation.hpp
+++ b/src/utilities/geometry/Transformation.hpp
@@ -35,11 +35,11 @@ class UTILITIES_API Transformation
   /// constructor from storage, asserts vector is size 16
   Transformation(const Vector& vector);
 
-  // Copy and move operators are implicitly declared (Rule of 1)
-  // Transformation(const Transformation& other) = default;
-  // Transformation(Transformation&& other) = default;
-  // Transformation& operator=(const Transformation&) = default;
-  // Transformation& operator=(Transformation&&) = default;
+  // Copy and move operators are implicitly declared (Rule of 1), but we want the copy ctor for SWIG so we have to define all of them
+  Transformation(const Transformation& other) = default;
+  Transformation(Transformation&& other) noexcept = default;
+  Transformation& operator=(const Transformation&) = default;
+  Transformation& operator=(Transformation&&) noexcept = default;
   // ~Transformation() noexcept = default;
 
   /// rotation about origin defined by axis and angle (radians)

--- a/src/utilities/geometry/Vector3d.hpp
+++ b/src/utilities/geometry/Vector3d.hpp
@@ -24,11 +24,11 @@ class UTILITIES_API Vector3d
   /// constructor with x, y, z
   Vector3d(double x, double y, double z);
 
-  // Copy and move operators are implicitly declared  (Rule of 1)
-  // Vector3d(const Vector3d& other) = default;
-  // Vector3d(Vector3d&& other) = default;
-  // Vector3d& operator=(const Vector3d&) = default;
-  // Vector3d& operator=(Vector3d&&) = default;
+  // Copy and move operators are implicitly declared  (Rule of 1), but we want the copy ctor for SWIG so we have to define all of them
+  Vector3d(const Vector3d& other) = default;
+  Vector3d(Vector3d&& other) noexcept = default;
+  Vector3d& operator=(const Vector3d&) = default;
+  Vector3d& operator=(Vector3d&&) noexcept = default;
   // ~Vector3d() noexcept = default;
 
   /// get x


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4957
 - Add a couple of convenience methods in the Polyhedron.hpp while I'm at it

**Note**: The missing swig copy ctors were never in any official release, this was only on 3.7.0-alpha, so I'm labeling as "Developer Issue"

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
