### PR TITLE
Fix issue in create_temporary_directory (affecting XMLValidator with schematron)

### DIFF
--- a/src/utilities/core/FilesystemHelpers.cpp
+++ b/src/utilities/core/FilesystemHelpers.cpp
@@ -137,16 +137,14 @@ namespace filesystem {
   }
 
   openstudio::path create_temporary_directory(const openstudio::path& basename) {
-    // making this count static/atomic so that we reduce the chance of collisions
-    // on each run of the binary. This is threadsafe, with the atomic
-    static std::atomic<unsigned int> count = 0;
-    constexpr unsigned int allowed_attempts = 1000;
-
     const auto base_temp_dir = openstudio::filesystem::temp_directory_path();
-    // std::filesystem::unique_path doesn't exist, if moving to std::filesystem, use emoveBraces(createUUID)
+    // std::filesystem::unique_path doesn't exist, if moving to std::filesystem, use removeBraces(createUUID())
     auto upath = boost::filesystem::unique_path();
     const auto temp_dir = base_temp_dir / fmt::format("{}-{}-{}-", basename.string(), upath.string(), std::time(nullptr));
 
+    // unique_path is supposed to be unique already...
+    unsigned int count = 0;
+    constexpr unsigned int allowed_attempts = 1000;
     while (count < allowed_attempts) {
       // concat number to path basename, without adding a new path element
       auto full_pathname = temp_dir;


### PR DESCRIPTION
Pull request overview
---------------------

Fix issue found in hpxml CI testing. If you try to run create_tempora…ry_directory more than 1000 times it fails...

The static std::atomic<int> was never reset to 0.

```ruby
1001.times { OpenStudio::XMLValidator.new('./HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml') }
```

```
[openstudio.XMLValidator] <-1> Saved transformed XSLT Stylesheet at '/tmp/xmlvalidation-2b1f-69c6-900c-7b06-1693932780-998/EPvalidator_stylesheet.xslt'.
[openstudio.XMLValidator] <-1> Transformed Schematron to an XSLT Stylesheet and saved it at /tmp/xmlvalidation-2b1f-69c6-900c-7b06-1693932780-998/EPvalidator_stylesheet.xslt.
[openstudio.XMLValidator] <-1> Treating schema as a Schematron, converting to an XSLT StyleSheet.
[openstudio.XMLValidator] <-1> Saved transformed XSLT Stylesheet at '/tmp/xmlvalidation-4a67-fcb1-a651-fa6d-1693932780-999/EPvalidator_stylesheet.xslt'.
[openstudio.XMLValidator] <-1> Transformed Schematron to an XSLT Stylesheet and saved it at /tmp/xmlvalidation-4a67-fcb1-a651-fa6d-1693932780-999/EPvalidator_stylesheet.xslt.
[openstudio.XMLValidator] <-1> Treating schema as a Schematron, converting to an XSLT StyleSheet.
[openstudio.XMLValidator] <2> Failed to create a temporary directory for extracting the stylesheets needed to transform the Schematron './HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml'
Traceback (most recent call last):
        8: from /usr/local/bin/irb:23:in `<main>'
        7: from /usr/local/bin/irb:23:in `load'
        6: from /usr/local/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        5: from (irb):70
        4: from (irb):70:in `times'
        3: from (irb):70:in `block in irb_binding'
        2: from (irb):70:in `new'
        1: from (irb):70:in `initialize'
RuntimeError (/srv/jenkins/openstudio/git/nightly/ubuntu_2004/src/utilities/xml/XMLValidator.cpp@180 : Failed to create a temporary directory for extracting the stylesheets needed to transform the Schematron './HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.xml')
```

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
