### PR TITLE
ZoneHVAC:*: new Design Specification Multispeed Object fields

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -29063,13 +29063,17 @@ OS:ZoneHVAC:TerminalUnit:VariableRefrigerantFlow,
         \units C
         \required-field
         \note Supplemental heater will not operate when outdoor temperature exceeds this value.
-  A15; \field Controlling Zone or Thermostat Location
+  A15, \field Controlling Zone or Thermostat Location
        \type object-list
        \object-list ThermalZoneNames
        \note Used only for AirloopHVAC equipment on a main branch and defines zone name where thermostat is located.
        \note Not required for zone equipment. Leave blank if terminal unit is used in AirLoopHVAC:OutdoorAirSystem:EquipmentList.
        \note Required when terminal unit is used on main AirloopHVAC branch and coils are not set point controlled.
        \note When terminal unit is used in air loop and is load controlled, this zone's thermostat will control operation.
+  A16; \field Design Specification Multispeed Object Name
+       \type object-list
+       \object-list UnitarySystemPerformaceNames
+       \note The name of the performance specification object used to describe the multispeed coil.
 
 OS:ZoneHVAC:WaterToAirHeatPump,
         \min-fields 25
@@ -29236,10 +29240,14 @@ OS:ZoneHVAC:WaterToAirHeatPump,
         \note Constant results in 100% water flow regardless of compressor PLR
         \note Cycling results in water flow that matches compressor PLR
         \note ConstantOnDemand results in 100% water flow whenever the coil is on, but is 0% whenever the coil has no load
-   A26; \field Design Specification ZoneHVAC Sizing Object Name
+   A26, \field Design Specification ZoneHVAC Sizing Object Name
         \note Enter the name of a DesignSpecificationZoneHVACSizing object.
         \type object-list
         \object-list DesignSpecificationZoneHVACSizingName
+   A27; \field Design Specification Multispeed Object Name
+        \type object-list
+        \object-list UnitarySystemPerformaceNames
+        \note The name of the performance specification object used to describe the multispeed coil.
 
 OS:ZoneHVAC:UnitHeater,
        \min-fields 10

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -440,8 +440,9 @@ namespace energyplus {
 
       if (_unitarySystemPerformance && _unitarySystemPerformance->name()) {
         idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectType,
-                                _unitarySystemPerformance->iddObject().name());
-        idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName, _unitarySystemPerformance->name().get());
+                            _unitarySystemPerformance->iddObject().name());
+        idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName,
+                            _unitarySystemPerformance->name().get());
       }
     }
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -29,6 +29,8 @@
 #include "../../model/CoilCoolingDXVariableRefrigerantFlow_Impl.hpp"
 #include "../../model/CoilHeatingDXVariableRefrigerantFlow.hpp"
 #include "../../model/CoilHeatingDXVariableRefrigerantFlow_Impl.hpp"
+#include "../../model/UnitarySystemPerformanceMultispeed.hpp"
+#include "../../model/UnitarySystemPerformanceMultispeed_Impl.hpp"
 #include "../../utilities/core/Logger.hpp"
 #include "../../utilities/core/Assert.hpp"
 #include "../../utilities/math/FloatCompare.hpp"
@@ -429,6 +431,17 @@ namespace energyplus {
         if (auto zone = translateAndMapModelObject(zones.front())) {
           idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::ControllingZoneorThermostatLocation, zone->name().get());
         }
+      }
+    }
+
+    // Design Specification Multispeed Object Name
+    if (boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject = modelObject.designSpecificationMultispeedObject()) {
+      boost::optional<IdfObject> _unitarySystemPerformance = translateAndMapModelObject(designSpecificationMultispeedObject.get());
+
+      if (_unitarySystemPerformance && _unitarySystemPerformance->name()) {
+        idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectType,
+                                _unitarySystemPerformance->iddObject().name());
+        idfObject.setString(ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName, _unitarySystemPerformance->name().get());
       }
     }
 

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
@@ -27,6 +27,8 @@
 #include "../../model/CoilHeatingGas_Impl.hpp"
 #include "../../model/CoilHeatingWater.hpp"
 #include "../../model/CoilHeatingWater_Impl.hpp"
+#include "../../model/UnitarySystemPerformanceMultispeed.hpp"
+#include "../../model/UnitarySystemPerformanceMultispeed_Impl.hpp"
 #include <utilities/idd/ZoneHVAC_WaterToAirHeatPump_FieldEnums.hxx>
 #include <utilities/idd/OutdoorAir_Mixer_FieldEnums.hxx>
 #include <utilities/idd/Fan_OnOff_FieldEnums.hxx>
@@ -374,6 +376,17 @@ namespace energyplus {
     idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode, modelObject.heatPumpCoilWaterFlowMode());
 
     // TODO: field 'Design Specification ZoneHVAC Sizing' isn't implemented since the object isn't wrapped in SDK
+
+    // Design Specification Multispeed Object Name
+    if (boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject = modelObject.designSpecificationMultispeedObject()) {
+      boost::optional<IdfObject> _unitarySystemPerformance = translateAndMapModelObject(designSpecificationMultispeedObject.get());
+
+      if (_unitarySystemPerformance && _unitarySystemPerformance->name()) {
+        idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectType,
+                                _unitarySystemPerformance->iddObject().name());
+        idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName, _unitarySystemPerformance->name().get());
+      }
+    }
 
     return idfObject;
   }

--- a/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateZoneHVACWaterToAirHeatPump.cpp
@@ -383,7 +383,7 @@ namespace energyplus {
 
       if (_unitarySystemPerformance && _unitarySystemPerformance->name()) {
         idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectType,
-                                _unitarySystemPerformance->iddObject().name());
+                            _unitarySystemPerformance->iddObject().name());
         idfObject.setString(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName, _unitarySystemPerformance->name().get());
       }
     }

--- a/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
+++ b/src/energyplus/Test/ZoneHVACWaterToAirHeatPump_GTest.cpp
@@ -27,6 +27,7 @@
 #include <utilities/idd/Coil_Heating_Electric_FieldEnums.hxx>
 #include <utilities/idd/Fan_OnOff_FieldEnums.hxx>
 #include <utilities/idd/OutdoorAir_Mixer_FieldEnums.hxx>
+#include <utilities/idd/UnitarySystemPerformance_Multispeed_FieldEnums.hxx>
 
 #include <utilities/idd/IddEnums.hxx>
 #include "../../utilities/idf/IdfObject.hpp"
@@ -269,6 +270,8 @@ TEST_F(EnergyPlusFixture, ForwardTranslator_ZoneHVACWaterToAirHeatPump) {
     EXPECT_TRUE(idf_hp.isEmpty(ZoneHVAC_WaterToAirHeatPumpFields::AvailabilityManagerListName));
     EXPECT_EQ("ConstantOnDemand", idf_hp.getString(ZoneHVAC_WaterToAirHeatPumpFields::HeatPumpCoilWaterFlowMode).get());
     EXPECT_TRUE(idf_hp.isEmpty(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationZoneHVACSizingObjectName));
+    EXPECT_TRUE(idf_hp.isEmpty(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectType));
+    EXPECT_TRUE(idf_hp.isEmpty(ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName));
 
     {
       ASSERT_TRUE(idf_hp.getTarget(ZoneHVAC_WaterToAirHeatPumpFields::HeatingCoilName));

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -38,6 +38,8 @@
 #include "AirConditionerVariableRefrigerantFlowFluidTemperatureControl_Impl.hpp"
 #include "AirConditionerVariableRefrigerantFlowFluidTemperatureControlHR.hpp"
 #include "AirConditionerVariableRefrigerantFlowFluidTemperatureControlHR_Impl.hpp"
+#include "UnitarySystemPerformanceMultispeed.hpp"
+#include "UnitarySystemPerformanceMultispeed_Impl.hpp"
 
 #include <utilities/idd/IddFactory.hxx>
 
@@ -581,6 +583,28 @@ namespace model {
       OS_ASSERT(result);
     }
 
+    boost::optional<UnitarySystemPerformanceMultispeed> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::designSpecificationMultispeedObject() const {
+      return getObject<ModelObject>().getModelObjectTarget<UnitarySystemPerformanceMultispeed>(
+        OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName);
+    }
+
+    bool ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::setDesignSpecificationMultispeedObject(
+      const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace) {
+      bool result(false);
+      if (unitarySystemPerformace) {
+        result = setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName, unitarySystemPerformace.get().handle());
+      } else {
+        resetDesignSpecificationMultispeedObject();
+        result = true;
+      }
+      return result;
+    }
+
+    void ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::resetDesignSpecificationMultispeedObject() {
+      bool result = setString(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName, "");
+      OS_ASSERT(result);
+    }
+
     ModelObject ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::clone(Model model) const {
       ModelObject terminalClone = ZoneHVACComponent_Impl::clone(model);
 
@@ -602,6 +626,10 @@ namespace model {
       if (auto coil = supplementalHeatingCoil()) {
         auto coilClone = coil->clone(model).cast<HVACComponent>();
         terminalClone.getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplementalHeatingCoil(coilClone);
+      }
+
+      if (auto designSpec = designSpecificationMultispeedObject()) {
+        terminalClone.setDesignSpecificationMultispeedObject(designSpec->clone(model).cast<UnitarySystemPerformanceMultispeed>());
       }
 
       // TODO Move this into base clase
@@ -628,6 +656,10 @@ namespace model {
 
       if (auto coil = supplementalHeatingCoil()) {
         result.push_back(coil.get());
+      }
+
+      if (auto designSpec = designSpecificationMultispeedObject()) {
+        result.push_back(*designSpec);
       }
 
       return result;
@@ -1332,6 +1364,18 @@ namespace model {
 
   bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement) {
     return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setSupplyAirFanPlacement(supplyAirFanPlacement);
+  }
+
+  boost::optional<UnitarySystemPerformanceMultispeed> ZoneHVACTerminalUnitVariableRefrigerantFlow::designSpecificationMultispeedObject() const {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->designSpecificationMultispeedObject();
+  }
+  
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace) {
+    return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setDesignSpecificationMultispeedObject(unitarySystemPerformace);
+  }
+
+  void ZoneHVACTerminalUnitVariableRefrigerantFlow::resetDesignSpecificationMultispeedObject() {
+    getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->resetDesignSpecificationMultispeedObject();
   }
 
   /// @cond

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.cpp
@@ -583,7 +583,8 @@ namespace model {
       OS_ASSERT(result);
     }
 
-    boost::optional<UnitarySystemPerformanceMultispeed> ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::designSpecificationMultispeedObject() const {
+    boost::optional<UnitarySystemPerformanceMultispeed>
+      ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl::designSpecificationMultispeedObject() const {
       return getObject<ModelObject>().getModelObjectTarget<UnitarySystemPerformanceMultispeed>(
         OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName);
     }
@@ -592,7 +593,8 @@ namespace model {
       const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace) {
       bool result(false);
       if (unitarySystemPerformace) {
-        result = setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName, unitarySystemPerformace.get().handle());
+        result = setPointer(OS_ZoneHVAC_TerminalUnit_VariableRefrigerantFlowFields::DesignSpecificationMultispeedObjectName,
+                            unitarySystemPerformace.get().handle());
       } else {
         resetDesignSpecificationMultispeedObject();
         result = true;
@@ -1369,8 +1371,9 @@ namespace model {
   boost::optional<UnitarySystemPerformanceMultispeed> ZoneHVACTerminalUnitVariableRefrigerantFlow::designSpecificationMultispeedObject() const {
     return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->designSpecificationMultispeedObject();
   }
-  
-  bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace) {
+
+  bool ZoneHVACTerminalUnitVariableRefrigerantFlow::setDesignSpecificationMultispeedObject(
+    const UnitarySystemPerformanceMultispeed& unitarySystemPerformace) {
     return getImpl<detail::ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl>()->setDesignSpecificationMultispeedObject(unitarySystemPerformace);
   }
 

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow.hpp
@@ -20,6 +20,7 @@ namespace model {
   class CoilHeatingDXVariableRefrigerantFlowFluidTemperatureControl;
   class CoilCoolingDXVariableRefrigerantFlowFluidTemperatureControl;
   class ThermalZone;
+  class UnitarySystemPerformanceMultispeed;
 
   namespace detail {
 
@@ -179,6 +180,10 @@ namespace model {
     boost::optional<ThermalZone> controllingZoneorThermostatLocation() const;
     bool setControllingZoneorThermostatLocation(const ThermalZone& thermalZone);
     void resetControllingZoneorThermostatLocation();
+
+    boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject() const;
+    bool setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace);
+    void resetDesignSpecificationMultispeedObject();
 
     boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 

--- a/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
+++ b/src/model/ZoneHVACTerminalUnitVariableRefrigerantFlow_Impl.hpp
@@ -16,6 +16,7 @@ namespace model {
   class HVACComponent;
   class Schedule;
   class ThermalZone;
+  class UnitarySystemPerformanceMultispeed;
 
   namespace detail {
 
@@ -140,6 +141,10 @@ namespace model {
       // Supply Air Fan Placement
       std::string supplyAirFanPlacement() const;
       bool setSupplyAirFanPlacement(const std::string& supplyAirFanPlacement);
+
+      boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject() const;
+      bool setDesignSpecificationMultispeedObject(const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace);
+      void resetDesignSpecificationMultispeedObject();
 
       boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 

--- a/src/model/ZoneHVACWaterToAirHeatPump.cpp
+++ b/src/model/ZoneHVACWaterToAirHeatPump.cpp
@@ -27,6 +27,8 @@
 #include "CoilHeatingWater_Impl.hpp"
 #include "Model.hpp"
 #include "Model_Impl.hpp"
+#include "UnitarySystemPerformanceMultispeed.hpp"
+#include "UnitarySystemPerformanceMultispeed_Impl.hpp"
 
 #include <utilities/idd/IddFactory.hxx>
 
@@ -77,6 +79,10 @@ namespace model {
 
       wahpClone.setSupplementalHeatingCoil(supplementalHeatingCoilClone);
 
+      if (auto designSpec = designSpecificationMultispeedObject()) {
+        wahpClone.setDesignSpecificationMultispeedObject(designSpec->clone(model).cast<UnitarySystemPerformanceMultispeed>());
+      }
+
       if (model == this->model()) {
         if (auto waterToAirComponent = t_coolingCoil.optionalCast<WaterToAirComponent>()) {
           if (auto plant = waterToAirComponent->plantLoop()) {
@@ -118,6 +124,9 @@ namespace model {
         if (boost::optional<PlantLoop> plantLoop = t_supplementalHeatingCoil->plantLoop()) {
           plantLoop->removeDemandBranchWithComponent(t_supplementalHeatingCoil.get());
         }
+      }
+      if (auto designSpec = designSpecificationMultispeedObject()) {
+        designSpec->remove();
       }
       return ZoneHVACComponent_Impl::remove();
     }
@@ -167,6 +176,9 @@ namespace model {
       }
       if (OptionalHVACComponent intermediate = optionalSupplementalHeatingCoil()) {
         result.push_back(*intermediate);
+      }
+      if (auto designSpec = designSpecificationMultispeedObject()) {
+        result.push_back(*designSpec);
       }
       return result;
     }
@@ -382,6 +394,11 @@ namespace model {
 
     boost::optional<Schedule> ZoneHVACWaterToAirHeatPump_Impl::supplyAirFanOperatingModeSchedule() const {
       return getObject<ModelObject>().getModelObjectTarget<Schedule>(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanOperatingModeScheduleName);
+    }
+
+    boost::optional<UnitarySystemPerformanceMultispeed> ZoneHVACWaterToAirHeatPump_Impl::designSpecificationMultispeedObject() const {
+      return getObject<ModelObject>().getModelObjectTarget<UnitarySystemPerformanceMultispeed>(
+        OS_ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName);
     }
 
     bool ZoneHVACWaterToAirHeatPump_Impl::setAvailabilitySchedule(Schedule& schedule) {
@@ -681,6 +698,23 @@ namespace model {
 
     void ZoneHVACWaterToAirHeatPump_Impl::resetSupplyAirFanOperatingModeSchedule() {
       bool result = setString(OS_ZoneHVAC_WaterToAirHeatPumpFields::SupplyAirFanOperatingModeScheduleName, "");
+      OS_ASSERT(result);
+    }
+
+    bool ZoneHVACWaterToAirHeatPump_Impl::setDesignSpecificationMultispeedObject(
+      const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace) {
+      bool result(false);
+      if (unitarySystemPerformace) {
+        result = setPointer(OS_ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName, unitarySystemPerformace.get().handle());
+      } else {
+        resetDesignSpecificationMultispeedObject();
+        result = true;
+      }
+      return result;
+    }
+
+    void ZoneHVACWaterToAirHeatPump_Impl::resetDesignSpecificationMultispeedObject() {
+      bool result = setString(OS_ZoneHVAC_WaterToAirHeatPumpFields::DesignSpecificationMultispeedObjectName, "");
       OS_ASSERT(result);
     }
 
@@ -1101,6 +1135,10 @@ namespace model {
     return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->supplyAirFanOperatingModeSchedule();
   }
 
+  boost::optional<ZoneHVACWaterToAirHeatPump> AirLoopHVACUnitarySystem::designSpecificationMultispeedObject() const {
+    return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->designSpecificationMultispeedObject();
+  }
+
   bool ZoneHVACWaterToAirHeatPump::setAvailabilitySchedule(Schedule& schedule) {
     return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setAvailabilitySchedule(schedule);
   }
@@ -1316,6 +1354,14 @@ namespace model {
 
   void ZoneHVACWaterToAirHeatPump::resetSupplyAirFanOperatingModeSchedule() {
     getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->resetSupplyAirFanOperatingModeSchedule();
+  }
+
+  bool ZoneHVACWaterToAirHeatPump::setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace) {
+    return getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->setDesignSpecificationMultispeedObject(unitarySystemPerformace);
+  }
+
+  void ZoneHVACWaterToAirHeatPump::resetDesignSpecificationMultispeedObject() {
+    getImpl<detail::ZoneHVACWaterToAirHeatPump_Impl>()->resetDesignSpecificationMultispeedObject();
   }
 
   /// @cond

--- a/src/model/ZoneHVACWaterToAirHeatPump.hpp
+++ b/src/model/ZoneHVACWaterToAirHeatPump.hpp
@@ -14,8 +14,8 @@ namespace openstudio {
 namespace model {
 
   class Schedule;
-
   class HVACComponent;
+  class UnitarySystemPerformanceMultispeed;
 
   namespace detail {
 
@@ -129,6 +129,8 @@ namespace model {
     // TODO: field 'Availability Manager List Name' isn't implemented
 
     // TODO: field 'Design Specification ZoneHVAC Sizing' isn't implemented since the object isn't wrapped in SDK
+
+    boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject() const;
 
     //@}
     /** @name Setters */
@@ -245,6 +247,10 @@ namespace model {
     bool setSupplyAirFanOperatingModeSchedule(Schedule& schedule);
 
     void resetSupplyAirFanOperatingModeSchedule();
+
+    bool setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace);
+
+    void resetDesignSpecificationMultispeedObject();
 
     //@}
     /** @name Other */

--- a/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
+++ b/src/model/ZoneHVACWaterToAirHeatPump_Impl.hpp
@@ -13,8 +13,8 @@ namespace openstudio {
 namespace model {
 
   class Schedule;
-
   class HVACComponent;
+  class UnitarySystemPerformanceMultispeed;
 
   namespace detail {
 
@@ -131,6 +131,8 @@ namespace model {
       bool isHeatPumpCoilWaterFlowModeDefaulted() const;
 
       boost::optional<Schedule> supplyAirFanOperatingModeSchedule() const;
+
+      boost::optional<UnitarySystemPerformanceMultispeed> designSpecificationMultispeedObject() const;
 
       boost::optional<double> autosizedSupplyAirFlowRateDuringCoolingOperation() const;
 
@@ -265,6 +267,10 @@ namespace model {
       bool setSupplyAirFanOperatingModeSchedule(Schedule& schedule);
 
       void resetSupplyAirFanOperatingModeSchedule();
+
+      bool setDesignSpecificationMultispeedObject(const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace);
+
+      void resetDesignSpecificationMultispeedObject();
 
       //@}
       /** @name Other */


### PR DESCRIPTION
Pull request overview
---------------------

Support new fields "Design Specification Multispeed Object Type" and "Design Specification Multispeed Object Name" for:
- [ ] `ZoneHVAC:WaterToAirHeatPump`
- [ ] `ZoneHVAC:TerminalUnit:VariableRefrigerantFlow`

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
