### PR TITLE
#4963 - AirLoopHVACUnitarySystem Default Supply Air Flow Rate Method When No Cooling or Heating is Required to None

### DIFF
--- a/developer/doc/ReleaseNotes/OpenStudio_Release_Notes_3_7_0_TDB.md
+++ b/developer/doc/ReleaseNotes/OpenStudio_Release_Notes_3_7_0_TDB.md
@@ -74,10 +74,13 @@ You can also refer to the [OpenStudio SDK Python Binding Version Compatibility M
 ## New Features, Major Fixes and API-breaking changes
 
 * [#4827](https://github.com/NREL/OpenStudio/pull/4827) - #4748 #4817 - Validate BCLXML with schema when loading + make sorting of files in measure.xml consistent when saving
-* [#4873](https://github.com/NREL/OpenStudio/pull/4873) - AirLoopHVACUnitarySystem set Method During XXX Operation
+* [#4873](https://github.com/NREL/OpenStudio/pull/4873) & [#4971](https://github.com/NREL/OpenStudio/pull/4971) - AirLoopHVACUnitarySystem set Method During XXX Operation
     * Fix #4695 - AirLoopHVACUnitarySystem: Supply Air Flow Rate Method During <XXX> Operation should be set via related setters/autosize
-    * Breaks the return of `supplyAirFlowRateMethodDuringCoolingOperation` and `supplyAirFlowRateMethodDuringHeatingOperation`: now returns `std::string` instead of `boost::optional<std::string>`
+    * Breaks the return of `supplyAirFlowRateMethodDuringCoolingOperation`, `supplyAirFlowRateMethodDuringHeatingOperation` and `supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired()`: now returns `std::string` instead of `boost::optional<std::string>`
     * Deprecates many set/reset methods
+    * These fields are now non-optional, and are set via the flow field setters and reset when the heating/cooling coils are reset.
+        * Example: `unitary.setSupplyAirFlowRatePerFloorAreaDuringCoolingOperation(1.0)` will set the "Supply Air Flow Rate Method During Cooling Operation" to "FlowPerFloorArea"
+
 * [#4932](https://github.com/NREL/OpenStudio/pull/4932) - Support undisturbed ground temperature models on GroundHeatExchangerVertical
     * Fix #4930 - Support undisturbed ground temperature models on GroundHeatExchangerVertical
     * Update `GroundHeatExchanger:Vertical` to actually use the Ground Temeprature Model field

--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -11902,7 +11902,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \key FlowPerFloorArea
        \key FractionOfAutosizedCoolingValue
        \key FlowPerCoolingCapacity
-       \default None
+       \required-field
        \note Enter the method used to determine the cooling supply air volume flow rate.
        \note None is used when a cooling coil is not included in the unitary system or this field may be blank.
        \note SupplyAirFlowRate is selected when the magnitude of the supply air volume is used.
@@ -11947,7 +11947,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \key FlowPerFloorArea
        \key FractionOfAutosizedHeatingValue
        \key FlowPerHeatingCapacity
-       \default None
+       \required-field
        \note Enter the method used to determine the heating supply air volume flow rate.
        \note None is used when a heating coil is not included in the unitary system or this field may be blank.
        \note SupplyAirFlowRate is selected when the magnitude of the supply air volume is used.
@@ -11994,6 +11994,7 @@ OS:AirLoopHVAC:UnitarySystem,
        \key FractionOfAutosizedHeatingValue
        \key FlowPerCoolingCapacity
        \key FlowPerHeatingCapacity
+       \required-field
        \note Enter the method used to determine the supply air volume flow rate when no cooling or heating is required.
        \note None is used when a cooling and heating coil is not included in the unitary system or this field may be blank.
        \note SupplyAirFlowRate is selected when the magnitude of the supply air volume is used.

--- a/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateAirLoopHVACUnitarySystem.cpp
@@ -309,10 +309,8 @@ namespace energyplus {
     }
 
     // Supply Air Flow Rate Method When No Cooling or Heating is Required
-    s = modelObject.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
-    if (s) {
-      unitarySystem.setString(AirLoopHVAC_UnitarySystemFields::NoLoadSupplyAirFlowRateMethod, s.get());
-    }
+    unitarySystem.setString(AirLoopHVAC_UnitarySystemFields::NoLoadSupplyAirFlowRateMethod,
+                            modelObject.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
 
     // Supply Air Flow Rate When No Cooling or Heating is Required
     if (modelObject.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized()) {

--- a/src/model/AirLoopHVACUnitarySystem.cpp
+++ b/src/model/AirLoopHVACUnitarySystem.cpp
@@ -1391,7 +1391,7 @@ namespace model {
     OS_ASSERT(ok);
     getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodDuringCoolingOperation("None");
     getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodDuringHeatingOperation("None");
-    autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+    setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("None");
     setMaximumSupplyAirTemperature(80.0);
     setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
     ok = setMaximumCyclingRate(2.5);

--- a/src/model/AirLoopHVACUnitarySystem.cpp
+++ b/src/model/AirLoopHVACUnitarySystem.cpp
@@ -24,7 +24,8 @@
 
 #include "../utilities/core/Assert.hpp"
 #include "../utilities/data/DataEnums.hpp"
-#include "utilities/core/Exception.hpp"
+#include "../utilities/core/Compare.hpp"
+#include "../utilities/core/Exception.hpp"
 
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/idd/OS_AirLoopHVAC_UnitarySystem_FieldEnums.hxx>
@@ -88,23 +89,22 @@ namespace model {
     }
 
     std::vector<ScheduleTypeKey> AirLoopHVACUnitarySystem_Impl::getScheduleTypeKeys(const Schedule& schedule) const {
-      // TODO: Check schedule display names.
       std::vector<ScheduleTypeKey> result;
-      UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
-      UnsignedVector::const_iterator b(fieldIndices.begin());
-      UnsignedVector::const_iterator e(fieldIndices.end());
+      const UnsignedVector fieldIndices = getSourceIndices(schedule.handle());
+      const auto b = fieldIndices.cbegin();
+      const auto e = fieldIndices.cend();
       if (std::find(b, e, OS_AirLoopHVAC_UnitarySystemFields::AvailabilityScheduleName) != e) {
-        result.push_back(ScheduleTypeKey("AirLoopHVACUnitarySystem", "Availability"));
+        result.emplace_back("AirLoopHVACUnitarySystem", "Availability");
       }
       if (std::find(b, e, OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFanOperatingModeScheduleName) != e) {
-        result.push_back(ScheduleTypeKey("AirLoopHVACUnitarySystem", "Supply Air Fan Operating Mode"));
+        result.emplace_back("AirLoopHVACUnitarySystem", "Supply Air Fan Operating Mode");
       }
       return result;
     }
 
     ModelObject AirLoopHVACUnitarySystem_Impl::clone(Model model) const {
       // Mimic what StraightComponent_Impl::clone would do (we inherit ZoneHVACComponent here...)
-      auto modelObjectClone = ModelObject_Impl::clone(model).cast<AirLoopHVACUnitarySystem>();
+      auto modelObjectClone = ModelObject_Impl::clone(model).cast<AirLoopHVACUnitarySystem>();  // NOLINT(bugprone-parent-virtual-call)
       modelObjectClone.setString(modelObjectClone.inletPort(), "");
       modelObjectClone.setString(modelObjectClone.outletPort(), "");
 
@@ -433,9 +433,11 @@ namespace model {
       return getDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation, true);
     }
 
-    boost::optional<std::string> AirLoopHVACUnitarySystem_Impl::supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const {
-      // No default, and return uninitialized if empty
-      return getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired, false, true);
+    std::string AirLoopHVACUnitarySystem_Impl::supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const {
+      boost::optional<std::string> value =
+        getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired, true);
+      OS_ASSERT(value);
+      return value.get();
     }
 
     boost::optional<double> AirLoopHVACUnitarySystem_Impl::supplyAirFlowRateWhenNoCoolingorHeatingisRequired() const {
@@ -593,91 +595,74 @@ namespace model {
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setControlType(const std::string& controlType) {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControlType, controlType);
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControlType, controlType);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetControlType() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControlType, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControlType, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setControllingZoneorThermostatLocation(const boost::optional<ThermalZone>& thermalZone) {
-      bool result(false);
-      if (thermalZone) {
-        result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::ControllingZoneorThermostatLocation, thermalZone.get().handle());
-      } else {
-        resetControllingZoneorThermostatLocation();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setControllingZoneorThermostatLocation(const ThermalZone& thermalZone) {
+      const bool result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::ControllingZoneorThermostatLocation, thermalZone.handle());
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetControllingZoneorThermostatLocation() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControllingZoneorThermostatLocation, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::ControllingZoneorThermostatLocation, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setDehumidificationControlType(const std::string& dehumidificationControlType) {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DehumidificationControlType, dehumidificationControlType);
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DehumidificationControlType, dehumidificationControlType);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDehumidificationControlType() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DehumidificationControlType, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DehumidificationControlType, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setAvailabilitySchedule(Schedule& schedule) {
-      bool result = setSchedule(OS_AirLoopHVAC_UnitarySystemFields::AvailabilityScheduleName, "AirLoopHVACUnitarySystem", "Availability", schedule);
+      const bool result =
+        setSchedule(OS_AirLoopHVAC_UnitarySystemFields::AvailabilityScheduleName, "AirLoopHVACUnitarySystem", "Availability", schedule);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetAvailabilitySchedule() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AvailabilityScheduleName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AvailabilityScheduleName, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setSupplyFan(const boost::optional<HVACComponent>& supplyFan) {
-      bool result(false);
-      if (supplyFan) {
-        result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::SupplyFanName, supplyFan.get().handle());
-      } else {
-        resetSupplyFan();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setSupplyFan(const HVACComponent& supplyFan) {
+      const bool result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::SupplyFanName, supplyFan.handle());
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplyFan() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyFanName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyFanName, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setFanPlacement(boost::optional<std::string> fanPlacement) {
-      bool result(false);
-      if (fanPlacement) {
-        result = setString(OS_AirLoopHVAC_UnitarySystemFields::FanPlacement, fanPlacement.get());
-      } else {
-        resetFanPlacement();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setFanPlacement(const std::string& fanPlacement) {
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::FanPlacement, fanPlacement);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetFanPlacement() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::FanPlacement, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::FanPlacement, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setSupplyAirFanOperatingModeSchedule(Schedule& schedule) {
-      bool result = setSchedule(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFanOperatingModeScheduleName, "AirLoopHVACUnitarySystem",
-                                "Supply Air Fan Operating Mode", schedule);
+      const bool result = setSchedule(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFanOperatingModeScheduleName, "AirLoopHVACUnitarySystem",
+                                      "Supply Air Fan Operating Mode", schedule);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplyAirFanOperatingModeSchedule() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFanOperatingModeScheduleName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFanOperatingModeScheduleName, "");
       OS_ASSERT(result);
     }
 
@@ -698,15 +683,24 @@ namespace model {
       resetSupplyAirFlowRatePerFloorAreaduringHeatingOperation();
       resetFractionofAutosizedDesignHeatingSupplyAirFlowRate();
       resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation();
+      if (!hasCoolingCoil()) {
+        setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("None");
+        resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+        resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+      }
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setDXHeatingCoilSizingRatio(double dXHeatingCoilSizingRatio) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::DXHeatingCoilSizingRatio, dXHeatingCoilSizingRatio);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::DXHeatingCoilSizingRatio, dXHeatingCoilSizingRatio);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDXHeatingCoilSizingRatio() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DXHeatingCoilSizingRatio, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DXHeatingCoilSizingRatio, "");
       OS_ASSERT(result);
     }
 
@@ -727,6 +721,15 @@ namespace model {
       resetSupplyAirFlowRatePerFloorAreaDuringCoolingOperation();
       resetFractionofAutosizedDesignCoolingSupplyAirFlowRate();
       resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation();
+      if (!hasHeatingCoil()) {
+        setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("None");
+        resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+        resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+      }
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setUseDOASDXCoolingCoil(bool useDOASDXCoolingCoil) {
@@ -734,49 +737,43 @@ namespace model {
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetUseDOASDXCoolingCoil() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::UseDOASDXCoolingCoil, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::UseDOASDXCoolingCoil, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setDOASDXCoolingCoilLeavingMinimumAirTemperature(double dOASDXCoolingCoilLeavingMinimumAirTemperature) {
-      bool result =
+      const bool result =
         setDouble(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, dOASDXCoolingCoilLeavingMinimumAirTemperature);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDOASDXCoolingCoilLeavingMinimumAirTemperature() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, "");
       OS_ASSERT(result);
     }
 
     void AirLoopHVACUnitarySystem_Impl::autosizeDOASDXCoolingCoilLeavingMinimumAirTemperature() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, "Autosize");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DOASDXCoolingCoilLeavingMinimumAirTemperature, "Autosize");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setLatentLoadControl(const std::string& latentLoadControl) {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl, latentLoadControl);
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl, latentLoadControl);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetLatentLoadControl() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::LatentLoadControl, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setSupplementalHeatingCoil(const boost::optional<HVACComponent>& supplementalHeatingCoil) {
-      bool result(false);
-      if (supplementalHeatingCoil) {
-        result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::SupplementalHeatingCoilName, supplementalHeatingCoil.get().handle());
-      } else {
-        resetSupplementalHeatingCoil();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setSupplementalHeatingCoil(const HVACComponent& supplementalHeatingCoil) {
+      const bool result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::SupplementalHeatingCoilName, supplementalHeatingCoil.handle());
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplementalHeatingCoil() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplementalHeatingCoilName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplementalHeatingCoilName, "");
       OS_ASSERT(result);
     }
 
@@ -949,304 +946,318 @@ namespace model {
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(
-      boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired) {
-        result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired,
-                           supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired.get());
-      } else {
-        resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
-        result = true;
-      }
+      const std::string& supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired) {
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired,
+                                    supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired, "None");
       OS_ASSERT(result);
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> supplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (supplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
-                           supplyAirFlowRateWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("SupplyAirFlowRate");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-        result = true;
+    bool
+      AirLoopHVACUnitarySystem_Impl::setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(double supplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
+                                    supplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("SupplyAirFlowRate"));
+      // resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
     void AirLoopHVACUnitarySystem_Impl::autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "Autosize");
-      boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("SupplyAirFlowRate");
-      result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "Autosize");
       OS_ASSERT(result);
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("SupplyAirFlowRate"));
+      // resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired,
-                           supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerFloorArea");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
-        result = true;
+      double supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired) {
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired,
+                                    supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired);
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerFloorArea"));
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      // resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
-                           fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FractionOfAutosizedCoolingValue");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-        result = true;
+      double fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
+      const bool result =
+        setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
+                  fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FractionOfAutosizedCoolingValue"));
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      // resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-      bool result =
+      const bool result =
         setString(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
-                           fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FractionOfAutosizedHeatingValue");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-        result = true;
+      double fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
+      const bool result =
+        setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired,
+                  fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FractionOfAutosizedHeatingValue"));
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      // resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-      bool result =
+      const bool result =
         setString(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(
-          OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired,
-          designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerCoolingCapacity");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
-        result = true;
+      double designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired) {
+      const bool result =
+        setDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired,
+                  designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired);
+
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerCoolingCapacity"));
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      // resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(
+      const bool result = setString(
+
         OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(
-      boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired) {
-      bool result(false);
-      if (designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired) {
-        result = setDouble(
-          OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired,
-          designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired.get());
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerHeatingCapacity");
-        result = result && setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-      } else {
-        resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
-        result = true;
+      double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired) {
+      const bool result =
+        setDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired,
+                  designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired);
+
+      if (!result) {
+        return false;
       }
-      return result;
+
+      OS_ASSERT(setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerHeatingCapacity"));
+      resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+      resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+      // resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+      return true;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired() {
-      bool result = setString(
+      const bool result = setString(
         OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setMaximumSupplyAirTemperature(boost::optional<double> maximumSupplyAirTemperature) {
-      bool result(false);
-      if (maximumSupplyAirTemperature) {
-        result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, maximumSupplyAirTemperature.get());
-      } else {
-        resetMaximumSupplyAirTemperature();
-        result = true;
-      }
-      OS_ASSERT(result);
+    bool AirLoopHVACUnitarySystem_Impl::setMaximumSupplyAirTemperature(double maximumSupplyAirTemperature) {
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, maximumSupplyAirTemperature);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetMaximumSupplyAirTemperature() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "");
       OS_ASSERT(result);
     }
 
     void AirLoopHVACUnitarySystem_Impl::autosizeMaximumSupplyAirTemperature() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "Autosize");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumSupplyAirTemperature, "Autosize");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(
       double maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation,
-                              maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
-      OS_ASSERT(result);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation,
+                                    maximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation, "");
       OS_ASSERT(result);
     }
 
-    bool AirLoopHVACUnitarySystem_Impl::setOutdoorDryBulbTemperatureSensorNodeName(
-      boost::optional<std::string> outdoorDryBulbTemperatureSensorNodeName) {
-      bool result(false);
-      if (outdoorDryBulbTemperatureSensorNodeName) {
-        result =
-          setString(OS_AirLoopHVAC_UnitarySystemFields::OutdoorDryBulbTemperatureSensorNodeName, outdoorDryBulbTemperatureSensorNodeName.get());
-      } else {
-        resetOutdoorDryBulbTemperatureSensorNodeName();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setOutdoorDryBulbTemperatureSensorNodeName(const std::string& outdoorDryBulbTemperatureSensorNodeName) {
+      const bool result =
+        setString(OS_AirLoopHVAC_UnitarySystemFields::OutdoorDryBulbTemperatureSensorNodeName, outdoorDryBulbTemperatureSensorNodeName);
       OS_ASSERT(result);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetOutdoorDryBulbTemperatureSensorNodeName() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::OutdoorDryBulbTemperatureSensorNodeName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::OutdoorDryBulbTemperatureSensorNodeName, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setMaximumCyclingRate(double maximumCyclingRate) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumCyclingRate, maximumCyclingRate);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumCyclingRate, maximumCyclingRate);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetMaximumCyclingRate() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumCyclingRate, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumCyclingRate, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setHeatPumpTimeConstant(double heatPumpTimeConstant) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpTimeConstant, heatPumpTimeConstant);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpTimeConstant, heatPumpTimeConstant);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetHeatPumpTimeConstant() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpTimeConstant, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpTimeConstant, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setFractionofOnCyclePowerUse(double fractionofOnCyclePowerUse) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofOnCyclePowerUse, fractionofOnCyclePowerUse);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofOnCyclePowerUse, fractionofOnCyclePowerUse);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetFractionofOnCyclePowerUse() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::FractionofOnCyclePowerUse, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::FractionofOnCyclePowerUse, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setHeatPumpFanDelayTime(double heatPumpFanDelayTime) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpFanDelayTime, heatPumpFanDelayTime);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpFanDelayTime, heatPumpFanDelayTime);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetHeatPumpFanDelayTime() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpFanDelayTime, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::HeatPumpFanDelayTime, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setAncilliaryOnCycleElectricPower(double ancilliaryOnCycleElectricPower) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOnCycleElectricPower, ancilliaryOnCycleElectricPower);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOnCycleElectricPower, ancilliaryOnCycleElectricPower);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetAncilliaryOnCycleElectricPower() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOnCycleElectricPower, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOnCycleElectricPower, "");
       OS_ASSERT(result);
     }
 
     bool AirLoopHVACUnitarySystem_Impl::setAncilliaryOffCycleElectricPower(double ancilliaryOffCycleElectricPower) {
-      bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOffCycleElectricPower, ancilliaryOffCycleElectricPower);
+      const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOffCycleElectricPower, ancilliaryOffCycleElectricPower);
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetAncilliaryOffCycleElectricPower() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOffCycleElectricPower, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::AncilliaryOffCycleElectricPower, "");
       OS_ASSERT(result);
     }
 
     // bool AirLoopHVACUnitarySystem_Impl::setDesignHeatRecoveryWaterFlowRate(double designHeatRecoveryWaterFlowRate) {
-    //   bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignHeatRecoveryWaterFlowRate, designHeatRecoveryWaterFlowRate);
+    //   const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignHeatRecoveryWaterFlowRate, designHeatRecoveryWaterFlowRate);
     //   return result;
     // }
 
     // void AirLoopHVACUnitarySystem_Impl::resetDesignHeatRecoveryWaterFlowRate() {
-    //   bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DesignHeatRecoveryWaterFlowRate, "");
+    //   const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DesignHeatRecoveryWaterFlowRate, "");
     //   OS_ASSERT(result);
     // }
 
     // bool AirLoopHVACUnitarySystem_Impl::setMaximumTemperatureforHeatRecovery(double maximumTemperatureforHeatRecovery) {
-    //   bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumTemperatureforHeatRecovery, maximumTemperatureforHeatRecovery);
+    //   const bool result = setDouble(OS_AirLoopHVAC_UnitarySystemFields::MaximumTemperatureforHeatRecovery, maximumTemperatureforHeatRecovery);
     //   return result;
     // }
 
     // void AirLoopHVACUnitarySystem_Impl::resetMaximumTemperatureforHeatRecovery() {
-    //   bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumTemperatureforHeatRecovery, "");
+    //   const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::MaximumTemperatureforHeatRecovery, "");
     //   OS_ASSERT(result);
     // }
 
-    bool AirLoopHVACUnitarySystem_Impl::setDesignSpecificationMultispeedObject(
-      const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace) {
-      bool result(false);
-      if (unitarySystemPerformace) {
-        result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::DesignSpecificationMultispeedObjectName, unitarySystemPerformace.get().handle());
-      } else {
-        resetDesignSpecificationMultispeedObject();
-        result = true;
-      }
+    bool AirLoopHVACUnitarySystem_Impl::setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace) {
+      const bool result = setPointer(OS_AirLoopHVAC_UnitarySystemFields::DesignSpecificationMultispeedObjectName, unitarySystemPerformace.handle());
       return result;
     }
 
     void AirLoopHVACUnitarySystem_Impl::resetDesignSpecificationMultispeedObject() {
-      bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DesignSpecificationMultispeedObjectName, "");
+      const bool result = setString(OS_AirLoopHVAC_UnitarySystemFields::DesignSpecificationMultispeedObjectName, "");
       OS_ASSERT(result);
     }
 
@@ -1391,7 +1402,7 @@ namespace model {
     OS_ASSERT(ok);
     getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodDuringCoolingOperation("None");
     getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodDuringHeatingOperation("None");
-    setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("None");
+    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("None");
     setMaximumSupplyAirTemperature(80.0);
     setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(21.0);
     ok = setMaximumCyclingRate(2.5);
@@ -1577,7 +1588,7 @@ namespace model {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation();
   }
 
-  boost::optional<std::string> AirLoopHVACUnitarySystem::supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const {
+  std::string AirLoopHVACUnitarySystem::supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
   }
 
@@ -1871,12 +1882,6 @@ namespace model {
       designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation);
   }
 
-  bool AirLoopHVACUnitarySystem::setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(
-    const std::string& supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired) {
-    return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(
-      supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
-  }
-
   void AirLoopHVACUnitarySystem::resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() {
     getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
   }
@@ -1884,10 +1889,6 @@ namespace model {
   bool AirLoopHVACUnitarySystem::setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(double supplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
       supplyAirFlowRateWhenNoCoolingorHeatingisRequired);
-  }
-
-  void AirLoopHVACUnitarySystem::resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
   }
 
   void AirLoopHVACUnitarySystem::autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
@@ -1900,28 +1901,16 @@ namespace model {
       supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired);
   }
 
-  void AirLoopHVACUnitarySystem::resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
-  }
-
   bool AirLoopHVACUnitarySystem::setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
     double fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
       fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
   }
 
-  void AirLoopHVACUnitarySystem::resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-  }
-
   bool AirLoopHVACUnitarySystem::setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
     double fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired) {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
       fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
-  }
-
-  void AirLoopHVACUnitarySystem::resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()->resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
   }
 
   bool AirLoopHVACUnitarySystem::setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(
@@ -1931,21 +1920,11 @@ namespace model {
         designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired);
   }
 
-  void AirLoopHVACUnitarySystem::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()
-      ->resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
-  }
-
   bool AirLoopHVACUnitarySystem::setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(
     double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired) {
     return getImpl<detail::AirLoopHVACUnitarySystem_Impl>()
       ->setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(
         designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired);
-  }
-
-  void AirLoopHVACUnitarySystem::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired() {
-    getImpl<detail::AirLoopHVACUnitarySystem_Impl>()
-      ->resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
   }
 
   bool AirLoopHVACUnitarySystem::setMaximumSupplyAirTemperature(double maximumSupplyAirTemperature) {
@@ -2155,6 +2134,48 @@ namespace model {
     DEPRECATED_AT_MSG(3, 7, 0,
                       "Use setSupplyAirFlowRateDuringHeatingOperation, autosizeSupplyAirFlowRateDuringHeatingOperation, "
                       "setSupplyAirFlowRatePerFloorAreaduringHeatingOperation, or setFractionofAutosizedDesignHeatingSupplyAirFlowRate instead.");
+  }
+
+  bool AirLoopHVACUnitarySystem::setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(const std::string& noCoolHeatMethod) {
+    // setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired, setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired, setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired, setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired, setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired, setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired
+    DEPRECATED_AT_MSG(3, 7, 0,
+                      "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired For 'None', one of the flow rate setters otherwise.");
+
+    if (openstudio::istringEqual("None", noCoolHeatMethod)) {
+      resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
+      return true;
+    }
+    return false;
+  }
+
+  void AirLoopHVACUnitarySystem::resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
+  }
+
+  void AirLoopHVACUnitarySystem::resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
+  }
+
+  void AirLoopHVACUnitarySystem::resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
+  }
+
+  void AirLoopHVACUnitarySystem::resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
+  }
+
+  void AirLoopHVACUnitarySystem::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
+  }
+
+  void AirLoopHVACUnitarySystem::resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired() {
+    DEPRECATED_AT_MSG(
+      3, 7, 0, "Use resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired to clear all fields, one of the flow rate setters otherwise.");
   }
 
   /// @endcond

--- a/src/model/AirLoopHVACUnitarySystem.hpp
+++ b/src/model/AirLoopHVACUnitarySystem.hpp
@@ -142,7 +142,7 @@ namespace model {
     boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation() const;
 
     /** In EnergyPlus 8.3.0 and above this property maps to the EnergyPlus field "No Load Supply Air Flow Rate Method" **/
-    boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const;
+    std::string supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const;
 
     /** In EnergyPlus 8.3.0 and above this property maps to the EnergyPlus field "No Load Supply Air Flow Rate" **/
     boost::optional<double> supplyAirFlowRateWhenNoCoolingorHeatingisRequired() const;
@@ -244,16 +244,26 @@ namespace model {
 
     void resetSupplyAirFanOperatingModeSchedule();
 
+    /** Sets the Heating Coil. If the "Supply Air Flow Rate Method During Heating Operation" was "None", switch to "SupplyAirFlowRate"
+      * and autosize the "Supply Air Flow Rate During Heating Operation" field */
     bool setHeatingCoil(const HVACComponent& heatingCoil);
 
+    /** This will switch the "Supply Air Flow Rate Method During Heating Operation" to "None" and clear all heating flow fields
+      * If the Unitary is left with no coils, the "Supply Air Flow Rate Method When No Heating Or Cooling" is also set to None
+      * and all NoCoolHeat flow fields are reset */
     void resetHeatingCoil();
 
     bool setDXHeatingCoilSizingRatio(double dXHeatingCoilSizingRatio);
 
     void resetDXHeatingCoilSizingRatio();
 
+    /** Sets the Cooling Coil. If the "Supply Air Flow Rate Method During Cooling Operation" was "None", switch to "SupplyAirFlowRate"
+      * and autosize the "Supply Air Flow Rate During Cooling Operation" field */
     bool setCoolingCoil(const HVACComponent& coolingCoil);
 
+    /** This will switch the "Supply Air Flow Rate Method During Cooling Operation" to "None" and clear all cooling flow fields
+      * If the Unitary is left with no coils, the "Supply Air Flow Rate Method When No Heating Or Cooling" is also set to None
+      * and all NoCoolHeat flow fields are reset */
     void resetCoolingCoil();
 
     bool setUseDOASDXCoolingCoil(bool useDOASDXCoolingCoil);
@@ -276,71 +286,93 @@ namespace model {
 
     void resetSupplementalHeatingCoil();
 
+    // During Cooling
+
+    /** Sets the field and switches "Supply Air Flow Rate Method During Cooling Operation" (coolingSAFMethod) to "SupplyAirFlowRate" */
+    bool setSupplyAirFlowRateDuringCoolingOperation(double supplyAirFlowRateDuringCoolingOperation);
+    /** Sets the field and switches the coolingSAFMethod to "SupplyAirFlowRate" */
+    void autosizeSupplyAirFlowRateDuringCoolingOperation();
+
+    /** Sets the field and switches the coolingSAFMethod to "FlowPerFloorArea" */
+    bool setSupplyAirFlowRatePerFloorAreaDuringCoolingOperation(double supplyAirFlowRatePerFloorAreaDuringCoolingOperation);
+
+    /** Sets the field and switches the coolingSAFMethod to "FractionOfAutosizedCoolingValue" */
+    bool setFractionofAutosizedDesignCoolingSupplyAirFlowRate(double fractionofAutosizedDesignCoolingSupplyAirFlowRate);
+
+    /** Sets the field and switches the coolingSAFMethod to "FlowPerCoolingCapacity" */
+    bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation(double designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation);
+
     OS_DEPRECATED(3, 7, 0) bool setSupplyAirFlowRateMethodDuringCoolingOperation(const std::string& supplyAirFlowRateMethodDuringCoolingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRateMethodDuringCoolingOperation();
 
-    bool setSupplyAirFlowRateDuringCoolingOperation(double supplyAirFlowRateDuringCoolingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRateDuringCoolingOperation();
-    void autosizeSupplyAirFlowRateDuringCoolingOperation();
-
-    bool setSupplyAirFlowRatePerFloorAreaDuringCoolingOperation(double supplyAirFlowRatePerFloorAreaDuringCoolingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRatePerFloorAreaDuringCoolingOperation();
-
-    bool setFractionofAutosizedDesignCoolingSupplyAirFlowRate(double fractionofAutosizedDesignCoolingSupplyAirFlowRate);
     OS_DEPRECATED(3, 7, 0) void resetFractionofAutosizedDesignCoolingSupplyAirFlowRate();
-
-    bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation(double designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation);
     OS_DEPRECATED(3, 7, 0) void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation();
+
+    // During Heating
+
+    /** Sets the field and switches "Supply Air Flow Rate Method During Heating Operation" (heatingSAFMethod) to "SupplyAirFlowRate" */
+    bool setSupplyAirFlowRateDuringHeatingOperation(double supplyAirFlowRateDuringHeatingOperation);
+    /** Sets the field and switches the heatingSAFMethod to "SupplyAirFlowRate" */
+    void autosizeSupplyAirFlowRateDuringHeatingOperation();
+
+    /** Sets the field and switches the heatingSAFMethod to "FlowPerFloorArea" */
+    bool setSupplyAirFlowRatePerFloorAreaduringHeatingOperation(double supplyAirFlowRatePerFloorAreaduringHeatingOperation);
+
+    /** Sets the field and switches the heatingSAFMethod to "FractionOfAutosizedHeatingValue" */
+    bool setFractionofAutosizedDesignHeatingSupplyAirFlowRate(double fractionofAutosizedDesignHeatingSupplyAirFlowRate);
+
+    /** Sets the field and switches the heatingSAFMethod to "FlowPerHeatingCapacity" */
+    bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation(double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation);
 
     OS_DEPRECATED(3, 7, 0) bool setSupplyAirFlowRateMethodDuringHeatingOperation(const std::string& supplyAirFlowRateMethodDuringHeatingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRateMethodDuringHeatingOperation();
 
-    bool setSupplyAirFlowRateDuringHeatingOperation(double supplyAirFlowRateDuringHeatingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRateDuringHeatingOperation();
-    void autosizeSupplyAirFlowRateDuringHeatingOperation();
-
-    bool setSupplyAirFlowRatePerFloorAreaduringHeatingOperation(double supplyAirFlowRatePerFloorAreaduringHeatingOperation);
     OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRatePerFloorAreaduringHeatingOperation();
-
-    bool setFractionofAutosizedDesignHeatingSupplyAirFlowRate(double fractionofAutosizedDesignHeatingSupplyAirFlowRate);
     OS_DEPRECATED(3, 7, 0) void resetFractionofAutosizedDesignHeatingSupplyAirFlowRate();
-
-    bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation(double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation);
     OS_DEPRECATED(3, 7, 0) void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation();
 
-    bool setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(const std::string& supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
+    // When no Heating or Cooling is Required
 
+    // Sets the "Supply Air Flow Rate Method When No Cooling or Heating is Required" (noCoolHeatSAFMethod) to "None" and clears the NoCoolHeat flow rate fields
     void resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
 
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "SupplyAirFlowRate" */
     bool setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(double supplyAirFlowRateWhenNoCoolingorHeatingisRequired);
-
-    void resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "SupplyAirFlowRate" */
     void autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "FlowPerFloorArea" */
     bool setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(double supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired);
 
-    void resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
-
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "FractionOfAutosizedCoolingValue" */
     bool setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
       double fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
 
-    void resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "FractionOfAutosizedHeatingValue" */
     bool setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
       double fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
 
-    void resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
-
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "FlowPerCoolingCapacity" */
     bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(
       double designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired);
 
-    void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
-
+    /** Sets the field and switches the noCoolHeatSAFMethod) to "FlowPerHeatingCapacity" */
     bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(
       double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired);
 
-    void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) bool setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(const std::string& noCoolHeatMethod);
+
+    OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) void resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) void resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) void resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
+    OS_DEPRECATED(3, 7, 0) void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
+
+    // End SAF methods
 
     bool setMaximumSupplyAirTemperature(double maximumSupplyAirTemperature);
 

--- a/src/model/AirLoopHVACUnitarySystem_Impl.hpp
+++ b/src/model/AirLoopHVACUnitarySystem_Impl.hpp
@@ -134,7 +134,7 @@ namespace model {
 
       boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation() const;
 
-      boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const;
+      std::string supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired() const;
 
       boost::optional<double> supplyAirFlowRateWhenNoCoolingorHeatingisRequired() const;
 
@@ -222,7 +222,7 @@ namespace model {
 
       void resetControlType();
 
-      bool setControllingZoneorThermostatLocation(const boost::optional<ThermalZone>& thermalZone);
+      bool setControllingZoneorThermostatLocation(const ThermalZone& thermalZone);
 
       void resetControllingZoneorThermostatLocation();
 
@@ -234,11 +234,11 @@ namespace model {
 
       void resetAvailabilitySchedule();
 
-      bool setSupplyFan(const boost::optional<HVACComponent>& supplyFan);
+      bool setSupplyFan(const HVACComponent& supplyFan);
 
       void resetSupplyFan();
 
-      bool setFanPlacement(boost::optional<std::string> fanPlacement);
+      bool setFanPlacement(const std::string& fanPlacement);
 
       void resetFanPlacement();
 
@@ -272,7 +272,7 @@ namespace model {
 
       void resetLatentLoadControl();
 
-      bool setSupplementalHeatingCoil(const boost::optional<HVACComponent>& supplementalHeatingCoil);
+      bool setSupplementalHeatingCoil(const HVACComponent& supplementalHeatingCoil);
 
       void resetSupplementalHeatingCoil();
 
@@ -318,43 +318,41 @@ namespace model {
 
       void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation();
 
-      bool setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(
-        boost::optional<std::string> supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
+      bool setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired(const std::string& supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired);
 
       void resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
 
-      bool setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(boost::optional<double> supplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+      bool setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(double supplyAirFlowRateWhenNoCoolingorHeatingisRequired);
 
       void resetSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
       void autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
-      bool setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(
-        boost::optional<double> supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired);
+      bool setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(double supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired);
 
       void resetSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired();
 
       bool setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
-        boost::optional<double> fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+        double fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
 
       void resetFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
       bool setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(
-        boost::optional<double> fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
+        double fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired);
 
       void resetFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
       bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(
-        boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired);
+        double designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired);
 
       void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired();
 
       bool setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(
-        boost::optional<double> designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired);
+        double designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired);
 
       void resetDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired();
 
-      bool setMaximumSupplyAirTemperature(boost::optional<double> maximumSupplyAirTemperature);
+      bool setMaximumSupplyAirTemperature(double maximumSupplyAirTemperature);
 
       void resetMaximumSupplyAirTemperature();
 
@@ -364,7 +362,7 @@ namespace model {
 
       void resetMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation();
 
-      bool setOutdoorDryBulbTemperatureSensorNodeName(boost::optional<std::string> outdoorDryBulbTemperatureSensorNodeName);
+      bool setOutdoorDryBulbTemperatureSensorNodeName(const std::string& outdoorDryBulbTemperatureSensorNodeName);
 
       void resetOutdoorDryBulbTemperatureSensorNodeName();
 
@@ -400,7 +398,7 @@ namespace model {
 
       // void resetMaximumTemperatureforHeatRecovery();
 
-      bool setDesignSpecificationMultispeedObject(const boost::optional<UnitarySystemPerformanceMultispeed>& unitarySystemPerformace);
+      bool setDesignSpecificationMultispeedObject(const UnitarySystemPerformanceMultispeed& unitarySystemPerformace);
 
       void resetDesignSpecificationMultispeedObject();
 

--- a/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
+++ b/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
@@ -121,6 +121,7 @@ TEST_F(ModelFixture, AirLoopHVACUnitarySystem_CloneOneModelWithDefaultData) {
   testObject.setCoolingCoil(coolingCoil);
   testObject.setHeatingCoil(heatingCoil);
   testObject.setSupplementalHeatingCoil(suppHeatingCoil);
+  testObject.autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
 
   auto testObjectClone = testObject.clone(m).cast<AirLoopHVACUnitarySystem>();
 

--- a/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
+++ b/src/model/test/AirLoopHVACUnitarySystem_GTest.cpp
@@ -719,8 +719,8 @@ TEST_F(ModelFixture, AirLoopHVACUnitarySystem_SupplyAirFlowRateMethodDuringOpera
   EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation());
 
   // Setting a coil changes things
-  CoilHeatingDXSingleSpeed cc(m);
-  EXPECT_TRUE(unitary.setHeatingCoil(cc));
+  CoilHeatingDXSingleSpeed hc(m);
+  EXPECT_TRUE(unitary.setHeatingCoil(hc));
   EXPECT_EQ("SupplyAirFlowRate", unitary.supplyAirFlowRateMethodDuringHeatingOperation());
   EXPECT_TRUE(unitary.isSupplyAirFlowRateDuringHeatingOperationAutosized());
   EXPECT_FALSE(unitary.supplyAirFlowRateDuringHeatingOperation());
@@ -736,7 +736,7 @@ TEST_F(ModelFixture, AirLoopHVACUnitarySystem_SupplyAirFlowRateMethodDuringOpera
   EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRate());
   EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation());
   // Put it back
-  EXPECT_TRUE(unitary.setHeatingCoil(cc));
+  EXPECT_TRUE(unitary.setHeatingCoil(hc));
 
   // SupplyAirFlowRate
   EXPECT_TRUE(unitary.setSupplyAirFlowRateDuringHeatingOperation(1.0));
@@ -777,6 +777,129 @@ TEST_F(ModelFixture, AirLoopHVACUnitarySystem_SupplyAirFlowRateMethodDuringOpera
   EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRate());
   ASSERT_TRUE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation());
   EXPECT_EQ(1.0, unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation().get());
+}
+
+TEST_F(ModelFixture, AirLoopHVACUnitarySystem_SupplyAirFlowRateMethodDuringOperation_NoCoolHeat) {
+  // Test for #4695 - AirLoopHVACUnitarySystem: Supply Air Flow Rate Method During <XXX> Operation should be set via related setters/autosize
+
+  Model m;
+  AirLoopHVACUnitarySystem unitary = AirLoopHVACUnitarySystem(m);
+  CoilCoolingDXSingleSpeed cc(m);
+  EXPECT_TRUE(unitary.setCoolingCoil(cc));
+  CoilHeatingDXSingleSpeed hc(m);
+  EXPECT_TRUE(unitary.setHeatingCoil(hc));
+
+  EXPECT_EQ("None", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("SupplyAirFlowRate", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  ASSERT_TRUE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired().get());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FlowPerFloorArea", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  ASSERT_TRUE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired().get());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  unitary.autosizeSupplyAirFlowRateWhenNoCoolingorHeatingisRequired();
+  EXPECT_EQ("SupplyAirFlowRate", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_TRUE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FractionOfAutosizedCoolingValue", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  ASSERT_TRUE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired().get());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FractionOfAutosizedHeatingValue", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  ASSERT_TRUE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired().get());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FlowPerCoolingCapacity", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  ASSERT_TRUE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired().get());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FlowPerHeatingCapacity", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  ASSERT_TRUE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_EQ(1.0, unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired().get());
+
+  // Reset both coils => back to None
+  unitary.resetHeatingCoil();
+  EXPECT_EQ("FlowPerHeatingCapacity", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+
+  unitary.resetCoolingCoil();
+  EXPECT_EQ("None", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
+
+  EXPECT_TRUE(unitary.setHeatingCoil(hc));
+  EXPECT_TRUE(unitary.setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(1.0));
+  EXPECT_EQ("FlowPerHeatingCapacity", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  unitary.resetSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired();
+  EXPECT_EQ("None", unitary.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.isSupplyAirFlowRateWhenNoCoolingorHeatingisRequiredAutosized());
+  EXPECT_FALSE(unitary.supplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.supplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.fractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired());
+  EXPECT_FALSE(unitary.designSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired());
 }
 
 TEST_F(ModelFixture, AirLoopHVACUnitarySystem_needToRemoveDeprecated) {

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -7755,26 +7755,35 @@ namespace osversion {
             }
           }
           if (!found) {
-            LOG(Warn, "For " << object.briefDescription()
-                             << ", there is a cooling coil, but no Supply Air Flow Rate Method During Cooling Operation and no flow rate fields set. "
-                                "Defaulting to SupplyAirFlowRate with Autosize");
+            LOG(Warn, "For AirLoopHVACUnitarySystem '"
+                        << object.nameString()
+                        << "', there is a cooling coil, but no Supply Air Flow Rate Method During Cooling Operation and no flow rate fields set. "
+                           "Defaulting to SupplyAirFlowRate with Autosize");
             newObject.setString(coolingSAFMethodIndex, "SupplyAirFlowRate");
             newObject.setString(coolingSAFMethodIndex + 1, "Autosize");
           }
         } else {
           std::string coolingSAFMethodUC = ascii_to_upper_copy(*coolingSAFMethod);
-          auto it = std::find_if(coolingSAFMethodChoicesUC.cbegin(), coolingSAFMethodChoicesUC.cend(),
-                                 [&coolingSAFMethodUC](auto& s) { return s == coolingSAFMethodUC; });
-          if (it == coolingSAFMethodChoicesUC.cend()) {
-            LOG(Error,
-                "For " << object.briefDescription() << ", Unrecognized Supply Air Flow Method Rate During Cooling Operation=" << *coolingSAFMethod);
+          if (coolingSAFMethodUC == "NONE") {
+            LOG(Warn, "For AirLoopHVACUnitarySystem '"
+                        << object.nameString()
+                        << "', Supply Air Flow Method Rate During Cooling Operation is 'None' but you have a Cooling Coil, consider changing it");
           } else {
-            auto index = std::distance(coolingSAFMethodChoicesUC.cbegin(), it);
-            if ((value == object.getString(index))) {
-              newObject.setString(index, *value);
+            auto it = std::find_if(coolingSAFMethodChoicesUC.cbegin(), coolingSAFMethodChoicesUC.cend(),
+                                   [&coolingSAFMethodUC](auto& s) { return s == coolingSAFMethodUC; });
+            if (it == coolingSAFMethodChoicesUC.cend()) {
+              LOG(Error, "For AirLoopHVACUnitarySystem '"
+                           << object.nameString() << "', Unrecognized Supply Air Flow Method Rate During Cooling Operation=" << *coolingSAFMethod);
             } else {
-              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Method Rate During Cooling Operation is '" << *coolingSAFMethod
-                                << "' but associated field is empty");
+              const auto dist = std::distance(coolingSAFMethodChoicesUC.cbegin(), it);
+              const size_t index = coolingSAFMethodIndex + 1 + dist;
+              if ((value = object.getString(index))) {
+                newObject.setString(index, *value);
+              } else {
+                LOG(Error, "For AirLoopHVACUnitarySystem '" << object.nameString() << "', Supply Air Flow Method Rate During Cooling Operation is '"
+                                                            << *coolingSAFMethod << "' but associated field is empty. Setting it to zero.");
+                newObject.setDouble(index, 0.0);
+              }
             }
           }
         }
@@ -7799,26 +7808,35 @@ namespace osversion {
             }
           }
           if (!found) {
-            LOG(Warn, "For " << object.briefDescription()
-                             << ", there is a heating coil, but no Supply Air Flow Rate Method During Heating Operation and no flow rate fields set. "
-                                "Defaulting to SupplyAirFlowRate with Autosize");
+            LOG(Warn, "For AirLoopHVACUnitarySystem '"
+                        << object.nameString()
+                        << "', there is a heating coil, but no Supply Air Flow Rate Method During Heating Operation and no flow rate fields set. "
+                           "Defaulting to SupplyAirFlowRate with Autosize");
             newObject.setString(heatingSAFMethodIndex, "SupplyAirFlowRate");
             newObject.setString(heatingSAFMethodIndex + 1, "Autosize");
           }
         } else {
           std::string heatingSAFMethodUC = ascii_to_upper_copy(*heatingSAFMethod);
-          auto it = std::find_if(heatingSAFMethodChoicesUC.cbegin(), heatingSAFMethodChoicesUC.cend(),
-                                 [&heatingSAFMethodUC](auto& s) { return s == heatingSAFMethodUC; });
-          if (it == heatingSAFMethodChoicesUC.cend()) {
-            LOG(Error,
-                "For " << object.briefDescription() << ", Unrecognized Supply Air Flow Method Rate During Heating Operation=" << *heatingSAFMethod);
+          if (heatingSAFMethodUC == "NONE") {
+            LOG(Warn, "For AirLoopHVACUnitarySystem '"
+                        << object.nameString()
+                        << "', Supply Air Flow Method Rate During Heating Operation is 'None' but you have a Heating coil, consider changing it");
           } else {
-            auto index = std::distance(heatingSAFMethodChoicesUC.cbegin(), it);
-            if ((value == object.getString(index))) {
-              newObject.setString(index, *value);
+            auto it = std::find_if(heatingSAFMethodChoicesUC.cbegin(), heatingSAFMethodChoicesUC.cend(),
+                                   [&heatingSAFMethodUC](auto& s) { return s == heatingSAFMethodUC; });
+            if (it == heatingSAFMethodChoicesUC.cend()) {
+              LOG(Error, "For AirLoopHVACUnitarySystem '"
+                           << object.nameString() << "', Unrecognized Supply Air Flow Method Rate During Heating Operation=" << *heatingSAFMethod);
             } else {
-              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Method Rate During Heating Operation is '" << *heatingSAFMethod
-                                << "' but associated field is empty");
+              auto dist = std::distance(heatingSAFMethodChoicesUC.cbegin(), it);
+              const size_t index = heatingSAFMethodIndex + 1 + dist;
+              if ((value = object.getString(index))) {
+                newObject.setString(index, *value);
+              } else {
+                LOG(Error, "For AirLoopHVACUnitarySystem '" << object.nameString() << "', Supply Air Flow Method Rate During Heating Operation is '"
+                                                            << *heatingSAFMethod << "' but associated field is empty. Setting it to zero.");
+                newObject.setDouble(index, 0.0);
+              }
             }
           }
         }
@@ -7848,7 +7866,7 @@ namespace osversion {
             }
           }
           if (!found) {
-            LOG(Warn, "For " << object.briefDescription()
+            LOG(Warn, "For AirLoopHVACUnitarySystem '" << object.nameString()
                              << ", there is no Supply Air Flow Rate Method When No Cooling or Heating is Required and no flow rate fields set. "
                                 "Defaulting to None");
             newObject.setString(noCoolHeatSAFMethodIndex, "None");
@@ -7856,18 +7874,23 @@ namespace osversion {
 #endif
         } else {
           std::string noCoolHeatSAFMethodUC = ascii_to_upper_copy(*noCoolHeatSAFMethod);
-          auto it = std::find_if(noCoolHeatSAFMethodChoicesUC.cbegin(), noCoolHeatSAFMethodChoicesUC.cend(),
-                                 [&noCoolHeatSAFMethodUC](auto& s) { return s == noCoolHeatSAFMethodUC; });
-          if (it == noCoolHeatSAFMethodChoicesUC.cend()) {
-            LOG(Error, "For " << object.briefDescription()
-                              << ", Unrecognized Supply Air Flow Rate Method When No Cooling or Heating is Required=" << *noCoolHeatSAFMethod);
-          } else {
-            auto index = std::distance(noCoolHeatSAFMethodChoicesUC.cbegin(), it);
-            if ((value == object.getString(index))) {
-              newObject.setString(index, *value);
+          if (noCoolHeatSAFMethodUC != "NONE") {
+            auto it = std::find_if(noCoolHeatSAFMethodChoicesUC.cbegin(), noCoolHeatSAFMethodChoicesUC.cend(),
+                                   [&noCoolHeatSAFMethodUC](auto& s) { return s == noCoolHeatSAFMethodUC; });
+            if (it == noCoolHeatSAFMethodChoicesUC.cend()) {
+              LOG(Error, "For AirLoopHVACUnitarySystem '"
+                           << object.nameString()
+                           << "', Unrecognized Supply Air Flow Rate Method When No Cooling or Heating is Required=" << *noCoolHeatSAFMethod);
             } else {
-              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Rate Method When No Cooling or Heating is Required is '"
-                                << *noCoolHeatSAFMethod << "' but associated field is empty");
+              auto dist = std::distance(noCoolHeatSAFMethodChoicesUC.cbegin(), it);
+              const size_t index = noCoolHeatSAFMethodIndex + 1 + dist;
+              if ((value = object.getString(index))) {
+                newObject.setString(index, *value);
+              } else {
+                LOG(Error, "For AirLoopHVACUnitarySystem '" << object.nameString()
+                                                            << "', Supply Air Flow Rate Method When No Cooling or Heating is Required is '"
+                                                            << *noCoolHeatSAFMethod << "' but associated field is empty");
+              }
             }
           }
         }

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -34,6 +34,7 @@
 #include "../utilities/math/FloatCompare.hpp"
 #include "../utilities/idf/IdfObject_Impl.hpp"
 #include "../utilities/core/UUID.hpp"
+#include "../utilities/core/ASCIIStrings.hpp"
 
 #include <utilities/idd/IddFactory.hxx>
 #include <utilities/idd/IddEnums.hxx>
@@ -7663,6 +7664,212 @@ namespace osversion {
 
         ss << ghxObject;
         ss << kusudaObject;
+
+      } else if (iddname == "OS:AirLoopHVAC:UnitarySystem") {
+
+        // NOTE: With 23.2.0-IOFreeze, we always have a change anyways cause some fields were removed
+
+        auto iddObject = idd_3_7_0.getObject(iddname);
+        IdfObject newObject(iddObject.get());
+
+        for (size_t i = 0; i < object.numFields(); ++i) {
+          if ((value = object.getString(i))) {
+            newObject.setString(i, value.get());
+          }
+        }
+
+        // * 11 - Heating Coil Name
+        constexpr unsigned heatingCoilNameIndex = 11;
+        const bool hasHeatingCoil = !object.isEmpty(heatingCoilNameIndex);
+
+        // * 13 - Cooling Coil Name
+        constexpr unsigned coolingCoilNameIndex = 13;
+        const bool hasCoolingCoil = !object.isEmpty(coolingCoilNameIndex);
+
+        // We use getString(idx, false, true) to not get default, returned unitialized empty
+
+        // * 18 - Supply Air Flow Rate Method During Cooling Operation
+        constexpr unsigned coolingSAFMethodIndex = 18;
+        boost::optional<std::string> coolingSAFMethod = object.getString(coolingSAFMethodIndex, false, true);
+
+        // * 23 - Supply Air Flow Rate Method During Heating Operation
+        constexpr unsigned heatingSAFMethodIndex = 23;
+        boost::optional<std::string> heatingSAFMethod = object.getString(heatingSAFMethodIndex, false, true);
+
+        // * 28 - Supply Air Flow Rate Method When No Cooling or Heating is Required
+        constexpr unsigned noCoolHeatSAFMethodIndex = 28;
+        boost::optional<std::string> noCoolHeatSAFMethod = object.getString(noCoolHeatSAFMethodIndex, false, true);
+
+        constexpr std::array<std::string_view, 4> coolingSAFMethodChoices{"SupplyAirFlowRate", "FlowPerFloorArea", "FractionOfAutosizedCoolingValue",
+                                                                          "FlowPerCoolingCapacity"};
+
+        constexpr std::array<std::string_view, 4> coolingSAFMethodChoicesUC{"SUPPLYAIRFLOWRATE", "FLOWPERFLOORAREA",
+                                                                            "FRACTIONOFAUTOSIZEDCOOLINGVALUE", "FLOWPERCOOLINGCAPACITY"};
+
+        constexpr std::array<std::string_view, 4> heatingSAFMethodChoices{"SupplyAirFlowRate", "FlowPerFloorArea", "FractionOfAutosizedHeatingValue",
+                                                                          "FlowPerHeatingCapacity"};
+        constexpr std::array<std::string_view, 4> heatingSAFMethodChoicesUC{"SUPPLYAIRFLOWRATE", "FLOWPERFLOORAREA",
+                                                                            "FRACTIONOFAUTOSIZEDHEATINGVALUE", "FLOWPERHEATINGCAPACITY"};
+
+        constexpr std::array<std::string_view, 6> noCoolHeatSAFMethodChoices{
+          "SupplyAirFlowRate",      "FlowPerFloorArea",      "FractionOfAutosizedCoolingValue", "FractionOfAutosizedHeatingValue",
+          "FlowPerCoolingCapacity", "FlowPerHeatingCapacity"};
+
+        constexpr std::array<std::string_view, 6> noCoolHeatSAFMethodChoicesUC{
+          "SUPPLYAIRFLOWRATE",      "FLOWPERFLOORAREA",      "FRACTIONOFAUTOSIZEDCOOLINGVALUE", "FRACTIONOFAUTOSIZEDHEATINGVALUE",
+          "FLOWPERCOOLINGCAPACITY", "FLOWPERHEATINGCAPACITY"};
+
+        // Reset all flow fields, we want only one at best to be set
+        for (size_t i = 0; i < coolingSAFMethodChoices.size(); ++i) {
+          const size_t fieldIndex = coolingSAFMethodIndex + 1 + i;
+          newObject.setString(fieldIndex, "");
+        }
+        for (size_t i = 0; i < heatingSAFMethodChoices.size(); ++i) {
+          const size_t fieldIndex = heatingSAFMethodIndex + 1 + i;
+          newObject.setString(fieldIndex, "");
+        }
+        for (size_t i = 0; i < noCoolHeatSAFMethodChoices.size(); ++i) {
+          const size_t fieldIndex = noCoolHeatSAFMethodIndex + 1 + i;
+          newObject.setString(fieldIndex, "");
+        }
+
+        if (!hasCoolingCoil) {
+          newObject.setString(coolingSAFMethodIndex, "None");
+        } else if (!coolingSAFMethod) {
+          // Technically here E+ checks if the cooling coil rated air flow rate is autosized or not
+          // Also could get overriden by the DesignSpecification:ZoneHVAC:Sizing
+          // Finally it lets it slide as long as one of the other SupplyAirFlowRateXXX is not empty
+          // Here I guess we'll scan the fields in order, and pick the first we find
+          // * 19 - Supply Air Flow Rate During Cooling Operation
+          // * 20 - Supply Air Flow Rate Per Floor Area During Cooling Operation
+          // * 21 - Fraction of Autosized Design Cooling Supply Air Flow Rate
+          // * 22 - Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation
+          bool found = false;
+          for (size_t i = 0; i < coolingSAFMethodChoices.size(); ++i) {
+            const size_t fieldIndex = coolingSAFMethodIndex + 1 + i;
+            if ((value = object.getString(fieldIndex))) {
+              newObject.setString(coolingSAFMethodIndex, std::string{coolingSAFMethodChoices[i]});
+              newObject.setString(fieldIndex, *value);
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            LOG(Warn, "For " << object.briefDescription()
+                             << ", there is a cooling coil, but no Supply Air Flow Rate Method During Cooling Operation and no flow rate fields set. "
+                                "Defaulting to SupplyAirFlowRate with Autosize");
+            newObject.setString(coolingSAFMethodIndex, "SupplyAirFlowRate");
+            newObject.setString(coolingSAFMethodIndex + 1, "Autosize");
+          }
+        } else {
+          std::string coolingSAFMethodUC = ascii_to_upper_copy(*coolingSAFMethod);
+          auto it = std::find_if(coolingSAFMethodChoicesUC.cbegin(), coolingSAFMethodChoicesUC.cend(),
+                                 [&coolingSAFMethodUC](auto& s) { return s == coolingSAFMethodUC; });
+          if (it == coolingSAFMethodChoicesUC.cend()) {
+            LOG(Error,
+                "For " << object.briefDescription() << ", Unrecognized Supply Air Flow Method Rate During Cooling Operation=" << *coolingSAFMethod);
+          } else {
+            auto index = std::distance(coolingSAFMethodChoicesUC.cbegin(), it);
+            if ((value == object.getString(index))) {
+              newObject.setString(index, *value);
+            } else {
+              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Method Rate During Cooling Operation is '" << *coolingSAFMethod
+                                << "' but associated field is empty");
+            }
+          }
+        }
+
+        if (!hasHeatingCoil) {
+          newObject.setString(heatingSAFMethodIndex, "None");
+        } else if (!heatingSAFMethod) {
+
+          // * 23 - Supply Air Flow Rate Method During Heating Operation
+          // * 24 - Supply Air Flow Rate During Heating Operation
+          // * 25 - Supply Air Flow Rate Per Floor Area during Heating Operation
+          // * 26 - Fraction of Autosized Design Heating Supply Air Flow Rate
+          // * 27 - Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation
+          bool found = false;
+          for (size_t i = 0; i < heatingSAFMethodChoices.size(); ++i) {
+            const size_t fieldIndex = heatingSAFMethodIndex + 1 + i;
+            if ((value = object.getString(fieldIndex))) {
+              newObject.setString(heatingSAFMethodIndex, std::string{heatingSAFMethodChoices[i]});
+              newObject.setString(fieldIndex, *value);
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            LOG(Warn, "For " << object.briefDescription()
+                             << ", there is a heating coil, but no Supply Air Flow Rate Method During Heating Operation and no flow rate fields set. "
+                                "Defaulting to SupplyAirFlowRate with Autosize");
+            newObject.setString(heatingSAFMethodIndex, "SupplyAirFlowRate");
+            newObject.setString(heatingSAFMethodIndex + 1, "Autosize");
+          }
+        } else {
+          std::string heatingSAFMethodUC = ascii_to_upper_copy(*heatingSAFMethod);
+          auto it = std::find_if(heatingSAFMethodChoicesUC.cbegin(), heatingSAFMethodChoicesUC.cend(),
+                                 [&heatingSAFMethodUC](auto& s) { return s == heatingSAFMethodUC; });
+          if (it == heatingSAFMethodChoicesUC.cend()) {
+            LOG(Error,
+                "For " << object.briefDescription() << ", Unrecognized Supply Air Flow Method Rate During Heating Operation=" << *heatingSAFMethod);
+          } else {
+            auto index = std::distance(heatingSAFMethodChoicesUC.cbegin(), it);
+            if ((value == object.getString(index))) {
+              newObject.setString(index, *value);
+            } else {
+              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Method Rate During Heating Operation is '" << *heatingSAFMethod
+                                << "' but associated field is empty");
+            }
+          }
+        }
+
+        if (!hasHeatingCoil && !hasCoolingCoil) {
+          // TODO: not sure here
+          newObject.setString(noCoolHeatSAFMethodIndex, "None");
+        } else if (!noCoolHeatSAFMethod) {
+
+          // * 29 - Supply Air Flow Rate When No Cooling or Heating is Required
+          // * 30 - Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required
+          // * 31 - Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+          // * 32 - Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+          // * 33 - Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required
+          // * 34 - Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required
+          bool found = false;
+          for (size_t i = 0; i < noCoolHeatSAFMethodChoices.size(); ++i) {
+            const size_t fieldIndex = noCoolHeatSAFMethodIndex + 1 + i;
+            if ((value = object.getString(fieldIndex))) {
+              newObject.setString(noCoolHeatSAFMethodIndex, std::string{noCoolHeatSAFMethodChoices[i]});
+              newObject.setString(fieldIndex, *value);
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            LOG(Warn, "For " << object.briefDescription()
+                             << ", there is no Supply Air Flow Rate Method When No Cooling or Heating is Required and no flow rate fields set. "
+                                "Defaulting to None");
+            newObject.setString(noCoolHeatSAFMethodIndex, "None");
+          }
+        } else {
+          std::string noCoolHeatSAFMethodUC = ascii_to_upper_copy(*noCoolHeatSAFMethod);
+          auto it = std::find_if(noCoolHeatSAFMethodChoicesUC.cbegin(), noCoolHeatSAFMethodChoicesUC.cend(),
+                                 [&noCoolHeatSAFMethodUC](auto& s) { return s == noCoolHeatSAFMethodUC; });
+          if (it == noCoolHeatSAFMethodChoicesUC.cend()) {
+            LOG(Error, "For " << object.briefDescription()
+                              << ", Unrecognized Supply Air Flow Rate Method When No Cooling or Heating is Required=" << *noCoolHeatSAFMethod);
+          } else {
+            auto index = std::distance(noCoolHeatSAFMethodChoicesUC.cbegin(), it);
+            if ((value == object.getString(index))) {
+              newObject.setString(index, *value);
+            } else {
+              LOG(Error, "For " << object.briefDescription() << ", Supply Air Flow Rate Method When No Cooling or Heating is Required is '"
+                                << *noCoolHeatSAFMethod << "' but associated field is empty");
+            }
+          }
+        }
+
+        ss << newObject;
+        m_refactored.emplace_back(std::move(object), std::move(newObject));
 
         // No-op
       } else {

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -7828,6 +7828,9 @@ namespace osversion {
           newObject.setString(noCoolHeatSAFMethodIndex, "None");
         } else if (!noCoolHeatSAFMethod) {
 
+          // Blank is equivalent to None here, no question
+          newObject.setString(noCoolHeatSAFMethodIndex, "None");
+#if 0
           // * 29 - Supply Air Flow Rate When No Cooling or Heating is Required
           // * 30 - Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required
           // * 31 - Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
@@ -7850,6 +7853,7 @@ namespace osversion {
                                 "Defaulting to None");
             newObject.setString(noCoolHeatSAFMethodIndex, "None");
           }
+#endif
         } else {
           std::string noCoolHeatSAFMethodUC = ascii_to_upper_copy(*noCoolHeatSAFMethod);
           auto it = std::find_if(noCoolHeatSAFMethodChoicesUC.cbegin(), noCoolHeatSAFMethodChoicesUC.cend(),

--- a/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods.py
+++ b/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods.py
@@ -1,0 +1,175 @@
+import openstudio
+
+FIELD_IDENTIFIERS = [
+    "CoolingSAFMethod",
+    "CoolingSAFMethod_SAFlow",
+    "CoolingSAFMethod_SAFlowPerFloorArea",
+    "CoolingSAFMethod_FracOfAutosizedCoolingSAFlow",
+    "CoolingSAFMethod_FlowPerCoolingCapacity",
+    "HeatingSAFMethod",
+    "HeatingSAFMethod_SAFlow",
+    "HeatingSAFMethod_SAFlowPerFloorArea",
+    "HeatingSAFMethod_FracOfAutosizedHeatingSAFlow",
+    "HeatingSAFMethod_FlowPerHeatingCapacity",
+    "NoCoolHeatSAFMethod",
+    "NoCoolHeatSAFMethod_SAFlow",
+    "NoCoolHeatSAFMethod_SAFlowPerFloorArea",
+    "NoCoolHeatSAFMethod_FracOfAutosizedCoolingSAFlow",
+    "NoCoolHeatSAFMethod_FracOfAutosizedHeatingSAFlow",
+    "NoCoolHeatSAFMethod_FlowPerCoolingCapacity",
+    "NoCoolHeatSAFMethod_FlowPerHeatingCapacity",
+]
+
+COOLINGSAFMETHODINDEX = 18
+
+
+def get_info(unitary):
+    return {
+        field_identifier: unitary.getString(i + COOLINGSAFMETHODINDEX, False, False).get()
+        for i, field_identifier in enumerate(FIELD_IDENTIFIERS)
+    }
+
+
+def add_cooling_coil(unitary: openstudio.model.AirLoopHVACUnitarySystem, model: openstudio.model.Model):
+    cc = openstudio.model.CoilCoolingDXSingleSpeed(model)
+    assert unitary.setCoolingCoil(cc)
+
+
+def add_heating_coil(unitary: openstudio.model.AirLoopHVACUnitarySystem, model: openstudio.model.Model):
+    hc = openstudio.model.CoilHeatingDXSingleSpeed(model)
+    assert unitary.setHeatingCoil(hc)
+
+
+def apply_coils_or_not(m: openstudio.model.Model, prefix: str):
+    coil_methods = [None, add_cooling_coil, add_heating_coil]
+
+    unitarys = m.getAirLoopHVACUnitarySystems()
+    assert len(unitarys) == 3
+
+    test_infos = []
+
+    for coil_method, u in zip(coil_methods, unitarys):
+        coil_method_name = "None"
+        has_cc = False
+        has_hc = False
+        if coil_method is not None:
+            coil_method(unitary=u, model=m)
+            coil_method_name = coil_method.__name__
+            if coil_method_name == "add_cooling_coil":
+                has_cc = True
+            else:
+                has_hc = True
+
+        test_case = f"{prefix} - {coil_method_name}"
+        u.setName(test_case)
+        print(test_case)
+        coolingSAFMethod = ""
+        heatingSAFMethod = ""
+        noCoolHeatSAFMethod = ""
+        if (coolingSAFMethod_ := u.supplyAirFlowRateMethodDuringCoolingOperation()).is_initialized():
+            coolingSAFMethod = coolingSAFMethod_.get()
+
+        if (heatingSAFMethod_ := u.supplyAirFlowRateMethodDuringHeatingOperation()).is_initialized():
+            heatingSAFMethod = heatingSAFMethod_.get()
+
+        if (noCoolHeatSAFMethod_ := u.supplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired()).is_initialized():
+            noCoolHeatSAFMethod = noCoolHeatSAFMethod_.get()
+
+        test_infos.append(
+            dict(
+                {
+                    "test_case": test_case,
+                    "CC": has_cc,
+                    "HC": has_hc,
+                    "coolingSAFMethod": coolingSAFMethod,
+                    "heatingSAFMethod": heatingSAFMethod,
+                    "noCoolHeatSAFMethod": noCoolHeatSAFMethod,
+                },
+                **get_info(unitary=u),
+            )
+        )
+
+    return test_infos
+
+
+def model_default():
+    """In this test, this is the Default constructed Unitary System, just adding coils (or not).
+
+    The Supply Air Flow During XXX field is set to Autosize, yet the Method field isn't "SupplyAirFlowRate" but blank.
+    """
+
+    m = openstudio.model.Model()
+    for i in range(3):
+        openstudio.model.AirLoopHVACUnitarySystem(m)
+    test_infos = apply_coils_or_not(m, prefix="Default")
+    return m, test_infos
+
+
+def test_SAF_not_null_but_correct_combos():
+    """In this test, the SAF method is filled out, and ALL flow fields are set.
+
+    We respect the SAF method choice, we keep the corresponding flow field, and clear out all the others
+    """
+    m = openstudio.model.Model()
+    for i in range(3):
+        u = openstudio.model.AirLoopHVACUnitarySystem(m)
+
+        # Supply Air Flow Rate Method During Cooling Operation
+        assert u.setSupplyAirFlowRateMethodDuringCoolingOperation("FlowPerFloorArea")
+        assert u.setSupplyAirFlowRateDuringCoolingOperation(1.0)
+        assert u.setSupplyAirFlowRatePerFloorAreaDuringCoolingOperation(1.1)
+        assert u.setFractionofAutosizedDesignCoolingSupplyAirFlowRate(1.2)
+        assert u.setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation(1.3)
+
+        # Supply Air Flow Rate Method During Heating Operation
+        assert u.setSupplyAirFlowRateMethodDuringHeatingOperation("FlowPerHeatingCapacity")
+        assert u.setSupplyAirFlowRateDuringHeatingOperation(2.0)
+        assert u.setSupplyAirFlowRatePerFloorAreaduringHeatingOperation(2.1)
+        assert u.setFractionofAutosizedDesignHeatingSupplyAirFlowRate(2.2)
+        assert u.setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation(2.3)
+
+        # Supply Air Flow Rate Method When No Cooling or Heating is Required
+        assert u.setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FractionOfAutosizedHeatingValue")
+        assert u.setSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0.1)
+        assert u.setSupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired(0.2)
+        assert u.setFractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0.3)
+        assert u.setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0.4)
+        assert u.setDesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired(0.5)
+        assert u.setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired(0.6)
+
+    test_infos = apply_coils_or_not(m, prefix="SAF_correct")
+    return m, test_infos
+
+
+def test_SAF_not_null_and_incorrect_combos():
+    """In this test, the SAF method is filled out, but the corresponding flow field isn't.
+
+    We respect the SAF method choice, and we set the corresponding flow field field to zero
+    """
+    m = openstudio.model.Model()
+    for i in range(3):
+        u = openstudio.model.AirLoopHVACUnitarySystem(m)
+        assert u.setSupplyAirFlowRateMethodDuringCoolingOperation("FractionOfAutosizedCoolingValue")
+        assert u.setSupplyAirFlowRatePerFloorAreaDuringCoolingOperation(1.0)
+
+        assert u.setSupplyAirFlowRateMethodDuringHeatingOperation("FlowPerFloorArea")
+        assert u.setDesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation(3.0)
+
+        assert u.setSupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired("FlowPerCoolingCapacity")
+        assert u.setFractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired(0.4)
+    test_infos = apply_coils_or_not(m, prefix="SAF_incorrect")
+    return m, test_infos
+
+
+if __name__ == "__main__":
+    m1, test_infos = model_default()
+    m1.save("test_vt_UnitarySystem_SAFMethods_default.osm", True)
+
+    m2, test_infos2 = test_SAF_not_null_but_correct_combos()
+    m2.save("test_vt_UnitarySystem_SAFMethods_CorrectCombos.osm", True)
+    test_infos += test_infos2
+
+    m3, test_infos3 = test_SAF_not_null_and_incorrect_combos()
+    m3.save("test_vt_UnitarySystem_SAFMethods_IncorrectCombos.osm", True)
+    test_infos += test_infos3
+    print(test_infos)

--- a/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods.py
+++ b/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods.py
@@ -1,5 +1,7 @@
 import openstudio
 
+assert openstudio.openStudioVersion() == "3.6.1"
+
 FIELD_IDENTIFIERS = [
     "CoolingSAFMethod",
     "CoolingSAFMethod_SAFlow",

--- a/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_CorrectCombos.osm
+++ b/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_CorrectCombos.osm
@@ -1,0 +1,320 @@
+
+OS:Version,
+  {826bc855-f2b0-4d21-a4e0-7feb01bf135a}, !- Handle
+  3.6.1;                                  !- Version Identifier
+
+OS:AirLoopHVAC:UnitarySystem,
+  {58e19f48-4089-4b57-9e5e-18ea9c483ad2}, !- Handle
+  SAF_correct - add_heating_coil,         !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {a3fd1a80-687a-4e6c-8552-0a37f52978de}, !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Cooling Operation
+  1,                                      !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1.1,                                    !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  1.2,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  1.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerHeatingCapacity,                 !- Supply Air Flow Rate Method During Heating Operation
+  2,                                      !- Supply Air Flow Rate During Heating Operation {m3/s}
+  2.1,                                    !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  2.2,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  2.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FractionOfAutosizedHeatingValue,        !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  0.1,                                    !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  0.2,                                    !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  0.3,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  0.5,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  0.6,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {18f22c23-ad26-44ba-bc05-c08bcd95c845}, !- Handle
+  SAF_correct - add_cooling_coil,         !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  {cb92d862-d9a0-4e5f-85e6-18684de45d25}, !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Cooling Operation
+  1,                                      !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1.1,                                    !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  1.2,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  1.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerHeatingCapacity,                 !- Supply Air Flow Rate Method During Heating Operation
+  2,                                      !- Supply Air Flow Rate During Heating Operation {m3/s}
+  2.1,                                    !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  2.2,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  2.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FractionOfAutosizedHeatingValue,        !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  0.1,                                    !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  0.2,                                    !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  0.3,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  0.5,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  0.6,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {891b942e-5509-4dc2-b924-1576b2326fc4}, !- Handle
+  SAF_correct - None,                     !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Cooling Operation
+  1,                                      !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1.1,                                    !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  1.2,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  1.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerHeatingCapacity,                 !- Supply Air Flow Rate Method During Heating Operation
+  2,                                      !- Supply Air Flow Rate During Heating Operation {m3/s}
+  2.1,                                    !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  2.2,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  2.3,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FractionOfAutosizedHeatingValue,        !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  0.1,                                    !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  0.2,                                    !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  0.3,                                    !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  0.5,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  0.6,                                    !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {cb92d862-d9a0-4e5f-85e6-18684de45d25}, !- Handle
+  Coil Cooling DX Single Speed 1,         !- Name
+  {3d5fe8ea-ba4b-40b5-a714-5b9ccef5eef0}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {3e685313-d3b8-4f51-81ec-faa748cb0ccf}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {9442da5a-0cd8-4014-ae12-784c9021760c}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {d14f84e0-acc8-4d8c-acff-529a16de7ce1}, !- Energy Input Ratio Function of Temperature Curve Name
+  {8e6cd4dd-3705-4541-8afe-9bfe326baf9f}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {a4ec44c3-6139-4982-a95c-a8a3807b2205}, !- Part Load Fraction Correlation Curve Name
+  -25,                                    !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  0,                                      !- Nominal Time for Condensate Removal to Begin {s}
+  0,                                      !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  0,                                      !- Maximum Cycling Rate {cycles/hr}
+  0,                                      !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0.9,                                    !- Evaporative Condenser Effectiveness {dimensionless}
+  autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  10,                                     !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  2;                                      !- Basin Heater Setpoint Temperature {C}
+
+OS:Curve:Biquadratic,
+  {3e685313-d3b8-4f51-81ec-faa748cb0ccf}, !- Handle
+  Curve Biquadratic 1,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {9442da5a-0cd8-4014-ae12-784c9021760c}, !- Handle
+  Curve Quadratic 1,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {d14f84e0-acc8-4d8c-acff-529a16de7ce1}, !- Handle
+  Curve Biquadratic 2,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {8e6cd4dd-3705-4541-8afe-9bfe326baf9f}, !- Handle
+  Curve Quadratic 2,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {a4ec44c3-6139-4982-a95c-a8a3807b2205}, !- Handle
+  Curve Quadratic 3,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Schedule:Constant,
+  {3d5fe8ea-ba4b-40b5-a714-5b9ccef5eef0}, !- Handle
+  Always On Discrete,                     !- Name
+  {6848911b-d942-4905-a3d7-a0994b4241f0}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {6848911b-d942-4905-a3d7-a0994b4241f0}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Coil:Heating:DX:SingleSpeed,
+  {a3fd1a80-687a-4e6c-8552-0a37f52978de}, !- Handle
+  Coil Heating DX Single Speed 1,         !- Name
+  {3d5fe8ea-ba4b-40b5-a714-5b9ccef5eef0}, !- Availability Schedule Name
+  Autosize,                               !- Rated Total Heating Capacity {W}
+  5,                                      !- Rated COP {W/W}
+  Autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {4929c2de-327f-4aef-9148-88958a4ea035}, !- Total Heating Capacity Function of Temperature Curve Name
+  {c16602e7-747a-45d2-b5e3-61006c406dac}, !- Total Heating Capacity Function of Flow Fraction Curve Name
+  {60d95f6b-2975-4bc2-a419-c058bd09a09b}, !- Energy Input Ratio Function of Temperature Curve Name
+  {c84710ff-52d9-4e54-a8d8-9548057e0b9e}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {5f186b70-8f3e-4d94-b6c4-714b123581f0}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Defrost Energy Input Ratio Function of Temperature Curve Name
+  ,                                       !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Defrost Operation {C}
+  ,                                       !- Crankcase Heater Capacity {W}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  Resistive,                              !- Defrost Strategy
+  Timed,                                  !- Defrost Control
+  0.166667,                               !- Defrost Time Period Fraction
+  2000;                                   !- Resistive Defrost Heater Capacity {W}
+
+OS:Curve:Cubic,
+  {4929c2de-327f-4aef-9148-88958a4ea035}, !- Handle
+  Curve Cubic 1,                          !- Name
+  0.758746,                               !- Coefficient1 Constant
+  0.027626,                               !- Coefficient2 x
+  0.000148716,                            !- Coefficient3 x**2
+  3.4992e-06,                             !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {c16602e7-747a-45d2-b5e3-61006c406dac}, !- Handle
+  Curve Cubic 2,                          !- Name
+  0.84,                                   !- Coefficient1 Constant
+  0.16,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {60d95f6b-2975-4bc2-a419-c058bd09a09b}, !- Handle
+  Curve Cubic 3,                          !- Name
+  1.19248,                                !- Coefficient1 Constant
+  -0.0300438,                             !- Coefficient2 x
+  0.00103745,                             !- Coefficient3 x**2
+  -2.3328e-05,                            !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {c84710ff-52d9-4e54-a8d8-9548057e0b9e}, !- Handle
+  Curve Quadratic 4,                      !- Name
+  1.3824,                                 !- Coefficient1 Constant
+  -0.4336,                                !- Coefficient2 x
+  0.0512,                                 !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {5f186b70-8f3e-4d94-b6c4-714b123581f0}, !- Handle
+  Curve Quadratic 5,                      !- Name
+  0.75,                                   !- Coefficient1 Constant
+  0.25,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+

--- a/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_IncorrectCombos.osm
+++ b/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_IncorrectCombos.osm
@@ -1,0 +1,320 @@
+
+OS:Version,
+  {f480fe7b-4869-4f4c-a40f-a36ca5fe0ee2}, !- Handle
+  3.6.1;                                  !- Version Identifier
+
+OS:AirLoopHVAC:UnitarySystem,
+  {afe538ed-29a5-4bb6-bc93-33362e70a083}, !- Handle
+  SAF_incorrect - add_heating_coil,       !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {c25703b5-59b9-472e-957e-c5e14975ec12}, !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FractionOfAutosizedCoolingValue,        !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1,                                      !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  3,                                      !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FlowPerCoolingCapacity,                 !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {89776c9d-4cc0-43db-b97e-2dcd9395a38d}, !- Handle
+  SAF_incorrect - add_cooling_coil,       !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  {7f0c5ec2-2082-4707-b28b-3afdef680ec7}, !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FractionOfAutosizedCoolingValue,        !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1,                                      !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  3,                                      !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FlowPerCoolingCapacity,                 !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {fd298370-9752-4469-868b-df4e69ca764d}, !- Handle
+  SAF_incorrect - None,                   !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  FractionOfAutosizedCoolingValue,        !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  1,                                      !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  FlowPerFloorArea,                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  3,                                      !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  FlowPerCoolingCapacity,                 !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  0.4,                                    !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {7f0c5ec2-2082-4707-b28b-3afdef680ec7}, !- Handle
+  Coil Cooling DX Single Speed 1,         !- Name
+  {d4d7ab0f-8358-4a08-a897-12fcfc3fb6cc}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {d9bb06f0-03a7-423d-a0c9-abc11ac7e876}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {be1b33e8-727c-49d3-8daa-8b4a79d6bc94}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {3ee6c8ce-6f40-4c36-8413-03d331783b42}, !- Energy Input Ratio Function of Temperature Curve Name
+  {29b0e682-aa96-475d-a269-2a6ac9934604}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {c846593d-7f90-48e2-a049-515c0f2f2f8f}, !- Part Load Fraction Correlation Curve Name
+  -25,                                    !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  0,                                      !- Nominal Time for Condensate Removal to Begin {s}
+  0,                                      !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  0,                                      !- Maximum Cycling Rate {cycles/hr}
+  0,                                      !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0.9,                                    !- Evaporative Condenser Effectiveness {dimensionless}
+  autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  10,                                     !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  2;                                      !- Basin Heater Setpoint Temperature {C}
+
+OS:Curve:Biquadratic,
+  {d9bb06f0-03a7-423d-a0c9-abc11ac7e876}, !- Handle
+  Curve Biquadratic 1,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {be1b33e8-727c-49d3-8daa-8b4a79d6bc94}, !- Handle
+  Curve Quadratic 1,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {3ee6c8ce-6f40-4c36-8413-03d331783b42}, !- Handle
+  Curve Biquadratic 2,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {29b0e682-aa96-475d-a269-2a6ac9934604}, !- Handle
+  Curve Quadratic 2,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {c846593d-7f90-48e2-a049-515c0f2f2f8f}, !- Handle
+  Curve Quadratic 3,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Schedule:Constant,
+  {d4d7ab0f-8358-4a08-a897-12fcfc3fb6cc}, !- Handle
+  Always On Discrete,                     !- Name
+  {1cf9fda4-9d4f-4c4c-97c8-1dfef16a2192}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {1cf9fda4-9d4f-4c4c-97c8-1dfef16a2192}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Coil:Heating:DX:SingleSpeed,
+  {c25703b5-59b9-472e-957e-c5e14975ec12}, !- Handle
+  Coil Heating DX Single Speed 1,         !- Name
+  {d4d7ab0f-8358-4a08-a897-12fcfc3fb6cc}, !- Availability Schedule Name
+  Autosize,                               !- Rated Total Heating Capacity {W}
+  5,                                      !- Rated COP {W/W}
+  Autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {794e6866-0c6f-49b9-b8d8-7d2d21937227}, !- Total Heating Capacity Function of Temperature Curve Name
+  {d4dde2dc-0a92-48b5-9eb4-26e608493c7f}, !- Total Heating Capacity Function of Flow Fraction Curve Name
+  {52593531-43ad-4c0b-a851-42015604ab16}, !- Energy Input Ratio Function of Temperature Curve Name
+  {f91e3329-e69a-4d66-909c-88617b95f34e}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {ccf71900-0aa5-4c50-a615-bbd07a61a263}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Defrost Energy Input Ratio Function of Temperature Curve Name
+  ,                                       !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Defrost Operation {C}
+  ,                                       !- Crankcase Heater Capacity {W}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  Resistive,                              !- Defrost Strategy
+  Timed,                                  !- Defrost Control
+  0.166667,                               !- Defrost Time Period Fraction
+  2000;                                   !- Resistive Defrost Heater Capacity {W}
+
+OS:Curve:Cubic,
+  {794e6866-0c6f-49b9-b8d8-7d2d21937227}, !- Handle
+  Curve Cubic 1,                          !- Name
+  0.758746,                               !- Coefficient1 Constant
+  0.027626,                               !- Coefficient2 x
+  0.000148716,                            !- Coefficient3 x**2
+  3.4992e-06,                             !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {d4dde2dc-0a92-48b5-9eb4-26e608493c7f}, !- Handle
+  Curve Cubic 2,                          !- Name
+  0.84,                                   !- Coefficient1 Constant
+  0.16,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {52593531-43ad-4c0b-a851-42015604ab16}, !- Handle
+  Curve Cubic 3,                          !- Name
+  1.19248,                                !- Coefficient1 Constant
+  -0.0300438,                             !- Coefficient2 x
+  0.00103745,                             !- Coefficient3 x**2
+  -2.3328e-05,                            !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {f91e3329-e69a-4d66-909c-88617b95f34e}, !- Handle
+  Curve Quadratic 4,                      !- Name
+  1.3824,                                 !- Coefficient1 Constant
+  -0.4336,                                !- Coefficient2 x
+  0.0512,                                 !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {ccf71900-0aa5-4c50-a615-bbd07a61a263}, !- Handle
+  Curve Quadratic 5,                      !- Name
+  0.75,                                   !- Coefficient1 Constant
+  0.25,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+

--- a/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_default.osm
+++ b/src/osversion/test/3_7_0/test_vt_UnitarySystem_SAFMethods_default.osm
@@ -1,0 +1,320 @@
+
+OS:Version,
+  {6f99e915-0dea-4dbe-96bd-3b7234a03c18}, !- Handle
+  3.6.1;                                  !- Version Identifier
+
+OS:AirLoopHVAC:UnitarySystem,
+  {f3f3c3bf-3329-40f8-9123-5215c701ef2b}, !- Handle
+  Default - add_heating_coil,             !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  {d6a209af-209d-471c-a4ea-71ab99d79d3f}, !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  ,                                       !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {be0b4235-62b4-4df8-a51b-e1d49176e17d}, !- Handle
+  Default - add_cooling_coil,             !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  {bb05defc-c2ad-4aad-b7fb-93b0fa1b50ce}, !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  ,                                       !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {72536bc6-9c33-45c4-9648-14117e0d545a}, !- Handle
+  Default - None,                         !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  None,                                   !- Dehumidification Control Type
+  ,                                       !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  ,                                       !- Supply Fan Name
+  ,                                       !- Fan Placement
+  ,                                       !- Supply Air Fan Operating Mode Schedule Name
+  ,                                       !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  ,                                       !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  SensibleOnlyLoadControl,                !- Latent Load Control
+  ,                                       !- Supplemental Heating Coil Name
+  ,                                       !- Supply Air Flow Rate Method During Cooling Operation
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method During Heating Operation
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  ,                                       !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  2.5,                                    !- Maximum Cycling Rate {cycles/hr}
+  60,                                     !- Heat Pump Time Constant {s}
+  0.01,                                   !- Fraction of On-Cycle Power Use
+  60,                                     !- Heat Pump Fan Delay Time {s}
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0;                                      !- Ancilliary Off-Cycle Electric Power {W}
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {bb05defc-c2ad-4aad-b7fb-93b0fa1b50ce}, !- Handle
+  Coil Cooling DX Single Speed 1,         !- Name
+  {d9b16da6-9221-4d9e-8d71-0f29546866be}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {de8d266b-78ba-4848-a454-b96278b6c40d}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {057a4af8-88a6-42e9-86e1-0f819a786b0b}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {0f22f79d-d2ce-4c53-a45c-3cbcca8fe6e4}, !- Energy Input Ratio Function of Temperature Curve Name
+  {1cb80fcb-2950-4157-9d46-4ea1fc8e7f2b}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {43556f19-7e35-4287-90a7-2bf9054f0a46}, !- Part Load Fraction Correlation Curve Name
+  -25,                                    !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  0,                                      !- Nominal Time for Condensate Removal to Begin {s}
+  0,                                      !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  0,                                      !- Maximum Cycling Rate {cycles/hr}
+  0,                                      !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0.9,                                    !- Evaporative Condenser Effectiveness {dimensionless}
+  autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  10,                                     !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  2;                                      !- Basin Heater Setpoint Temperature {C}
+
+OS:Curve:Biquadratic,
+  {de8d266b-78ba-4848-a454-b96278b6c40d}, !- Handle
+  Curve Biquadratic 1,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {057a4af8-88a6-42e9-86e1-0f819a786b0b}, !- Handle
+  Curve Quadratic 1,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {0f22f79d-d2ce-4c53-a45c-3cbcca8fe6e4}, !- Handle
+  Curve Biquadratic 2,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {1cb80fcb-2950-4157-9d46-4ea1fc8e7f2b}, !- Handle
+  Curve Quadratic 2,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {43556f19-7e35-4287-90a7-2bf9054f0a46}, !- Handle
+  Curve Quadratic 3,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Schedule:Constant,
+  {d9b16da6-9221-4d9e-8d71-0f29546866be}, !- Handle
+  Always On Discrete,                     !- Name
+  {f5380b2f-2236-4498-afe8-a744f74e129b}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {f5380b2f-2236-4498-afe8-a744f74e129b}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Coil:Heating:DX:SingleSpeed,
+  {d6a209af-209d-471c-a4ea-71ab99d79d3f}, !- Handle
+  Coil Heating DX Single Speed 1,         !- Name
+  {d9b16da6-9221-4d9e-8d71-0f29546866be}, !- Availability Schedule Name
+  Autosize,                               !- Rated Total Heating Capacity {W}
+  5,                                      !- Rated COP {W/W}
+  Autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {8ab033a4-9daf-49b6-aa94-c35f67f0104d}, !- Total Heating Capacity Function of Temperature Curve Name
+  {5ba05bcf-e2e8-4a39-9c2b-549daed55da8}, !- Total Heating Capacity Function of Flow Fraction Curve Name
+  {6e54493e-45e7-41db-a31e-7a10dc13a23e}, !- Energy Input Ratio Function of Temperature Curve Name
+  {188e8017-d722-4d68-be85-dcc41e11b0ef}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {9870c076-04bc-4c08-aec7-6bd71f17a9cf}, !- Part Load Fraction Correlation Curve Name
+  ,                                       !- Defrost Energy Input Ratio Function of Temperature Curve Name
+  ,                                       !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Defrost Operation {C}
+  ,                                       !- Crankcase Heater Capacity {W}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  Resistive,                              !- Defrost Strategy
+  Timed,                                  !- Defrost Control
+  0.166667,                               !- Defrost Time Period Fraction
+  2000;                                   !- Resistive Defrost Heater Capacity {W}
+
+OS:Curve:Cubic,
+  {8ab033a4-9daf-49b6-aa94-c35f67f0104d}, !- Handle
+  Curve Cubic 1,                          !- Name
+  0.758746,                               !- Coefficient1 Constant
+  0.027626,                               !- Coefficient2 x
+  0.000148716,                            !- Coefficient3 x**2
+  3.4992e-06,                             !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {5ba05bcf-e2e8-4a39-9c2b-549daed55da8}, !- Handle
+  Curve Cubic 2,                          !- Name
+  0.84,                                   !- Coefficient1 Constant
+  0.16,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {6e54493e-45e7-41db-a31e-7a10dc13a23e}, !- Handle
+  Curve Cubic 3,                          !- Name
+  1.19248,                                !- Coefficient1 Constant
+  -0.0300438,                             !- Coefficient2 x
+  0.00103745,                             !- Coefficient3 x**2
+  -2.3328e-05,                            !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {188e8017-d722-4d68-be85-dcc41e11b0ef}, !- Handle
+  Curve Quadratic 4,                      !- Name
+  1.3824,                                 !- Coefficient1 Constant
+  -0.4336,                                !- Coefficient2 x
+  0.0512,                                 !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {9870c076-04bc-4c08-aec7-6bd71f17a9cf}, !- Handle
+  Curve Quadratic 5,                      !- Name
+  0.75,                                   !- Coefficient1 Constant
+  0.25,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -2698,7 +2698,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
     if (hasCoolingCoil) {
       EXPECT_EQ("FractionOfAutosizedCoolingValue",
                 unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
-      EXPECT_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
+      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
@@ -2709,7 +2709,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
 
     if (hasHeatingCoil) {
       EXPECT_EQ("FlowPerFloorArea", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
-      EXPECT_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
+      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
@@ -2722,7 +2722,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
     if (hasCoolingCoil || hasHeatingCoil) {
       EXPECT_EQ("FlowPerCoolingCapacity",
                 unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
-      EXPECT_EQ(
+      EXPECT_DOUBLE_EQ(
         0.0, unitary
                .getDouble(
                  OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired)

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -2690,8 +2690,6 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
   // We respect the SAF method choice, and we set the corresponding flow field field to zero
   // =====================================================================================================
 
-  constexpr double ZERO = 0.0;
-
   for (const auto& unitary : unitarys) {
 
     const bool hasHeatingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::HeatingCoilName);
@@ -2700,7 +2698,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
     if (hasCoolingCoil) {
       EXPECT_EQ("FractionOfAutosizedCoolingValue",
                 unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
-      EXPECT_EQ(ZERO, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
+      EXPECT_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
@@ -2711,7 +2709,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
 
     if (hasHeatingCoil) {
       EXPECT_EQ("FlowPerFloorArea", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
-      EXPECT_EQ(ZERO, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
+      EXPECT_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
@@ -2725,10 +2723,10 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
       EXPECT_EQ("FlowPerCoolingCapacity",
                 unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
       EXPECT_EQ(
-        ZERO, unitary
-                .getDouble(
-                  OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired)
-                .get());
+        0.0, unitary
+               .getDouble(
+                 OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired)
+               .get());
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
       EXPECT_TRUE(unitary.isEmpty(

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -32,6 +32,7 @@
 #include <utilities/idd/OS_Fan_SystemModel_FieldEnums.hxx>
 #include <utilities/idd/OS_Connection_FieldEnums.hxx>
 #include <utilities/idd/OS_Version_FieldEnums.hxx>
+#include <utilities/idd/OS_AirLoopHVAC_UnitarySystem_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 #include "../../utilities/core/Compare.hpp"
 
@@ -2547,4 +2548,201 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_GroundHeatExchangerVertical) {
   EXPECT_EQ(13.375, uka.getDouble(5).get());                                                    // Average Soil Surface Temperature
   EXPECT_EQ(3.2, uka.getDouble(6).get());                                                       // Average Amplitude of Surface Temperature
   EXPECT_EQ(8.0, uka.getDouble(7).get());                                                       // Phase Shift of Minimum Surface Temperature
+}
+
+TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_default) {
+  openstudio::path osmPath = resourcesPath() / toPath("osversion/3_7_0/test_vt_UnitarySystem_SAFMethods_default.osm");
+  osversion::VersionTranslator vt;
+  boost::optional<model::Model> model_ = vt.loadModel(osmPath);
+  ASSERT_TRUE(model_) << "Failed to load " << osmPath;
+
+  openstudio::path outPath = osmPath.parent_path() / toPath(osmPath.stem().string() + "_updated" + osmPath.extension().string());
+  model_->save(outPath, true);
+
+  // =====================================================================================================
+  // In this test, this is the Default constructed Unitary System, just adding coils (or not).
+  // The Supply Air Flow During XXX field is set to Autosize,
+  // yet the Method field isn't "SupplyAirFlowRate" but blank.
+  // =====================================================================================================
+
+  std::vector<WorkspaceObject> unitarys = model_->getObjectsByType("OS:AirLoopHVAC:UnitarySystem");
+  ASSERT_EQ(3u, unitarys.size());
+  for (const auto& unitary : unitarys) {
+
+    const bool hasHeatingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::HeatingCoilName);
+    const bool hasCoolingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::CoolingCoilName);
+
+    if (hasCoolingCoil) {
+      EXPECT_EQ("SupplyAirFlowRate", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_EQ("Autosize", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaDuringCoolingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation));
+
+    if (hasHeatingCoil) {
+      EXPECT_EQ("SupplyAirFlowRate", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_EQ("Autosize", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRate));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation));
+
+    EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(
+      unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(
+      unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired));
+  }
+}
+
+TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_CorrectCombos) {
+  openstudio::path osmPath = resourcesPath() / toPath("osversion/3_7_0/test_vt_UnitarySystem_SAFMethods_CorrectCombos.osm");
+  osversion::VersionTranslator vt;
+  boost::optional<model::Model> model_ = vt.loadModel(osmPath);
+  ASSERT_TRUE(model_) << "Failed to load " << osmPath;
+
+  openstudio::path outPath = osmPath.parent_path() / toPath(osmPath.stem().string() + "_updated" + osmPath.extension().string());
+  model_->save(outPath, true);
+
+  // =====================================================================================================
+  // In this test, the SAF method is filled out, and ALL flow fields are set.
+  // We respect the SAF method choice, we keep the corresponding flow field, and clear out all the others
+  // =====================================================================================================
+
+  std::vector<WorkspaceObject> unitarys = model_->getObjectsByType("OS:AirLoopHVAC:UnitarySystem");
+  ASSERT_EQ(3u, unitarys.size());
+  for (const auto& unitary : unitarys) {
+
+    const bool hasHeatingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::HeatingCoilName);
+    const bool hasCoolingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::CoolingCoilName);
+
+    if (hasCoolingCoil) {
+      EXPECT_EQ("FlowPerFloorArea", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_EQ(1.1, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaDuringCoolingOperation).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaDuringCoolingOperation));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation));
+
+    if (hasHeatingCoil) {
+      EXPECT_EQ("FlowPerHeatingCapacity", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_EQ(2.3, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRate));
+
+    if (hasCoolingCoil || hasHeatingCoil) {
+      EXPECT_EQ("FractionOfAutosizedHeatingValue",
+                unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
+      EXPECT_EQ(
+        0.4, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired)
+               .get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
+      EXPECT_TRUE(
+        unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(
+      unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired));
+  }
+}
+
+TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_IncorrectCombos) {
+  openstudio::path osmPath = resourcesPath() / toPath("osversion/3_7_0/test_vt_UnitarySystem_SAFMethods_IncorrectCombos.osm");
+  osversion::VersionTranslator vt;
+  boost::optional<model::Model> model_ = vt.loadModel(osmPath);
+  ASSERT_TRUE(model_) << "Failed to load " << osmPath;
+
+  openstudio::path outPath = osmPath.parent_path() / toPath(osmPath.stem().string() + "_updated" + osmPath.extension().string());
+  model_->save(outPath, true);
+
+  std::vector<WorkspaceObject> unitarys = model_->getObjectsByType("OS:AirLoopHVAC:UnitarySystem");
+  ASSERT_EQ(3u, unitarys.size());
+
+  // =====================================================================================================
+  // In this test, the SAF method is filled out, but the corresponding flow field isn't.
+  // We respect the SAF method choice, and we set the corresponding flow field field to zero
+  // =====================================================================================================
+
+  constexpr double ZERO = 0.0;
+
+  for (const auto& unitary : unitarys) {
+
+    const bool hasHeatingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::HeatingCoilName);
+    const bool hasCoolingCoil = !unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::CoolingCoilName);
+
+    if (hasCoolingCoil) {
+      EXPECT_EQ("FractionOfAutosizedCoolingValue",
+                unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_EQ(ZERO, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringCoolingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaDuringCoolingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperation));
+
+    if (hasHeatingCoil) {
+      EXPECT_EQ("FlowPerFloorArea", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_EQ(ZERO, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
+      EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateDuringHeatingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRate));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperation));
+
+    if (hasCoolingCoil || hasHeatingCoil) {
+      EXPECT_EQ("FlowPerCoolingCapacity",
+                unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
+      EXPECT_EQ(
+        ZERO, unitary
+                .getDouble(
+                  OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired)
+                .get());
+    } else {
+      EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
+      EXPECT_TRUE(unitary.isEmpty(
+        OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired));
+    }
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(
+      unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(
+      unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignHeatingSupplyAirFlowRateWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired));
+    EXPECT_TRUE(unitary.isEmpty(
+      OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringHeatingOperationWhenNoCoolingorHeatingisRequired));
+  }
 }

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -2698,7 +2698,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
     if (hasCoolingCoil) {
       EXPECT_EQ("FractionOfAutosizedCoolingValue",
                 unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
-      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get());
+      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate).get()) << unitary;
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringCoolingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::FractionofAutosizedDesignCoolingSupplyAirFlowRate));
@@ -2709,7 +2709,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
 
     if (hasHeatingCoil) {
       EXPECT_EQ("FlowPerFloorArea", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
-      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get());
+      EXPECT_DOUBLE_EQ(0.0, unitary.getDouble(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation).get()) << unitary;
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodDuringHeatingOperation).get());
       EXPECT_TRUE(unitary.isEmpty(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRatePerFloorAreaduringHeatingOperation));
@@ -2726,7 +2726,7 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_UnitarySystem_SAFMethods_Incorrec
         0.0, unitary
                .getDouble(
                  OS_AirLoopHVAC_UnitarySystemFields::DesignSupplyAirFlowRatePerUnitofCapacityDuringCoolingOperationWhenNoCoolingorHeatingisRequired)
-               .get());
+               .get()) << unitary;
     } else {
       EXPECT_EQ("None", unitary.getString(OS_AirLoopHVAC_UnitarySystemFields::SupplyAirFlowRateMethodWhenNoCoolingorHeatingisRequired).get());
       EXPECT_TRUE(unitary.isEmpty(

--- a/src/utilities/core/ASCIIStrings.hpp
+++ b/src/utilities/core/ASCIIStrings.hpp
@@ -22,6 +22,17 @@ inline std::string ascii_to_lower_copy(std::string_view input) {
   return result;
 }
 
+inline std::string ascii_to_upper_copy(std::string_view input) {
+  std::string result{input};
+  constexpr auto to_upper_diff = 'A' - 'a';
+  for (auto& c : result) {
+    if (c >= 'a' && c <= 'z') {
+      c += to_upper_diff;
+    }
+  }
+  return result;
+}
+
 inline std::string_view ascii_trim_left(std::string_view s) {
   return s.substr(std::min(s.find_first_not_of(" \f\n\r\t\v"), s.size()));
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Potential fix for #4963 
 - When Method is None or empty, doesn't matte…r if the flow rate is Autosized, it takes precendence

cf https://github.com/NREL/EnergyPlus/blob/4502b0c6561281693f837217eb99339372b86abd/src/EnergyPlus/UnitarySystem.cc#L6080-L6081

**Marking Developer Issue as this only affects develop (not released yet)**

Follow up to 
* #4873

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
