### PR TITLE
Fix #4978 - adjust definitions for boost 1.79 to work with modern clang/apple clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,8 +377,9 @@ if(APPLE)
   # This appears to be a legacy choice by the cmake developers, and seems out of place,
   # so the OpenStudio project will use the library suffix ".dylib"
   find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-  add_definitions(-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
-  #add_definitions(-DBOOST_SYSTEM_NO_DEPRECATED)
+  # TODO: remove when bumping Boost to 1.81+, cf https://github.com/NREL/OpenStudio/issues/4978
+  add_definitions(-DBOOST_NO_CXX98_FUNCTION_BASE)
+  add_definitions(-D_HAS_AUTO_PTR_ETC=0)
 endif()
 
 if(UNIX AND NOT APPLE)


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4978

Xcode removed auto_ptr before 10.1 (not sure when)

Xcode 15: removed unary/binary_function:
* https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes
* unary_function and binary_function are no longer provided in C++17 and newer Standard modes. They can be re-enabled with _LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
