### PR TITLE
Fix #4999 - Change latent degration constructor defaults for CoilCoolingWaterToAirHeatPump:XXXX

### DIFF
--- a/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
@@ -589,9 +589,10 @@ namespace model {
 
       ok = setPartLoadFractionCorrelationCurve(plfCorrelation);
 
-      ok = setMaximumCyclingRate(0.0);
+      // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+      ok = setMaximumCyclingRate(2.5);
       OS_ASSERT(ok);
-      ok = setLatentCapacityTimeConstant(0.0);
+      ok = setLatentCapacityTimeConstant(60.0);
       OS_ASSERT(ok);
       ok = setFanDelayTime(60.0);
       OS_ASSERT(ok);

--- a/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpEquationFit.cpp
@@ -582,6 +582,7 @@ namespace model {
       ok = setRatedEnteringAirWetBulbTemperature(19.0);
       OS_ASSERT(ok);
 
+      // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
       constexpr double maximumCyclingRatePerHour = 2.5;
       constexpr double heatPumpTimeConstantSeconds = 60.0;
       const CurveLinear plfCorrelation =
@@ -589,10 +590,9 @@ namespace model {
 
       ok = setPartLoadFractionCorrelationCurve(plfCorrelation);
 
-      // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
-      ok = setMaximumCyclingRate(2.5);
+      ok = setMaximumCyclingRate(maximumCyclingRatePerHour);
       OS_ASSERT(ok);
-      ok = setLatentCapacityTimeConstant(60.0);
+      ok = setLatentCapacityTimeConstant(heatPumpTimeConstantSeconds);
       OS_ASSERT(ok);
       ok = setFanDelayTime(60.0);
       OS_ASSERT(ok);

--- a/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -515,9 +515,10 @@ namespace model {
     OS_ASSERT(ok);
     ok = setInitialMoistureEvaporationRateDividedbySteadyStateACLatentCapacity(0);
     OS_ASSERT(ok);
-    ok = setMaximumCyclingRate(0.0);
+    // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+    ok = setMaximumCyclingRate(2.5);
     OS_ASSERT(ok);
-    ok = setLatentCapacityTimeConstant(0.0);
+    ok = setLatentCapacityTimeConstant(60.0);
     OS_ASSERT(ok);
     ok = setFanDelayTime(60.0);
     OS_ASSERT(ok);
@@ -553,9 +554,10 @@ namespace model {
     OS_ASSERT(ok);
     ok = setInitialMoistureEvaporationRateDividedbySteadyStateACLatentCapacity(0);
     OS_ASSERT(ok);
-    ok = setMaximumCyclingRate(0.0);
+    // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+    ok = setMaximumCyclingRate(2.5);
     OS_ASSERT(ok);
-    ok = setLatentCapacityTimeConstant(0.0);
+    ok = setLatentCapacityTimeConstant(60.0);
     OS_ASSERT(ok);
     ok = setFanDelayTime(60.0);
     OS_ASSERT(ok);

--- a/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
+++ b/src/model/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit.cpp
@@ -524,6 +524,7 @@ namespace model {
     OS_ASSERT(ok);
     setUseHotGasReheat(false);
 
+    // Note: this predates v23.2.0. Consider switching to CurveLinear::defaultHeatPumpCoilPLFCorrelationCurve (would calculate c1=0.8337, c2=0.1662)
     auto partLoadFraction = CurveQuadratic(model);
     partLoadFraction.setCoefficient1Constant(0.85);
     partLoadFraction.setCoefficient2x(0.15);

--- a/src/model/test/CoilCoolingWaterToAirHeatPumpEquationFit_GTest.cpp
+++ b/src/model/test/CoilCoolingWaterToAirHeatPumpEquationFit_GTest.cpp
@@ -246,9 +246,10 @@ TEST_F(ModelFixture, CoilCoolingWaterToAirHeatPumpEquationFit_2320_NewFields) {
 
   CoilCoolingWaterToAirHeatPumpEquationFit coil(m);
 
+  // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+  EXPECT_EQ(2.5, coil.maximumCyclingRate());
+  EXPECT_EQ(60.0, coil.latentCapacityTimeConstant());
   // Test IDD defaults
-  EXPECT_EQ(0.0, coil.maximumCyclingRate());
-  EXPECT_EQ(0.0, coil.latentCapacityTimeConstant());
   EXPECT_EQ(60.0, coil.fanDelayTime());
 
   EXPECT_TRUE(coil.setMaximumCyclingRate(3.5));

--- a/src/model/test/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_GTest.cpp
+++ b/src/model/test/CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_GTest.cpp
@@ -47,9 +47,10 @@ TEST_F(ModelFixture, CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit_2320_
 
   CoilCoolingWaterToAirHeatPumpVariableSpeedEquationFit coil(m);
 
+  // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+  EXPECT_EQ(2.5, coil.maximumCyclingRate());
+  EXPECT_EQ(60.0, coil.latentCapacityTimeConstant());
   // Test IDD defaults
-  EXPECT_EQ(0.0, coil.maximumCyclingRate());
-  EXPECT_EQ(0.0, coil.latentCapacityTimeConstant());
   EXPECT_EQ(60.0, coil.fanDelayTime());
 
   EXPECT_TRUE(coil.setMaximumCyclingRate(3.5));

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -8513,8 +8513,9 @@ namespace osversion {
         const std::string curveName = hasCoilInfo ? it->curveName() : fmt::format("{}-PLFCorrelationCurve", object.nameString());
         newObject.setString(17, curveName);
 
-        double maxCyclingRate = 0.0;
-        double heatPumpTimeConst = 0.0;
+        // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+        double maxCyclingRate = 2.5;
+        double heatPumpTimeConst = 60.0;
         double hpDelayTime = 60.0;
         if (hasCoilInfo) {
           maxCyclingRate = it->maxCyclingRate;
@@ -8560,8 +8561,9 @@ namespace osversion {
         auto it = CoilLatentTransitionInfo::findFromCoolingCoil(coilTransitionInfos, object);
         const bool hasCoilInfo = (it != coilTransitionInfos.end());
 
-        double maxCyclingRate = 0.0;
-        double heatPumpTimeConst = 0.0;
+        // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+        double maxCyclingRate = 2.5;
+        double heatPumpTimeConst = 60.0;
         double hpDelayTime = 60.0;
         if (hasCoilInfo) {
           maxCyclingRate = it->maxCyclingRate;

--- a/src/osversion/test/VersionTranslator_GTest.cpp
+++ b/src/osversion/test/VersionTranslator_GTest.cpp
@@ -3106,8 +3106,9 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_Coils_Latent_solo) {
     {
       const size_t insertionIndex = 20;
       // No Unitary -> IDD DEFAULTS
-      EXPECT_EQ(0.0, coil.getDouble(insertionIndex).get());       // Maximum Cycling Rate
-      EXPECT_EQ(0.0, coil.getDouble(insertionIndex + 1).get());   // Latent Capacity Time Constant
+      // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+      EXPECT_EQ(2.5, coil.getDouble(insertionIndex).get());       // Maximum Cycling Rate
+      EXPECT_EQ(60.0, coil.getDouble(insertionIndex + 1).get());  // Latent Capacity Time Constant
       EXPECT_EQ(60.0, coil.getDouble(insertionIndex + 2).get());  // Fan Delay Time
     }
   }
@@ -3124,8 +3125,9 @@ TEST_F(OSVersionFixture, update_3_6_1_to_3_7_0_Coils_Latent_solo) {
       EXPECT_EQ(0.02, coil.getDouble(insertionIndex - 1).get());
 
       // No Unitary -> IDD DEFAULTS
-      EXPECT_EQ(0.0, coil.getDouble(insertionIndex).get());       // Maximum Cycling Rate
-      EXPECT_EQ(0.0, coil.getDouble(insertionIndex + 1).get());   // Latent Capacity Time Constant
+      // E+ 23.2.0 defaults Maximum Cycling Rate and Latent Capacity Time Constant to 0.0, we don't, cf #4999
+      EXPECT_EQ(2.5, coil.getDouble(insertionIndex).get());       // Maximum Cycling Rate
+      EXPECT_EQ(60.0, coil.getDouble(insertionIndex + 1).get());  // Latent Capacity Time Constant
       EXPECT_EQ(60.0, coil.getDouble(insertionIndex + 2).get());  // Fan Delay Time
 
       EXPECT_EQ("Yes", coil.getString(insertionIndex + 3).get());


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4999

- Maximum Cycling rate and Latent Capacity Time Constant default to old parent unitary values (2.5 and 60.0 respectively), not E+ 23.2.0 default (which zeroes latent degradation)

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
