### PR TITLE
[internal] Schedule:File relative paths mod

### DIFF
--- a/resources/model/OpenStudio.idd
+++ b/resources/model/OpenStudio.idd
@@ -5111,7 +5111,9 @@ OS:Schedule:File,
        \key Yes
        \key No
        \default Yes
-  A8;  \field Translate File Name
+  A8;  \field Translate File With Relative Path
+       \note "No" means the absolute path of the ExternalFile is resolved and translated to IDF.
+       \note "Yes" means only the filename (relative) is translated
        \type choice
        \default No
        \key Yes

--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleFile.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleFile.cpp
@@ -40,22 +40,8 @@ namespace energyplus {
         idfObject.setString(openstudio::Schedule_FileFields::ScheduleTypeLimitsName, idfScheduleTypeLimits->name().get());
       }
     }
-
-    path fileName;
-    if (modelObject.translateFileName()) {
-      fileName = toPath(modelObject.externalFile().fileName());
-    } else {
-      fileName = modelObject.externalFile().filePath();
-      if (!exists(fileName)) {
-        LOG(Warn, "Cannot find file \"" << fileName << "\"");
-      } else {
-        // make the path correct for this system
-        fileName = system_complete(fileName);
-      }
-    }
-
     // DLM: this path is going to be in the temp dir, might want to fix it up when saving model temp dir
-    idfObject.setString(openstudio::Schedule_FileFields::FileName, toString(fileName));
+    idfObject.setString(openstudio::Schedule_FileFields::FileName, toString(modelObject.translatedFilePath()));
 
     idfObject.setInt(openstudio::Schedule_FileFields::ColumnNumber, modelObject.columnNumber());
     idfObject.setInt(openstudio::Schedule_FileFields::RowstoSkipatTop, modelObject.rowstoSkipatTop());

--- a/src/energyplus/Test/ScheduleInterval_GTest.cpp
+++ b/src/energyplus/Test/ScheduleInterval_GTest.cpp
@@ -1869,8 +1869,8 @@ TEST_F(EnergyPlusFixture, ScheduleFileRelativePath) {
     boost::optional<ExternalFile> external_file = ExternalFile::getExternalFile(model, openstudio::toString(p));
     ASSERT_TRUE(external_file);
     ScheduleFile schedule(*external_file);
-    EXPECT_TRUE(schedule.setTranslateFileName(true));
-    EXPECT_TRUE(schedule.translateFileName());
+    EXPECT_TRUE(schedule.setTranslateFileWithRelativePath(true));
+    EXPECT_TRUE(schedule.translateFileWithRelativePath());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ScheduleFile>().size());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ExternalFile>().size());
     ExternalFile externalfile = schedule.externalFile();
@@ -1904,8 +1904,8 @@ TEST_F(EnergyPlusFixture, ScheduleFileRelativePath) {
     boost::optional<ExternalFile> external_file = ExternalFile::getExternalFile(model, openstudio::toString(p));
     ASSERT_TRUE(external_file);
     ScheduleFile schedule(*external_file);
-    EXPECT_TRUE(schedule.setTranslateFileName(true));
-    EXPECT_TRUE(schedule.translateFileName());
+    EXPECT_TRUE(schedule.setTranslateFileWithRelativePath(true));
+    EXPECT_TRUE(schedule.translateFileWithRelativePath());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ScheduleFile>().size());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ExternalFile>().size());
     ExternalFile externalfile = schedule.externalFile();
@@ -1937,8 +1937,8 @@ TEST_F(EnergyPlusFixture, ScheduleFileRelativePath) {
     EXPECT_FALSE(p.is_relative());
 
     ScheduleFile schedule(model, openstudio::toString(p));
-    EXPECT_TRUE(schedule.setTranslateFileName(true));
-    EXPECT_TRUE(schedule.translateFileName());
+    EXPECT_TRUE(schedule.setTranslateFileWithRelativePath(true));
+    EXPECT_TRUE(schedule.translateFileWithRelativePath());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ScheduleFile>().size());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ExternalFile>().size());
     ExternalFile externalfile = schedule.externalFile();
@@ -1970,8 +1970,8 @@ TEST_F(EnergyPlusFixture, ScheduleFileRelativePath) {
     EXPECT_TRUE(p.is_relative());
 
     ScheduleFile schedule(model, openstudio::toString(p));
-    EXPECT_TRUE(schedule.setTranslateFileName(true));
-    EXPECT_TRUE(schedule.translateFileName());
+    EXPECT_TRUE(schedule.setTranslateFileWithRelativePath(true));
+    EXPECT_TRUE(schedule.translateFileWithRelativePath());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ScheduleFile>().size());
     EXPECT_EQ(1u, model.getConcreteModelObjects<ExternalFile>().size());
     ExternalFile externalfile = schedule.externalFile();

--- a/src/model/ScheduleFile.cpp
+++ b/src/model/ScheduleFile.cpp
@@ -233,14 +233,14 @@ namespace model {
       return csvFile;
     }
 
-    bool ScheduleFile_Impl::translateFileName() const {
-      boost::optional<std::string> value = getString(OS_Schedule_FileFields::TranslateFileName, true);
+    bool ScheduleFile_Impl::translateFileWithRelativePath() const {
+      boost::optional<std::string> value = getString(OS_Schedule_FileFields::TranslateFileWithRelativePath, true);
       OS_ASSERT(value);
       return openstudio::istringEqual(value.get(), "Yes");
     }
 
-    bool ScheduleFile_Impl::isTranslateFileNameDefaulted() const {
-      return isEmpty(OS_Schedule_FileFields::TranslateFileName);
+    bool ScheduleFile_Impl::isTranslateFileWithRelativePathDefaulted() const {
+      return isEmpty(OS_Schedule_FileFields::TranslateFileWithRelativePath);
     }
 
     /* FIXME!
@@ -386,20 +386,34 @@ namespace model {
     }*/
     }
 
-    bool ScheduleFile_Impl::setTranslateFileName(bool translateFileName) {
+    bool ScheduleFile_Impl::setTranslateFileWithRelativePath(bool translateFileWithRelativePath) {
       bool result = false;
-      if (translateFileName) {
-        result = setString(OS_Schedule_FileFields::TranslateFileName, "Yes");
+      if (translateFileWithRelativePath) {
+        result = setString(OS_Schedule_FileFields::TranslateFileWithRelativePath, "Yes");
       } else {
-        result = setString(OS_Schedule_FileFields::TranslateFileName, "No");
+        result = setString(OS_Schedule_FileFields::TranslateFileWithRelativePath, "No");
       }
       OS_ASSERT(result);
       return result;
     }
 
-    void ScheduleFile_Impl::resetTranslateFileName() {
-      const bool result = setString(OS_Schedule_FileFields::TranslateFileName, "");
+    void ScheduleFile_Impl::resetTranslateFileWithRelativePath() {
+      const bool result = setString(OS_Schedule_FileFields::TranslateFileWithRelativePath, "");
       OS_ASSERT(result);
+    }
+
+    openstudio::path ScheduleFile_Impl::translatedFilePath() const {
+      if (translateFileWithRelativePath()) {
+        return toPath(externalFile().fileName());
+      }
+      openstudio::path filePath = externalFile().filePath();
+      if (!exists(filePath)) {
+        LOG(Warn, "Cannot find file \"" << filePath << "\"");
+      } else {
+        // make the path correct for this system
+        filePath = system_complete(filePath);
+      }
+      return filePath;
     }
 
   }  // namespace detail
@@ -503,12 +517,12 @@ namespace model {
     return getImpl<detail::ScheduleFile_Impl>()->csvFile();
   }
 
-  bool ScheduleFile::translateFileName() const {
-    return getImpl<detail::ScheduleFile_Impl>()->translateFileName();
+  bool ScheduleFile::translateFileWithRelativePath() const {
+    return getImpl<detail::ScheduleFile_Impl>()->translateFileWithRelativePath();
   }
 
-  bool ScheduleFile::isTranslateFileNameDefaulted() const {
-    return getImpl<detail::ScheduleFile_Impl>()->isTranslateFileNameDefaulted();
+  bool ScheduleFile::isTranslateFileWithRelativePathDefaulted() const {
+    return getImpl<detail::ScheduleFile_Impl>()->isTranslateFileWithRelativePathDefaulted();
   }
 
   /* FIXME!
@@ -585,12 +599,16 @@ unsigned ScheduleFile::addTimeSeries(const openstudio::TimeSeries& timeSeries) {
     getImpl<detail::ScheduleFile_Impl>()->resetAdjustScheduleforDaylightSavings();
   }
 
-  bool ScheduleFile::setTranslateFileName(bool translateFileName) {
-    return getImpl<detail::ScheduleFile_Impl>()->setTranslateFileName(translateFileName);
+  bool ScheduleFile::setTranslateFileWithRelativePath(bool translateFileWithRelativePath) {
+    return getImpl<detail::ScheduleFile_Impl>()->setTranslateFileWithRelativePath(translateFileWithRelativePath);
   }
 
-  void ScheduleFile::resetTranslateFileName() {
-    getImpl<detail::ScheduleFile_Impl>()->resetTranslateFileName();
+  void ScheduleFile::resetTranslateFileWithRelativePath() {
+    getImpl<detail::ScheduleFile_Impl>()->resetTranslateFileWithRelativePath();
+  }
+
+  openstudio::path ScheduleFile::translatedFilePath() const {
+    return getImpl<detail::ScheduleFile_Impl>()->translatedFilePath();
   }
 
   /// @cond

--- a/src/model/ScheduleFile.hpp
+++ b/src/model/ScheduleFile.hpp
@@ -86,9 +86,9 @@ namespace model {
 
     boost::optional<CSVFile> csvFile() const;
 
-    bool translateFileName() const;
+    bool translateFileWithRelativePath() const;
 
-    bool isTranslateFileNameDefaulted() const;
+    bool isTranslateFileWithRelativePathDefaulted() const;
 
     //@}
     /** @name Setters */
@@ -124,13 +124,16 @@ namespace model {
 
     /* FIXME! unsigned addTimeSeries(const openstudio::TimeSeries& timeSeries); */
 
-    bool setTranslateFileName(bool translateFileName);
+    bool setTranslateFileWithRelativePath(bool translateFileWithRelativePath);
 
-    void resetTranslateFileName();
+    void resetTranslateFileWithRelativePath();
 
     //@}
     /** @name Other */
     //@{
+
+    // Depending on the value of 'Translate File With Relative Path', returns an absolute or a relative path
+    openstudio::path translatedFilePath() const;
 
     //@}
    protected:

--- a/src/model/ScheduleFile_Impl.hpp
+++ b/src/model/ScheduleFile_Impl.hpp
@@ -88,9 +88,9 @@ namespace model {
 
       boost::optional<CSVFile> csvFile() const;
 
-      bool translateFileName() const;
+      bool translateFileWithRelativePath() const;
 
-      bool isTranslateFileNameDefaulted() const;
+      bool isTranslateFileWithRelativePathDefaulted() const;
 
       //@}
       /** @name Setters */
@@ -125,13 +125,15 @@ namespace model {
       // ensure that this object does not contain the date 2/29
       virtual void ensureNoLeapDays() override;
 
-      bool setTranslateFileName(bool translateFileName);
+      bool setTranslateFileWithRelativePath(bool translateFileWithRelativePath);
 
-      void resetTranslateFileName();
+      void resetTranslateFileWithRelativePath();
 
       //@}
       /** @name Other */
       //@{
+
+      openstudio::path translatedFilePath() const;
 
       //@}
      protected:

--- a/src/model/test/ScheduleInterval_GTest.cpp
+++ b/src/model/test/ScheduleInterval_GTest.cpp
@@ -320,14 +320,18 @@ TEST_F(ModelFixture, ScheduleFile) {
   schedule3.resetAdjustScheduleforDaylightSavings();
   EXPECT_TRUE(schedule3.isAdjustScheduleforDaylightSavingsDefaulted());
 
-  EXPECT_FALSE(schedule3.translateFileName());
-  EXPECT_TRUE(schedule3.isTranslateFileNameDefaulted());
-  EXPECT_TRUE(schedule3.setTranslateFileName(true));
-  EXPECT_TRUE(schedule3.translateFileName());
-  EXPECT_FALSE(schedule3.isTranslateFileNameDefaulted());
-  schedule3.resetTranslateFileName();
-  EXPECT_FALSE(schedule3.translateFileName());
-  EXPECT_TRUE(schedule3.isTranslateFileNameDefaulted());
+  EXPECT_FALSE(schedule3.translateFileWithRelativePath());
+  EXPECT_TRUE(schedule3.isTranslateFileWithRelativePathDefaulted());
+  EXPECT_EQ(externalfile->filePath(), schedule3.translatedFilePath());
+
+  EXPECT_TRUE(schedule3.setTranslateFileWithRelativePath(true));
+  EXPECT_TRUE(schedule3.translateFileWithRelativePath());
+  EXPECT_FALSE(schedule3.isTranslateFileWithRelativePathDefaulted());
+  EXPECT_EQ(toPath(externalfile->fileName()), schedule3.translatedFilePath());
+
+  schedule3.resetTranslateFileWithRelativePath();
+  EXPECT_FALSE(schedule3.translateFileWithRelativePath());
+  EXPECT_TRUE(schedule3.isTranslateFileWithRelativePathDefaulted());
 
   // shouldn't create a new object
   boost::optional<ExternalFile> externalfile2 = ExternalFile::getExternalFile(model, openstudio::toString(p));


### PR DESCRIPTION
Pull request overview
---------------------

- Modify #4879
- Rename IDD Field
- Move path logic into model `openstudio::path ScheduleFile::translatedFilePath() const`

I'm building these changes, will hopefully report back soonish