### PR TITLE
Fix #5062 - Properly forward the --help flag to ruby/python scripts

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -297,10 +297,17 @@ if(BUILD_TESTING)
 
   # Test via optparse and check file exists
   # Historical CLI versions
-    add_test(NAME OpenStudioCLI.Classic.execute_ruby_script.forward_flags.optparse.path_forwardslash
+  add_test(NAME OpenStudioCLI.Classic.execute_ruby_script.forward_flags.optparse.path_forwardslash
     COMMAND $<TARGET_FILE:openstudio> classic execute_ruby_script execute_ruby_script_optparse_path.rb -x "./test_folder/hello.xml"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test/"
   )
+  add_test(NAME OpenStudioCLI.Classic.execute_ruby_script.forward_flags.forward_help
+    COMMAND $<TARGET_FILE:openstudio> classic execute_ruby_script ${CMAKE_CURRENT_SOURCE_DIR}/test/execute_ruby_script_optparse_path.rb --help
+  )
+  set_tests_properties(OpenStudioCLI.Classic.execute_ruby_script.forward_flags.forward_help PROPERTIES
+    PASS_REGULAR_EXPRESSION "The Ruby help description."
+  )
+
   if (WIN32)
     # Posix paths don't understand a backward slash anyways
     add_test(NAME OpenStudioCLI.Classic.execute_ruby_script.forward_flags.optparse.path_backwardslash
@@ -313,6 +320,21 @@ if(BUILD_TESTING)
     COMMAND $<TARGET_FILE:openstudio> execute_ruby_script execute_ruby_script_optparse_path.rb -x "./test_folder/hello.xml"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test/"
   )
+
+  add_test(NAME OpenStudioCLI.execute_ruby_script.forward_flags.forward_help
+    COMMAND $<TARGET_FILE:openstudio> execute_ruby_script ${CMAKE_CURRENT_SOURCE_DIR}/test/execute_ruby_script_optparse_path.rb --help
+  )
+  set_tests_properties(OpenStudioCLI.execute_ruby_script.forward_flags.forward_help PROPERTIES
+    PASS_REGULAR_EXPRESSION "The Ruby help description."
+  )
+
+  add_test(NAME OpenStudioCLI.execute_python_script.forward_flags.forward_help
+    COMMAND $<TARGET_FILE:openstudio> execute_python_script ${CMAKE_CURRENT_SOURCE_DIR}/test/execute_python_script_argparse_path.py --help
+  )
+  set_tests_properties(OpenStudioCLI.execute_python_script.forward_flags.forward_help PROPERTIES
+    PASS_REGULAR_EXPRESSION "The Python help description."
+  )
+
   if (WIN32)
     add_test(NAME OpenStudioCLI.execute_ruby_script.forward_flags.optparse.path_backwardslash
       COMMAND $<TARGET_FILE:openstudio> execute_ruby_script execute_ruby_script_optparse_path.rb -x ".\\test_folder\\hello.xml"

--- a/src/cli/UpdateCommand.cpp
+++ b/src/cli/UpdateCommand.cpp
@@ -69,6 +69,8 @@ namespace cli {
     cmd += fmt::format(R"(
 begin
   require '{}'
+rescue SystemExit
+  # puts "help was called"
 rescue Exception => e
   puts
   puts "Error: #{{e.message}}"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -244,30 +244,32 @@ int main(int argc, char* argv[]) {
     // {
     auto* execute_ruby_scriptCommand = app.add_subcommand("execute_ruby_script", "Executes a ruby file");
     openstudio::filesystem::path rubyScriptPath;
-    execute_ruby_scriptCommand->add_option("path", rubyScriptPath, "Path to ruby file")->required(true)->check(CLI::ExistingFile);
-    // We can't do this because that means we can't pass extra **flags**
-    // std::vector<std::string> executeRubyScriptCommandArgs;
-    // execute_ruby_scriptCommand->add_option("arguments", executeRubyScriptCommandArgs, "Arguments to pass to the ruby file")
-    //   ->required(false)
-    //   ->option_text("args");
-    execute_ruby_scriptCommand->allow_extras(true);
-    execute_ruby_scriptCommand->footer("You can pass extra arguments after the ruby file, they will be forwarded.");
-
-    execute_ruby_scriptCommand->callback([&rubyScriptPath, &rubyEngine, &execute_ruby_scriptCommand] {
-      openstudio::cli::executeRubyScriptCommand(rubyScriptPath, rubyEngine, execute_ruby_scriptCommand->remaining());
-    });
+    std::vector<std::string> ruby_fwd_args;
+    execute_ruby_scriptCommand->add_option("path", rubyScriptPath, "Path to Ruby file")
+      ->option_text("RUBY_SCRIPT")
+      ->required(true)
+      ->check(CLI::ExistingFile);
+    execute_ruby_scriptCommand->add_option("args", ruby_fwd_args, "Extra Arguments forwarded to the Ruby script")->option_text("ARG ...");
+    execute_ruby_scriptCommand->positionals_at_end(true);
+    execute_ruby_scriptCommand->footer("Any additional arguments passed after the Ruby file are forwarded");
+    execute_ruby_scriptCommand->callback(
+      [&rubyScriptPath, &rubyEngine, &ruby_fwd_args] { openstudio::cli::executeRubyScriptCommand(rubyScriptPath, rubyEngine, ruby_fwd_args); });
     // }
 
     // {
     auto* execute_python_scriptCommand = app.add_subcommand("execute_python_script", "Executes a python file");
     openstudio::filesystem::path pythonScriptPath;
-    execute_python_scriptCommand->add_option("path", pythonScriptPath, "Path to python file")->required(true)->check(CLI::ExistingFile);
+    std::vector<std::string> python_fwd_args;
+    execute_python_scriptCommand->add_option("path", pythonScriptPath, "Path to Python file")
+      ->option_text("PYTHON_SCRIPT")
+      ->required(true)
+      ->check(CLI::ExistingFile);
+    execute_python_scriptCommand->add_option("args", python_fwd_args, "Extra Arguments forwarded to the Python script")->option_text("ARG ...");
+    execute_python_scriptCommand->positionals_at_end(true);
+    execute_python_scriptCommand->footer("You can pass extra arguments after the Python file, they will be forwarded.");
 
-    execute_python_scriptCommand->allow_extras(true);
-    execute_python_scriptCommand->footer("You can pass extra arguments after the python file, they will be forwarded.");
-
-    execute_python_scriptCommand->callback([&pythonScriptPath, &pythonEngine, &execute_python_scriptCommand] {
-      openstudio::cli::executePythonScriptCommand(pythonScriptPath, pythonEngine, execute_python_scriptCommand->remaining());
+    execute_python_scriptCommand->callback([&pythonScriptPath, &pythonEngine, &python_fwd_args] {
+      openstudio::cli::executePythonScriptCommand(pythonScriptPath, pythonEngine, python_fwd_args);
     });
     // }
 

--- a/src/cli/test/execute_python_script_argparse_path.py
+++ b/src/cli/test/execute_python_script_argparse_path.py
@@ -1,0 +1,21 @@
+import argparse
+from pathlib import Path
+
+
+def validate_file(arg):
+    if (filepath := Path(arg)).is_file():
+        return filepath
+    else:
+        raise FileNotFoundError(arg)
+
+def validate_xml_file(arg):
+    filepath = validate_file(arg)
+    if (filepath.suffix != '.xml'):
+        raise FileNotFoundError(f"{arg} is not a .xml file")
+    return filepath
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="The Python help description.")
+    parser.add_argument("-x,--xml", metavar='FILE', required=True, type=validate_xml_file, help="HPXML file")
+    args = parser.parse_args()
+    print(args)

--- a/src/cli/test/execute_ruby_script_optparse_path.rb
+++ b/src/cli/test/execute_ruby_script_optparse_path.rb
@@ -4,6 +4,7 @@ require 'pathname'
 options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: #{File.basename(__FILE__)} -x building.xml"
+  opts.banner += "\n\nThe Ruby help description.\n\n"
 
   opts.on('-x', '--xml <FILE>', 'HPXML file') do |t|
     options[:hpxml] = t


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5062

When script omitted, --help displays the C++ subcommand help

```
$os_build_rel/Products/openstudio execute_ruby_script --help
Executes a ruby file
Usage: /Users/julien/Software/Others/OS-build-release/Products/openstudio execute_ruby_script [OPTIONS] path [args...]

Positionals:
  path RUBY_SCRIPT                 Path to Ruby file
  args ARG ...                     Extra Arguments forwarded to the Ruby script

Options:
  -h,--help                        Print this help message and exit

Any additional arguments passed after the Ruby file are forwarded
```

When --help is passed after the ruby script, the Ruby's script is displayed (if any):

```
$os_build_rel/Products/openstudio execute_ruby_script execute_ruby_script_optparse_path.rb --help
Usage: execute_ruby_script_optparse_path.rb -x building.xml

The Ruby help description.

    -x, --xml <FILE>                 HPXML file
```


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
