### PR TITLE
Specify the requirement of Doxygen.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,8 +1089,16 @@ mark_as_advanced(MAXIMIZE_CPU_USAGE)
 # Doxygen
 if(BUILD_DOCUMENTATION)
   # need doxygen
-  find_package(Doxygen REQUIRED)
+  find_package(Doxygen 1.8.7 REQUIRED)
 
+  if(NOT Doxygen_FOUND)
+    find_package(Doxygen 1.8.8 REQUIRED)
+  endif()
+
+  if(NOT Doxygen_FOUND)
+    message(FATAL_ERROR "Doxygen version 1.8.7 or 1.8.8 not found")
+  endif()
+  
   # if have dot you have more options
   #if(DOXYGEN_DOT_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,16 +1089,7 @@ mark_as_advanced(MAXIMIZE_CPU_USAGE)
 # Doxygen
 if(BUILD_DOCUMENTATION)
   # need doxygen
-  find_package(Doxygen 1.8.7 REQUIRED)
-
-  if(NOT Doxygen_FOUND)
-    find_package(Doxygen 1.8.8 REQUIRED)
-  endif()
-
-  if(NOT Doxygen_FOUND)
-    message(FATAL_ERROR "Doxygen version 1.8.7 or 1.8.8 not found")
-  endif()
-  
+  find_package(Doxygen 1.8.7...<1.8.9 REQUIRED)
   # if have dot you have more options
   #if(DOXYGEN_DOT_FOUND)
 


### PR DESCRIPTION
short term solution of issue #5063 

https://github.com/NREL/OpenStudio/issues/5063

https://github.com/NREL/OpenStudio/wiki/Configuring-OpenStudio-SDK-Build-Environments-(3.X.X-or-greater)#windows-1

Since it required 1.8.7 or 1.8.8 I specify the requirement.
Since it only effect the documentation generation flag, not much test need to be done.