### PR TITLE
Incorrect FT of ScheduleRules at end of year

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
@@ -309,6 +309,11 @@ namespace energyplus {
               case DayOfWeek::Friday:
                 lastDate = date - Time(6);
                 break;
+              case DayOfWeek::Saturday:
+                // do nothing
+                break;
+              default:
+                OS_ASSERT(false);
             }
             lastWeekSchedule = weekSchedule;
           }

--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
@@ -300,13 +300,14 @@ namespace energyplus {
           weekSchedule->thursdaySchedule = thursdaySchedule.name().get();
           weekSchedule->fridaySchedule = fridaySchedule.name().get();
           weekSchedule->saturdaySchedule = saturdaySchedule.name().get();
+          // from Schedule:Ruleset
           weekSchedule->holidaySchedule = holidaySchedule.name().get();
           weekSchedule->summerDesignDaySchedule = summerDesignDaySchedule.name().get();
           weekSchedule->winterDesignDaySchedule = winterDesignDaySchedule.name().get();
           weekSchedule->customDay1Schedule = customDay1Schedule.name().get();
           weekSchedule->customDay2Schedule = customDay2Schedule.name().get();
 
-          // check if this schedule is equal to last week schedule
+          // check if this schedule is equal to last week schedule
           if (weekSchedule && lastWeekSchedule && (!(weekSchedule.get() == lastWeekSchedule.get()))) {
             // if not write out last week schedule
 
@@ -324,58 +325,24 @@ namespace energyplus {
               startDate = yd.makeDate(*startMonth, *startDay) + Time(1);
             }
 
-            OS_ASSERT(startDate <= lastDate);
+            OS_ASSERT(startDate <= date);
 
             // Name the schedule week
-            lastWeekSchedule->setName(scheduleYearName, startDate, lastDate);
+            weekSchedule->setName(scheduleYearName, startDate, date);
 
             // add the values
             std::vector<std::string> values;
-            values.push_back(lastWeekSchedule->name);
+            values.push_back(weekSchedule->name);
             values.push_back(boost::lexical_cast<std::string>(startDate.monthOfYear().value()));
             values.push_back(boost::lexical_cast<std::string>(startDate.dayOfMonth()));
-            values.push_back(boost::lexical_cast<std::string>(lastDate.monthOfYear().value()));
-            values.push_back(boost::lexical_cast<std::string>(lastDate.dayOfMonth()));
+            values.push_back(boost::lexical_cast<std::string>(date.monthOfYear().value()));
+            values.push_back(boost::lexical_cast<std::string>(date.dayOfMonth()));
             IdfExtensibleGroup test = scheduleYear.pushExtensibleGroup(values);
             OS_ASSERT(!test.empty());
 
             // Write the schedule
-            m_idfObjects.push_back(lastWeekSchedule->toIdfObject());
+            m_idfObjects.push_back(weekSchedule->toIdfObject());
           }
-
-          // write out the last week schedule
-
-          // get last extensible group, if any, to find start date otherwise use jan1
-          openstudio::Date startDate;
-          std::vector<IdfExtensibleGroup> extensibleGroups = scheduleYear.extensibleGroups();
-          if (extensibleGroups.empty()) {
-            startDate = jan1;
-          } else {
-            // day after last end date
-            boost::optional<int> startMonth = extensibleGroups.back().getInt(3, true);
-            OS_ASSERT(startMonth);
-            boost::optional<int> startDay = extensibleGroups.back().getInt(4, true);
-            OS_ASSERT(startDay);
-            startDate = yd.makeDate(*startMonth, *startDay) + Time(1);
-          }
-
-          OS_ASSERT(startDate <= date);
-
-          // Name the schedule week
-          weekSchedule->setName(scheduleYearName, startDate, date);
-
-          // add the values
-          std::vector<std::string> values;
-          values.push_back(weekSchedule->name);
-          values.push_back(boost::lexical_cast<std::string>(startDate.monthOfYear().value()));
-          values.push_back(boost::lexical_cast<std::string>(startDate.dayOfMonth()));
-          values.push_back(boost::lexical_cast<std::string>(date.monthOfYear().value()));
-          values.push_back(boost::lexical_cast<std::string>(date.dayOfMonth()));
-          IdfExtensibleGroup test = scheduleYear.pushExtensibleGroup(values);
-          OS_ASSERT(!test.empty());
-
-          // Write the schedule
-          m_idfObjects.push_back(weekSchedule->toIdfObject());
         }
 
         // increment date

--- a/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateScheduleRuleset.cpp
@@ -288,9 +288,28 @@ namespace energyplus {
           // 2 if the week that includes 12/31 is different from the last week schedule
 
           // set last week schedule before we overwrite week schedule
-          lastDate = date - Time(1);                                 // i.e., Dec30?
-          if (!(date.dayOfWeek().value() == DayOfWeek::Saturday)) {  // otherwise we already wrote this out
-            lastDate = lastDate - Time(1);  // FIXME: this can't be right. wouldn't this depend on the day of the week for 12/31?
+          bool isSaturday = (date.dayOfWeek().value() == DayOfWeek::Saturday);
+          if (!isSaturday) {  // if it was Saturday, we've already written this week out
+            switch (date.dayOfWeek().value()) {
+              case DayOfWeek::Sunday:
+                lastDate = date - Time(1);
+                break;
+              case DayOfWeek::Monday:
+                lastDate = date - Time(2);
+                break;
+              case DayOfWeek::Tuesday:
+                lastDate = date - Time(3);
+                break;
+              case DayOfWeek::Wednesday:
+                lastDate = date - Time(4);
+                break;
+              case DayOfWeek::Thursday:
+                lastDate = date - Time(5);
+                break;
+              case DayOfWeek::Friday:
+                lastDate = date - Time(6);
+                break;
+            }
             lastWeekSchedule = weekSchedule;
           }
 
@@ -310,7 +329,8 @@ namespace energyplus {
           weekSchedule->customDay2Schedule = customDay2Schedule.name().get();
 
           // check if this schedule is equal to last week schedule
-          if (weekSchedule && lastWeekSchedule && (!(weekSchedule.get() == lastWeekSchedule.get()))) {
+          if (weekSchedule && lastWeekSchedule && (!(weekSchedule.get() == lastWeekSchedule.get()))
+              && (!isSaturday)) {  // if it was Saturday, we've already written this week out
             // if not write out last week schedule
 
             // get last extensible group, if any, to find start date otherwise use jan1


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5113.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
