### PR TITLE
Fix #5116 - Annoying FT warnings for always XX Scheduled missing the schedule type limits object

### DIFF
--- a/src/energyplus/ForwardTranslator.cpp
+++ b/src/energyplus/ForwardTranslator.cpp
@@ -3672,6 +3672,16 @@ namespace energyplus {
 
   void ForwardTranslator::translateSchedules(const model::Model& model) {
 
+    // Make sure these get in the idf file
+    {
+      auto schedule = model.alwaysOnDiscreteSchedule();
+      translateAndMapModelObject(schedule);
+      schedule = model.alwaysOffDiscreteSchedule();
+      translateAndMapModelObject(schedule);
+      schedule = model.alwaysOnContinuousSchedule();
+      translateAndMapModelObject(schedule);
+    }
+
     // loop over schedule type limits
     std::vector<WorkspaceObject> objects = model.getObjectsByType(IddObjectType::OS_ScheduleTypeLimits);
     std::sort(objects.begin(), objects.end(), WorkspaceObjectNameLess());
@@ -3697,16 +3707,6 @@ namespace energyplus {
         auto modelObject = workspaceObject.cast<ModelObject>();
         translateAndMapModelObject(modelObject);
       }
-    }
-
-    // Make sure these get in the idf file
-    {
-      auto schedule = model.alwaysOnDiscreteSchedule();
-      translateAndMapModelObject(schedule);
-      schedule = model.alwaysOffDiscreteSchedule();
-      translateAndMapModelObject(schedule);
-      schedule = model.alwaysOnContinuousSchedule();
-      translateAndMapModelObject(schedule);
     }
   }
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5116 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
