### PR TITLE
Fix #1472 - Respect user's SimulationControl choices and move smart defaults to the modelObject

### DIFF
--- a/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
+++ b/src/energyplus/ForwardTranslator/ForwardTranslateSimulationControl.cpp
@@ -4,17 +4,15 @@
 ***********************************************************************************************************************/
 
 #include "../ForwardTranslator.hpp"
-#include "../../model/AirLoopHVAC.hpp"
-#include "../../model/AirLoopHVAC_Impl.hpp"
+
+#include "../../model/SimulationControl.hpp"
+
 #include "../../model/PlantLoop.hpp"
 #include "../../model/PlantLoop_Impl.hpp"
-#include "../../model/SimulationControl.hpp"
 #include "../../model/SizingPeriod.hpp"
 #include "../../model/SizingPeriod_Impl.hpp"
 #include "../../model/SizingPlant.hpp"
-#include "../../model/SizingPlant_Impl.hpp"
-#include "../../model/ThermalZone.hpp"
-#include "../../model/ThermalZone_Impl.hpp"
+
 #include <utilities/idd/SimulationControl_FieldEnums.hxx>
 #include <utilities/idd/IddEnums.hxx>
 
@@ -27,95 +25,30 @@ namespace openstudio {
 namespace energyplus {
 
   boost::optional<IdfObject> ForwardTranslator::translateSimulationControl(SimulationControl& modelObject) {
-    IdfObject simCon(openstudio::IddObjectType::SimulationControl);
 
-    m_idfObjects.push_back(simCon);
+    IdfObject simCon = createAndRegisterIdfObject(openstudio::IddObjectType::SimulationControl, modelObject);
 
-    OptionalString s = modelObject.name();
-    if (s) {
-      simCon.setName(*s);
-    }
+    auto boolToString = [](bool b) { return b ? "Yes" : "No"; };
 
-    const unsigned numSizingPeriods = modelObject.model().getModelObjects<SizingPeriod>().size();
+    // NOTE: the logic for these three where it's defaulted is inside the model object:
+    // it checks if you have Design Days + (Zonal equipment / AirLoopHVAC / PlantLoop)
+    simCon.setString(openstudio::SimulationControlFields::DoZoneSizingCalculation, boolToString(modelObject.doZoneSizingCalculation()));
+    simCon.setString(openstudio::SimulationControlFields::DoSystemSizingCalculation, boolToString(modelObject.doSystemSizingCalculation()));
+    simCon.setString(openstudio::SimulationControlFields::DoPlantSizingCalculation, boolToString(modelObject.doPlantSizingCalculation()));
 
-    auto hasZoneEquipment = [](const Model& m) {
-      auto zones = m.getConcreteModelObjects<ThermalZone>();
-      return std::any_of(zones.cbegin(), zones.cend(), [](const auto& z) { return !z.equipment().empty(); });
-    };
-
-    if (modelObject.doZoneSizingCalculation()) {
-      simCon.setString(openstudio::SimulationControlFields::DoZoneSizingCalculation, "Yes");
-    } else if ((numSizingPeriods > 0) && hasZoneEquipment(modelObject.model())) {
-      if (modelObject.isDoZoneSizingCalculationDefaulted()) {
-        LOG(Info, "You have zonal equipment and design days, and SimulationControl::DoZoneSizingCalculation is defaulted: turning on.");
-        simCon.setString(openstudio::SimulationControlFields::DoZoneSizingCalculation, "Yes");
-      } else {
-        LOG(Warn, "You have zonal equipment and design days, it's possible you should enable SimulationControl::DoZoneSizingCalculation");
-        simCon.setString(openstudio::SimulationControlFields::DoZoneSizingCalculation, "No");
-      }
-    } else {
-      simCon.setString(openstudio::SimulationControlFields::DoZoneSizingCalculation, "No");
-    }
-
-    if (modelObject.doSystemSizingCalculation()) {
-      simCon.setString(openstudio::SimulationControlFields::DoSystemSizingCalculation, "Yes");
-    } else if ((numSizingPeriods > 0) && (!modelObject.model().getConcreteModelObjects<AirLoopHVAC>().empty())) {
-      if (modelObject.isDoSystemSizingCalculationDefaulted()) {
-        LOG(Info, "You have AirLoopHVACs and design days, and SimulationControl::DoSystemSizingCalculation is defaulted: turning it on.");
-        simCon.setString(openstudio::SimulationControlFields::DoSystemSizingCalculation, "Yes");
-      } else {
-        LOG(Warn, "You have AirLoopHVACs and design days, it's possible you should enable SimulationControl::DoSystemSizingCalculation");
-        simCon.setString(openstudio::SimulationControlFields::DoSystemSizingCalculation, "No");
-      }
-    } else {
-      simCon.setString(openstudio::SimulationControlFields::DoSystemSizingCalculation, "No");
-    }
-
-    if (modelObject.doPlantSizingCalculation()) {
-      simCon.setString(openstudio::SimulationControlFields::DoPlantSizingCalculation, "Yes");
-    } else if ((numSizingPeriods > 0) && (!modelObject.model().getConcreteModelObjects<PlantLoop>().empty())) {
-      if (modelObject.isDoPlantSizingCalculationDefaulted()) {
-        LOG(Info, "You have PlantLoops and design days, and SimulationControl::DoPlantSizingCalculation is defaulted: turning it on.");
-        simCon.setString(openstudio::SimulationControlFields::DoPlantSizingCalculation, "Yes");
-      } else {
-        LOG(Warn, "You have PlantLoops and design days, it's possible you should enable SimulationControl::DoPlantSizingCalculation");
-        simCon.setString(openstudio::SimulationControlFields::DoPlantSizingCalculation, "No");
-      }
-    } else {
-      simCon.setString(openstudio::SimulationControlFields::DoPlantSizingCalculation, "No");
-    }
-
-    if (modelObject.runSimulationforSizingPeriods()) {
-      simCon.setString(openstudio::SimulationControlFields::RunSimulationforSizingPeriods, "Yes");
-    } else {
-      simCon.setString(openstudio::SimulationControlFields::RunSimulationforSizingPeriods, "No");
-    }
+    simCon.setString(openstudio::SimulationControlFields::RunSimulationforSizingPeriods, boolToString(modelObject.runSimulationforSizingPeriods()));
 
     // DLM: might want to check for weather file object?
-    if (modelObject.runSimulationforWeatherFileRunPeriods()) {
-      simCon.setString(openstudio::SimulationControlFields::RunSimulationforWeatherFileRunPeriods, "Yes");
-    } else {
-      simCon.setString(openstudio::SimulationControlFields::RunSimulationforWeatherFileRunPeriods, "No");
-    }
+    simCon.setString(openstudio::SimulationControlFields::RunSimulationforWeatherFileRunPeriods,
+                     boolToString(modelObject.runSimulationforWeatherFileRunPeriods()));
 
-    if (modelObject.doHVACSizingSimulationforSizingPeriods()) {
+    // The logic when defaulted is inside the model object
+    if (!modelObject.isDoHVACSizingSimulationforSizingPeriodsDefaulted()) {
+      simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods,
+                       boolToString(modelObject.doHVACSizingSimulationforSizingPeriods()));
+    } else if (modelObject.doHVACSizingSimulationforSizingPeriods()) {
+      // We only write it if it's not the IDD default of "No", so we don't want to pollute the IDF with advanced fields that people aren't used to.
       simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, "Yes");
-    } else if (numSizingPeriods > 0) {
-      // Sizing:Plant I/O: "The use of 'Coincident' sizing option requires that the object
-      // be set to YES for the input field called Do HVAC Sizing Simulation for Sizing Periods"
-      std::vector<PlantLoop> plantLoops = modelObject.model().getConcreteModelObjects<PlantLoop>();
-      if (std::any_of(plantLoops.begin(), plantLoops.end(),
-                      [](const PlantLoop& p) { return openstudio::istringEqual("Coincident", p.sizingPlant().sizingOption()); })) {
-        simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, "Yes");
-      } else {
-        if (!modelObject.isDoZoneSizingCalculationDefaulted()) {
-          simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, "No");
-        }
-      }
-    } else {
-      if (!modelObject.isDoZoneSizingCalculationDefaulted()) {
-        simCon.setString(openstudio::SimulationControlFields::DoHVACSizingSimulationforSizingPeriods, "No");
-      }
     }
 
     if (!modelObject.isMaximumNumberofHVACSizingSimulationPassesDefaulted()) {
@@ -125,7 +58,7 @@ namespace energyplus {
 
     // other fields mapped to Building
 
-    return boost::optional<IdfObject>(simCon);
+    return simCon;
   }
 
 }  // namespace energyplus

--- a/src/model/SimulationControl.hpp
+++ b/src/model/SimulationControl.hpp
@@ -60,14 +60,17 @@ namespace model {
     /** @name Getters */
     //@{
 
+    // When defaulted, this will return true if you have DesignDays in your model and any zone with a Zonal HVAC equipment, false otherwise
     bool doZoneSizingCalculation() const;
 
     bool isDoZoneSizingCalculationDefaulted() const;
 
+    // When defaulted, this will return true only if you have DesignDays and at least one AirLoopHVAC in your model
     bool doSystemSizingCalculation() const;
 
     bool isDoSystemSizingCalculationDefaulted() const;
 
+    // When defaulted, this will return true only if you have DesignDays and at least one PlantLoop in your model
     bool doPlantSizingCalculation() const;
 
     bool isDoPlantSizingCalculationDefaulted() const;
@@ -100,6 +103,7 @@ namespace model {
 
     bool isMinimumNumberofWarmupDaysDefaulted() const;
 
+    // When defaulted, this will return true only if you have DesignDays and at least one PlantLoop with a Sizing Plant having a 'Coincident' Sizing Option
     bool doHVACSizingSimulationforSizingPeriods() const;
     bool isDoHVACSizingSimulationforSizingPeriodsDefaulted() const;
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #1472

- We always respect a value that the user has picked
    - I don't care if this means that the E+ simulation will crash. It's going to be clear that's the problem
    - I do issue a Warning if the user has deliberately picked "No" but it looks like it should be enabled
- When defaulted, the smart default is in the model object itself

@kbenne does that make sense to you?

### Pull Request Author

 - [x] Model API Changes / Additions
 - [x] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [x] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
