### PR TITLE
#5121 - Extensible Groups problems in ModelObject/WorkspaceObject

### DIFF
--- a/src/model/test/ZoneHVACEquipmentList_GTest.cpp
+++ b/src/model/test/ZoneHVACEquipmentList_GTest.cpp
@@ -160,6 +160,10 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_ModelObject_Is_First)
   Model m;
   ThermalZone z(m);
 
+  auto eqlists = m.getConcreteModelObjects<ZoneHVACEquipmentList>();
+  EXPECT_EQ(1, eqlists.size());
+  auto& eqlist = eqlists.front();
+
   ZoneHVACBaseboardConvectiveElectric bb_delete(m);
 
   ScheduleConstant bb_sch(m);
@@ -174,11 +178,39 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_ModelObject_Is_First)
   EXPECT_TRUE(bb_delete.addToThermalZone(z));
   EXPECT_TRUE(bb.addToThermalZone(z));
 
-  auto objects = m.getObjectsByName(bb.nameString());
-  EXPECT_EQ(2, objects.size());
-  EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), objects.front().iddObject().type());
+  {
+    EXPECT_EQ(2, eqlist.numExtensibleGroups());
+    auto idf_egs = eqlist.extensibleGroups();
+    for (const auto& idf_eg : idf_egs) {
+      // Using getField so we don't resolve object name, but get the handle string
+      const auto val_ = idf_eg.getField(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment);
+      const auto uid = openstudio::toUUID(*val_);
+      auto obj_ = m.getObject(uid);
+      ASSERT_TRUE(obj_);
+      EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
+    }
+  }
+
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), objects.front().iddObject().type());
+  }
 
   EXPECT_NO_THROW(bb_delete.remove());
+
+  {
+    EXPECT_EQ(1, eqlist.numExtensibleGroups());
+    auto idf_egs = eqlist.extensibleGroups();
+    for (const auto& idf_eg : idf_egs) {
+      // Using getField so we don't resolve object name, but get the handle string
+      const auto val_ = idf_eg.getField(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment);
+      const auto uid = openstudio::toUUID(*val_);
+      auto obj_ = m.getObject(uid);
+      ASSERT_TRUE(obj_);
+      EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
+    }
+  }
 }
 
 TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First) {
@@ -204,23 +236,39 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First) {
   EXPECT_TRUE(bb_delete.addToThermalZone(z));
   EXPECT_TRUE(bb.addToThermalZone(z));
 
-  EXPECT_EQ(2, eqlist.numExtensibleGroups());
-  // I deliberately use idfObject.extensibleGroups so the handles aren't resolved to object name
-  auto idf_egs = eqlist.idfObject().extensibleGroups();
-
-  for (const auto& idf_eg : idf_egs) {
-    const std::string val = idf_eg.getString(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment).get();
-    const auto uid = openstudio::toUUID(val);
-    auto obj_ = m.getObject(uid);
-    ASSERT_TRUE(obj_);
-    EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
+  {
+    EXPECT_EQ(2, eqlist.numExtensibleGroups());
+    auto idf_egs = eqlist.extensibleGroups();
+    for (const auto& idf_eg : idf_egs) {
+      // Using getField so we don't resolve object name, but get the handle string
+      const auto val_ = idf_eg.getField(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment);
+      const auto uid = openstudio::toUUID(*val_);
+      auto obj_ = m.getObject(uid);
+      ASSERT_TRUE(obj_);
+      EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
+    }
   }
 
-  auto objects = m.getObjectsByName(bb.nameString());
-  EXPECT_EQ(2, objects.size());
-  EXPECT_EQ(IddObjectType(IddObjectType::OS_Schedule_Constant), objects.front().iddObject().type());
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    EXPECT_EQ(IddObjectType(IddObjectType::OS_Schedule_Constant), objects.front().iddObject().type());
+  }
 
   EXPECT_NO_THROW(bb_delete.remove());
+
+  {
+    EXPECT_EQ(1, eqlist.numExtensibleGroups());
+    auto idf_egs = eqlist.extensibleGroups();
+    for (const auto& idf_eg : idf_egs) {
+      // Using getField so we don't resolve object name, but get the handle string
+      const auto val_ = idf_eg.getField(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment);
+      const auto uid = openstudio::toUUID(*val_);
+      auto obj_ = m.getObject(uid);
+      ASSERT_TRUE(obj_);
+      EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
+    }
+  }
 }
 
 TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First_OnlyPop) {
@@ -306,10 +354,11 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_OnlyPop_Work
     EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
   }
 
-  eqlist.idfObject().eraseExtensibleGroup(0);
+  auto i = eqlist.idfObject();
+  i.eraseExtensibleGroup(0);
 
-  EXPECT_EQ(1, eqlist.numExtensibleGroups());
-  idf_egs = eqlist.idfObject().extensibleGroups();
+  EXPECT_EQ(1, i.numExtensibleGroups());
+  idf_egs = i.extensibleGroups();
   for (const auto& idf_eg : idf_egs) {
     const std::string val = idf_eg.getString(OS_ZoneHVAC_EquipmentListExtensibleFields::ZoneEquipment).get();
     const auto uid = openstudio::toUUID(val);

--- a/src/utilities/idf/IdfExtensibleGroup.cpp
+++ b/src/utilities/idf/IdfExtensibleGroup.cpp
@@ -22,6 +22,17 @@ StringVector IdfExtensibleGroup::fields(bool returnDefault) const {
   return result;
 }
 
+StringVector IdfExtensibleGroup::fieldsWithHandles(bool returnDefault) const {
+  StringVector result;
+  const unsigned n = numFields();
+  result.reserve(n);
+  for (unsigned i = 0; i < n; ++i) {
+    OptionalString str = getField(i, returnDefault);
+    result.push_back(str.get_value_or(""));
+  }
+  return result;
+}
+
 StringVector IdfExtensibleGroup::fieldComments(bool returnDefault) const {
   StringVector result;
   for (unsigned i = 0, n = numFields(); i < n; ++i) {
@@ -55,6 +66,13 @@ OptionalString IdfExtensibleGroup::getString(unsigned fieldIndex, bool returnDef
     return boost::none;
   }
   return m_impl->getString(mf_toIndex(fieldIndex), returnDefault);
+}
+
+boost::optional<std::string> IdfExtensibleGroup::getField(unsigned index, bool returnDefault) const {
+  if (!isValid(index)) {
+    return boost::none;
+  }
+  return m_impl->getField(mf_toIndex(index), returnDefault);
 }
 
 OptionalDouble IdfExtensibleGroup::getDouble(unsigned fieldIndex, bool returnDefault) const {
@@ -169,7 +187,7 @@ IdfExtensibleGroup IdfExtensibleGroup::pushClone() const {
     return {p, 0};
   }
 
-  StringVector values = fields();
+  StringVector values = fieldsWithHandles();
   OS_ASSERT(values.size() == numFields());
   return m_impl->pushExtensibleGroup(values);
 }
@@ -180,7 +198,7 @@ IdfExtensibleGroup IdfExtensibleGroup::insertClone(unsigned groupIndex) const {
     return {p, 0};
   }
 
-  StringVector values = fields();
+  StringVector values = fieldsWithHandles();
   OS_ASSERT(values.size() == numFields());
   return m_impl->insertExtensibleGroup(groupIndex, values);
 }

--- a/src/utilities/idf/IdfExtensibleGroup.hpp
+++ b/src/utilities/idf/IdfExtensibleGroup.hpp
@@ -40,9 +40,12 @@ class UTILITIES_API IdfExtensibleGroup
   /** @name Getters */
   //@{
 
-  /** Returns this extensible group's fields. Return value will be empty() if this group is
-   *  empty(). */
+  /** Returns this extensible group's fields. Return value will be empty() if this group is empty(). */
   std::vector<std::string> fields(bool returnDefault = false) const;
+
+  /** Returns this extensible group's fields. Return value will be empty() if this group is empty().
+    * Unlike fields(), in the case it's a WorkspaceObject_Impl, it uses handles as string and not the name of the target object */
+  std::vector<std::string> fieldsWithHandles(bool returnDefault = false) const;
 
   /** Returns the comments associated with this extensible group's fields. */
   std::vector<std::string> fieldComments(bool returnDefault = false) const;
@@ -53,6 +56,10 @@ class UTILITIES_API IdfExtensibleGroup
   /** Returns the string value of this extensible group's field fieldIndex, if that field
    *  exists (isValid(fieldIndex)). */
   boost::optional<std::string> getString(unsigned fieldIndex, bool returnDefault = false) const;
+
+  /** Like getString except for reference fields getString will return the name of the referenced object.
+   * This method, getField, will always return the string value  of the field.   */
+  boost::optional<std::string> getField(unsigned index, bool returnDefault = false) const;
 
   /** Returns true if the field is empty. */
   bool isEmpty(unsigned fieldIndex) const;

--- a/src/utilities/idf/IdfObject.cpp
+++ b/src/utilities/idf/IdfObject.cpp
@@ -209,6 +209,10 @@ namespace detail {
     return boost::none;
   }
 
+  boost::optional<std::string> IdfObject_Impl::getField(unsigned index, bool returnDefault) const {
+    return IdfObject_Impl::getString(index, returnDefault, false);
+  }
+
   boost::optional<double> IdfObject_Impl::getDouble(unsigned index, bool returnDefault) const {
     OptionalDouble result;
     OptionalString value = getString(index, returnDefault, false);
@@ -687,7 +691,7 @@ namespace detail {
       unsigned i = numExtensibleGroups() - 1;
       IdfExtensibleGroup eg = getExtensibleGroup(i);
       OS_ASSERT(!eg.empty());
-      IdfExtensibleGroup temp = pushExtensibleGroup(eg.fields(), checkValidity);
+      IdfExtensibleGroup temp = pushExtensibleGroup(eg.fieldsWithHandles(), checkValidity);
       if (temp.empty()) {
         OS_ASSERT(numFields() == n);
         OS_ASSERT(m_diffs.size() == diffSize);
@@ -701,7 +705,7 @@ namespace detail {
         --i;
         IdfExtensibleGroup peg = getExtensibleGroup(i);
         OS_ASSERT(!peg.empty());
-        ok = eg.setFields(peg.fields(), false);
+        ok = eg.setFields(peg.fieldsWithHandles(), false);
         if (!ok) {
           // roll back
           i += 2;
@@ -710,7 +714,7 @@ namespace detail {
             OS_ASSERT(!peg.empty());
             eg = getExtensibleGroup(i + 1);
             OS_ASSERT(!eg.empty());
-            peg.setFields(eg.fields(), false);
+            peg.setFields(eg.fieldsWithHandles(), false);
             ++i;
           }
           popExtensibleGroup(false);
@@ -734,7 +738,7 @@ namespace detail {
           ++i;
           eg = getExtensibleGroup(i);
           OS_ASSERT(!eg.empty());
-          peg.setFields(eg.fields(), false);
+          peg.setFields(eg.fieldsWithHandles(), false);
           peg = eg;
         }
         popExtensibleGroup(false);
@@ -774,7 +778,7 @@ namespace detail {
       IdfExtensibleGroup egToPop = getExtensibleGroup(numExtensibleGroups() - 1);
       OS_ASSERT(!egToPop.empty());
       UnsignedVector indices = egToPop.mf_indices();
-      result = egToPop.fields();
+      result = egToPop.fieldsWithHandles();
       OS_ASSERT(result.size() == groupSize);
 
       // record diffs for each field going backwards
@@ -825,14 +829,14 @@ namespace detail {
       StringVector temp = result;
       IdfExtensibleGroup eg = getExtensibleGroup(i);
       OS_ASSERT(!eg.empty());
-      result = eg.fields();
+      result = eg.fieldsWithHandles();
       ok = eg.setFields(temp, checkValidity);
       if (!ok) {
         // roll back changes and return
         for (unsigned j = i + 1, n = numExtensibleGroups(); j < n; ++j) {
           eg = getExtensibleGroup(j);
           OS_ASSERT(!eg.empty());
-          result = eg.fields();
+          result = eg.fieldsWithHandles();
           OS_ASSERT(result.size() == temp.size());
           eg.setFields(temp, false);
           temp = result;
@@ -884,7 +888,7 @@ namespace detail {
       if (indices.empty()) {
         indices = eg.mf_indices();
       }
-      rollbackValues.push_back(eg.fields());
+      rollbackValues.push_back(eg.fieldsWithHandles());
       rollbackComments.push_back(eg.fieldComments());
       // try to pop
       StringVector result = popExtensibleGroup(checkValidity);
@@ -2061,6 +2065,10 @@ bool IdfObject::isEmpty(unsigned index) const {
 
 boost::optional<std::string> IdfObject::getString(unsigned index, bool returnDefault, bool returnUninitializedEmpty) const {
   return m_impl->getString(index, returnDefault, returnUninitializedEmpty);
+}
+
+boost::optional<std::string> IdfObject::getField(unsigned index, bool returnDefault) const {
+  return m_impl->getField(index, returnDefault);
 }
 
 boost::optional<double> IdfObject::getDouble(unsigned index, bool returnDefault) const {

--- a/src/utilities/idf/IdfObject.hpp
+++ b/src/utilities/idf/IdfObject.hpp
@@ -144,6 +144,11 @@ class UTILITIES_API IdfObject
    */
   boost::optional<std::string> getString(unsigned index, bool returnDefault = false, bool returnUninitializedEmpty = false) const;
 
+  /** Like getString except for reference fields getString will return the name of the referenced object.
+    * This method, getField, will always return the string value of the field.
+    * For IdfObject, this is the same as getString */
+  boost::optional<std::string> getField(unsigned index, bool returnDefault = false) const;
+
   /** Get the value of the field at index, converted to double, if possible. Returns an
    *  uninitialized object if the conversion is unsuccessful for any reason. Logs a warning
    *  if the conversion fails, the field is RealType, and the field is not equal to

--- a/src/utilities/idf/IdfObject_Impl.hpp
+++ b/src/utilities/idf/IdfObject_Impl.hpp
@@ -101,6 +101,11 @@ namespace detail {
      */
     virtual boost::optional<std::string> getString(unsigned index, bool returnDefault = false, bool returnUninitializedEmpty = false) const;
 
+    /** Like getString except for reference fields getString will return the name of the referenced object.
+     * This method, getField, will always return the string value of the field.
+     * For IdfObject, this is the same as getString */
+    virtual boost::optional<std::string> getField(unsigned index, bool returnDefault = false) const;
+
     /** Get the value of the field at index, converted to double, if possible. Returns an
      *  uninitialized object if the conversion is unsuccessful for any reason. Logs a warning
      *  if the conversion fails, the field is RealType, and the field is not equal to

--- a/src/utilities/idf/Test/ExtensibleGroup_GTest.cpp
+++ b/src/utilities/idf/Test/ExtensibleGroup_GTest.cpp
@@ -469,11 +469,14 @@ TEST_F(IdfFixture, ExtensibleGroup_Erase) {
   objects[3].setName("Gypsum");
   WorkspaceObjectVector temp = ws.addObjects(objects);
   ASSERT_EQ(static_cast<unsigned>(4), temp.size());
-  ASSERT_TRUE(temp[0].iddObject().type() == IddObjectType::Construction);
-  ASSERT_TRUE(temp[1].name().get() == "Brick");
-  ASSERT_TRUE(temp[2].name().get() == "Insulation");
-  ASSERT_TRUE(temp[3].name().get() == "Gypsum");
-  WorkspaceObject wsConstruction = temp[0];
+  WorkspaceObject& wsConstruction = temp[0];
+  WorkspaceObject& wsBrick = temp[1];
+  WorkspaceObject& wsInsulation = temp[2];
+  WorkspaceObject& wsGypsum = temp[3];
+  ASSERT_TRUE(wsConstruction.iddObject().type() == IddObjectType::Construction);
+  ASSERT_TRUE(wsBrick.name().get() == "Brick");
+  ASSERT_TRUE(wsInsulation.name().get() == "Insulation");
+  ASSERT_TRUE(wsGypsum.name().get() == "Gypsum");
 
   values[0] = "Brick";
   eg = wsConstruction.pushExtensibleGroup(values);
@@ -488,17 +491,19 @@ TEST_F(IdfFixture, ExtensibleGroup_Erase) {
   ASSERT_FALSE(eg.empty());  // Brick, Insulation, Insulation, Gypsum
 
   // erase and check pointers
-  EXPECT_EQ(static_cast<unsigned>(2), temp[2].numSources());
+  EXPECT_EQ(static_cast<unsigned>(2), wsInsulation.numSources());
   values = wsConstruction.eraseExtensibleGroup(1);
   ASSERT_EQ(static_cast<unsigned>(1), values.size());
-  EXPECT_EQ("Insulation", values[0]);  // Brick, Insulation, Gypsum
-  EXPECT_EQ(static_cast<unsigned>(1), temp[2].numSources());
+  EXPECT_EQ(openstudio::toString(wsInsulation.handle()), values[0]);  // Brick, Insulation, Gypsum
+  EXPECT_EQ(static_cast<unsigned>(1), wsInsulation.numSources());
+
   values = wsConstruction.eraseExtensibleGroup(2);
   ASSERT_EQ(static_cast<unsigned>(1), values.size());
-  EXPECT_EQ("Gypsum", values[0]);  // Brick, Insulation
-  EXPECT_EQ(static_cast<unsigned>(1), temp[1].numSources());
-  EXPECT_EQ(static_cast<unsigned>(1), temp[2].numSources());
-  EXPECT_EQ(static_cast<unsigned>(0), temp[3].numSources());
+  EXPECT_EQ(openstudio::toString(wsGypsum.handle()), values[0]);  // Brick, Insulation
+
+  EXPECT_EQ(static_cast<unsigned>(1), wsBrick.numSources());
+  EXPECT_EQ(static_cast<unsigned>(1), wsInsulation.numSources());
+  EXPECT_EQ(static_cast<unsigned>(0), wsGypsum.numSources());
   ASSERT_EQ(static_cast<unsigned>(3), wsConstruction.numFields());
   EXPECT_EQ("Brick", wsConstruction.getString(1).get());
   EXPECT_EQ("Insulation", wsConstruction.getString(2).get());

--- a/src/utilities/idf/WorkspaceExtensibleGroup.cpp
+++ b/src/utilities/idf/WorkspaceExtensibleGroup.cpp
@@ -45,13 +45,6 @@ std::vector<unsigned> WorkspaceExtensibleGroup::getSourceFieldIndices(const Hand
   return result;
 }
 
-boost::optional<std::string> WorkspaceExtensibleGroup::getField(unsigned index) const {
-  if (!isValid(index)) {
-    return boost::none;
-  }
-  return getImpl<detail::WorkspaceObject_Impl>()->getField(mf_toIndex(index));
-}
-
 // SETTERS
 bool WorkspaceExtensibleGroup::setPointer(unsigned fieldIndex, const Handle& targetHandle) {
   return setPointer(fieldIndex, targetHandle, true);

--- a/src/utilities/idf/WorkspaceExtensibleGroup.hpp
+++ b/src/utilities/idf/WorkspaceExtensibleGroup.hpp
@@ -42,12 +42,6 @@ class UTILITIES_API WorkspaceExtensibleGroup : public IdfExtensibleGroup
    *  if possible. */
   std::vector<unsigned> getSourceFieldIndices(const Handle& targetHandle) const;
 
-  /** Like getString except for reference fields getString will return the
-   *  name of the referenced object. This method, getField, will always return the string value
-   *  of the field.
-   */
-  boost::optional<std::string> getField(unsigned index) const;
-
   //@}
   /** @name Setters */
   //@{

--- a/src/utilities/idf/WorkspaceObject.cpp
+++ b/src/utilities/idf/WorkspaceObject.cpp
@@ -188,7 +188,7 @@ namespace detail {
     return IdfObject_Impl::getString(index, returnDefault, returnUninitializedEmpty);
   }
 
-  boost::optional<std::string> WorkspaceObject_Impl::getField(unsigned index) const {
+  boost::optional<std::string> WorkspaceObject_Impl::getField(unsigned index, bool returnDefault) const {
     boost::optional<std::string> result;
 
     // IdfObject_Impl::getString won't work if this is a source field... since m_fields will be blank
@@ -212,7 +212,7 @@ namespace detail {
       }
     } else {
       // If not source, then call getString
-      result = IdfObject_Impl::getString(index, false, false);
+      result = IdfObject_Impl::getString(index, returnDefault, false);
     }
 
     return result;
@@ -1374,10 +1374,6 @@ bool WorkspaceObject::objectListFieldsEqual(const WorkspaceObject& other) const 
 
 bool WorkspaceObject::objectListFieldsNonConflicting(const WorkspaceObject& other) const {
   return getImpl<WorkspaceObject_Impl>()->objectListFieldsNonConflicting(other);
-}
-
-boost::optional<std::string> WorkspaceObject::getField(unsigned index) const {
-  return getImpl<WorkspaceObject_Impl>()->getField(index);
 }
 
 // SERIALIZATION

--- a/src/utilities/idf/WorkspaceObject.hpp
+++ b/src/utilities/idf/WorkspaceObject.hpp
@@ -66,12 +66,6 @@ class UTILITIES_API WorkspaceObject : public IdfObject
   /** Returns all objects of type that point to this object, filtering for duplicate objects. */
   std::vector<WorkspaceObject> getSources(IddObjectType type) const;
 
-  /** Like getString except for reference fields getString will return the
-   *  name of the referenced object. This method, getField, will always return the string value
-   *  of the field.
-   */
-  boost::optional<std::string> getField(unsigned index) const;
-
   //@}
   /** @name Setters */
   //@{

--- a/src/utilities/idf/WorkspaceObject_Impl.hpp
+++ b/src/utilities/idf/WorkspaceObject_Impl.hpp
@@ -129,7 +129,7 @@ namespace detail {
      *  (non-extensible) fields and fields with empty data, if a default exists. */
     virtual boost::optional<std::string> getString(unsigned index, bool returnDefault = false, bool returnUninitializedEmpty = false) const override;
 
-    boost::optional<std::string> getField(unsigned index) const;
+    virtual boost::optional<std::string> getField(unsigned index, bool returnDefault = false) const override;
 
     /** Returns the object pointed to by the field at index, if it exists. */
     boost::optional<WorkspaceObject> getTarget(unsigned index) const;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix for #5121 
 
Seems like the problem is that ModelObject, via WorkspaceObject resolves any handle field to the name the target, and during eraseExtensibleGroup, that goes nuclear, and if the Schedule is named like the object, and the schedule is found first in the workspace, then you end up with the Schedule being on the ZoneHVACEquipmentList...

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
