### PR TITLE
Keep track of version ids for outdated measures and components

### DIFF
--- a/src/utilities/bcl/RemoteBCL.hpp
+++ b/src/utilities/bcl/RemoteBCL.hpp
@@ -288,8 +288,10 @@ class UTILITIES_API RemoteBCL : public BCL
   bool validDevAuthKey;
 
   std::vector<BCLSearchResult> m_componentsWithUpdates;
+  std::map<std::string, std::vector<std::string>> m_outdatedComponentVersionIdMap;
 
   std::vector<BCLSearchResult> m_measuresWithUpdates;
+  std::map<std::string, std::vector<std::string>> m_outdatedMeasureVersionIdMap;
 
   unsigned m_timeOutSeconds;
 };


### PR DESCRIPTION
Keep track of version ids for outdated measures and components, remove only outdated versions when updating measures and components

Pull request overview
---------------------

 - Fixes https://github.com/NREL/OpenStudio/issues/5128

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

<!--- Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol. -->

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
