### PR TITLE
Fix #5128 - Properly remove old components/measures when updating

### DIFF
--- a/src/utilities/bcl/LocalBCL.cpp
+++ b/src/utilities/bcl/LocalBCL.cpp
@@ -1360,6 +1360,28 @@ bool LocalBCL::removeMeasure(BCLMeasure& measure) {
   return true;
 }
 
+size_t LocalBCL::removeOutdatedLocalComponents(const std::string& uid, const std::string& currentVersionId) {
+  size_t num_removed = 0;
+  for (auto& component : components()) {
+    if ((component.uid() == uid) && (component.versionId() != currentVersionId)) {
+      ++num_removed;
+      removeComponent(component);
+    }
+  }
+  return num_removed;
+}
+
+size_t LocalBCL::removeOutdatedLocalMeasures(const std::string& uid, const std::string& currentVersionId) {
+  size_t num_removed = 0;
+  for (auto& measure : measures()) {
+    if ((measure.uid() == uid) && (measure.versionId() != currentVersionId)) {
+      ++num_removed;
+      removeMeasure(measure);
+    }
+  }
+  return num_removed;
+}
+
 std::vector<BCLComponent> LocalBCL::componentAttributeSearch(const std::vector<std::pair<std::string, std::string>>& searchTerms) const {
   auto uids = attributeSearch(searchTerms, "component");
   if (uids.empty()) {

--- a/src/utilities/bcl/LocalBCL.hpp
+++ b/src/utilities/bcl/LocalBCL.hpp
@@ -97,6 +97,12 @@ class UTILITIES_API LocalBCL : public BCL
   // cppcheck-suppress constParameter
   bool removeMeasure(BCLMeasure& measure);
 
+  // Removes all components with uid but NOT currentVersionId
+  size_t removeOutdatedLocalComponents(const std::string& uid, const std::string& currentVersionId);
+
+  // Removes all measures with uid but NOT currentVersionId
+  size_t removeOutdatedLocalMeasures(const std::string& uid, const std::string& currentVersionId);
+
   /// Search for components with attributes matching those in searchTerms
   std::vector<BCLComponent> componentAttributeSearch(const std::vector<std::pair<std::string, std::string>>& searchTerms) const;
 

--- a/src/utilities/bcl/RemoteBCL.cpp
+++ b/src/utilities/bcl/RemoteBCL.cpp
@@ -290,14 +290,11 @@ void RemoteBCL::updateComponents() {
   }
 
   for (const BCLSearchResult& component : m_componentsWithUpdates) {
-    downloadMeasure(component.uid());
+    downloadComponent(component.uid());
     boost::optional<BCLComponent> newComponent = waitForComponentDownload();
 
     if (newComponent) {
-      boost::optional<BCLComponent> oldComponent = LocalBCL::instance().getComponent(newComponent->uid());
-      if (oldComponent && oldComponent->versionId() != newComponent->versionId()) {
-        LocalBCL::instance().removeComponent(*oldComponent);
-      }
+      LocalBCL::instance().removeOutdatedLocalComponents(newComponent->uid(), newComponent->versionId());
     }
   }
 }
@@ -312,10 +309,7 @@ void RemoteBCL::updateMeasures() {
     boost::optional<BCLMeasure> newMeasure = waitForMeasureDownload();
 
     if (newMeasure) {
-      boost::optional<BCLMeasure> oldMeasure = LocalBCL::instance().getMeasure(newMeasure->uid());
-      if (oldMeasure && oldMeasure->versionId() != newMeasure->versionId()) {
-        LocalBCL::instance().removeMeasure(*oldMeasure);
-      }
+      LocalBCL::instance().removeOutdatedLocalMeasures(newMeasure->uid(), newMeasure->versionId());
     }
   }
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #5128 
 - Properly remove old components/measures when updating
 - Different implementation from #5127 from @macumber 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
