### PR TITLE
5155 ruby engine fixture.wrong method measure

### DIFF
--- a/ruby/engine/test/RubyEngine_GTest.cpp
+++ b/ruby/engine/test/RubyEngine_GTest.cpp
@@ -25,7 +25,7 @@ class RubyEngineFixture : public testing::Test
   }
 
   static std::string stripAddressFromErrorMessage(const std::string& error_message) {
-    static std::regex object_address_re("0x[[:alnum:]]*>");
+    static std::regex object_address_re("0x[[:alnum:]]* @__swigtype__=\"_p_openstudio__model__Model\">");
 
     return std::regex_replace(error_message, object_address_re, "ADDRESS>");
   }


### PR DESCRIPTION
@jmarrec see the description of what is going on in the [issue](https://github.com/NREL/OpenStudio/issues/5155) I suppose it is possible the issue is local to me. 

I'm working with @wenyikuang to get the CI passing the ruby tests. 