### PR TITLE
Fix #5167 - measure.xml default bool values reported as 0/1 on develop

### DIFF
--- a/src/measure/OSArgument.cpp
+++ b/src/measure/OSArgument.cpp
@@ -979,7 +979,11 @@ namespace measure {
       [&ss](const auto& arg) {
         // Needed to properly compare the types
         using T = std::decay_t<decltype(arg)>;
-        if constexpr (!std::is_same_v<T, std::monostate>) {
+        if constexpr (std::is_same_v<T, std::monostate>) {
+          // No-op
+        } else if constexpr (std::is_same_v<T, bool>) {
+          ss << std::boolalpha << arg;
+        } else {
           ss << arg;
         }
       },


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5167

Tested locally by adding a new bool argument with a default value of true in a measure and running the update before/after fix

Ideally I'd add an automated test but this is likely going to take me 2 hours which I don't have

![image](https://github.com/NREL/OpenStudio/assets/5479063/15c3e216-9833-43cf-b392-3144e1cdfeb4)


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
