### PR TITLE
Fix #5164 - Unless --show-stdout, do not print any ExpandObjects / EnergyPlus messages

### DIFF
--- a/src/utilities/xml/XMLValidator.cpp
+++ b/src/utilities/xml/XMLValidator.cpp
@@ -140,7 +140,7 @@ openstudio::path XMLValidator::schematronToXslt(const openstudio::path& schemaPa
   saveXmlDocToFile(xsltPath, compiled);
 
   xmlFreeDoc(compiled);
-  LOG(Info, "Saved transformed XSLT Stylesheet at '" << toString(xsltPath) << "'.");
+  LOG(Trace, "Saved transformed XSLT Stylesheet at '" << toString(xsltPath) << "'.");
 
   return xsltPath;
 }
@@ -166,13 +166,13 @@ XMLValidator::XMLValidator(const openstudio::path& schemaPath) : m_schemaPath(op
 
   if (schemaPath.extension() == ".xsd") {
     m_validatorType = XMLValidatorType::XSD;
-    logAndStore(Info, "Treating schema as a regular XSD");
+    logAndStore(Trace, "Treating schema as a regular XSD");
   } else if (schemaPath.extension() == ".xslt") {
     m_validatorType = XMLValidatorType::XSLTSchematron;
-    logAndStore(Info, "Treating schema as a XLST StyleSheet that derives from a Schematron.");
+    logAndStore(Trace, "Treating schema as a XLST StyleSheet that derives from a Schematron.");
   } else if ((schemaPath.extension() == ".xml") || (schemaPath.extension() == ".sct")) {
     m_validatorType = XMLValidatorType::Schematron;
-    logAndStore(Info, "Treating schema as a Schematron, converting to an XSLT StyleSheet.");
+    logAndStore(Trace, "Treating schema as a Schematron, converting to an XSLT StyleSheet.");
     // Let's use a temporary directory for this, so we avoid having two instances trying to write to the same file and we avoid issues where the
     // directory is write protected.
     m_tempDir = openstudio::filesystem::create_temporary_directory("xmlvalidation");
@@ -181,7 +181,7 @@ XMLValidator::XMLValidator(const openstudio::path& schemaPath) : m_schemaPath(op
                                 toString(schemaPath)));
     }
     m_schemaPath = schematronToXslt(m_schemaPath, m_tempDir.get());
-    logAndStore(Info, fmt::format("Transformed Schematron to an XSLT Stylesheet and saved it at {}.", toString(m_schemaPath)));
+    logAndStore(Trace, fmt::format("Transformed Schematron to an XSLT Stylesheet and saved it at {}.", toString(m_schemaPath)));
   } else {
     std::string logMessage = fmt::format("Schema path extension '{}' not supported.", toString(schemaPath.extension()));
     m_logMessages.emplace_back(Fatal, "openstudio.XMLValidator", logMessage);
@@ -193,7 +193,7 @@ XMLValidator::~XMLValidator() {
   if (m_tempDir) {
     try {
       const auto count = openstudio::filesystem::remove_all(m_tempDir.get());
-      logAndStore(Debug, fmt::format("Removed temporary directory with {} files", count));
+      logAndStore(Trace, fmt::format("Removed temporary directory with {} files", count));
     } catch (const std::exception& e) {
       logAndStore(Warn, fmt::format("Error removing temporary directory at {}, Description: {}", toString(m_tempDir.get()), e.what()));
     }

--- a/src/workflow/RunEnergyPlus.cpp
+++ b/src/workflow/RunEnergyPlus.cpp
@@ -259,11 +259,16 @@ void OSWorkflow::runEnergyPlus() {
         const openstudio::energyplus::ErrorFile errFile(errPath);
         std::string status = errFile.completedSuccessfully() ? "Completed Successfully" : "Failed";
         if (m_show_stdout) {
-          fmt::print("RunEnergyPlus: {} with ", status);
-          fmt::print(fmt::fg(fmt::color::red), "{} Fatal Errors, ", errFile.fatalErrors().size());
-          fmt::print(fmt::fg(fmt::color::orange), "{} Severe Errors, ", errFile.severeErrors().size());
-          fmt::print(fmt::fg(fmt::color::yellow), "{} Warnings.", errFile.warnings().size());
-          fmt::print("\n");
+          if (m_style_stdout) {
+            fmt::print("RunEnergyPlus: {} with ", status);
+            fmt::print(fmt::fg(fmt::color::red), "{} Fatal Errors, ", errFile.fatalErrors().size());
+            fmt::print(fmt::fg(fmt::color::orange), "{} Severe Errors, ", errFile.severeErrors().size());
+            fmt::print(fmt::fg(fmt::color::yellow), "{} Warnings.", errFile.warnings().size());
+            fmt::print("\n");
+          } else {
+            fmt::print("RunEnergyPlus: {} with {} Fatal Errors, {} Severe Errors, {} Warnings.\n", status, errFile.fatalErrors().size(),
+                       errFile.severeErrors().size(), errFile.warnings().size());
+          }
         }
         if (!errFile.completedSuccessfully()) {
           throw std::runtime_error("EnergyPlus Terminated with a Fatal Error. Check eplusout.err log.");


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #5164


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
