### PR TITLE
Fix #5133 - Conversion to/from pathlib.Path in python bindings now rejects openstudio.Path

### DIFF
--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -21,7 +21,8 @@ def test_path():
     """Assert you can load a model with a str or a pathlib.Path without throwing."""
     assert openstudio.model.Model.load("wrong.osm").empty()
     assert openstudio.model.Model.load(Path("wrong.osm")).empty()
-
+    # And we still support toPath
+    assert openstudio.model.Model.load(openstudio.toPath("wrong.osm")).empty()
 
 def test_json():
     """We can return jsoncpp objects to a native python dict."""

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -341,7 +341,7 @@ namespace openstudio {
     %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") path {
       bool stringOrPathlibType = PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
-      if (stringOrPathlibType){
+      if (!stringOrPathlibType){
         void *vptr = 0;
         int res = SWIG_ConvertPtr($input, &vptr, $&1_descriptor, 0);
         pathType = (SWIG_IsOK(res) && (vptr != 0));
@@ -397,7 +397,7 @@ namespace openstudio {
     %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") const path& {
       bool stringOrPathlibType = PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
-      if (stringOrPathlibType) {
+      if (!stringOrPathlibType) {
         void *vptr = 0;
         int res = SWIG_ConvertPtr($input, &vptr, $1_descriptor, 0);
         pathType = (SWIG_IsOK(res) && (vptr != 0));

--- a/src/utilities/core/Path.i
+++ b/src/utilities/core/Path.i
@@ -312,7 +312,7 @@ namespace openstudio {
         }
     }
 
-    %typemap(in, fragment="SWIG_openstudio_path") (path) {
+    %typemap(in, fragment="SWIG_openstudio_path") path {
 
       // check if input is a path already
       void *vptr = 0;
@@ -326,12 +326,7 @@ namespace openstudio {
           SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path");
         }
       } else if(PyUnicode_Check($input)) {
-        // Python 3
         std::string s(PyUnicode_AsUTF8($input));
-        $1 = openstudio::toPath(s);
-      } else if(PyString_Check($input)) {
-        // Python2, PyString_Check does PyBytes_Check
-        std::string s(PyString_AsString($input));
         $1 = openstudio::toPath(s);
       } else if (isPathInstance($input)) {
         PyObject * str_obj = PyObject_Str($input);   // New reference
@@ -343,8 +338,8 @@ namespace openstudio {
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") (path) {
-      bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") path {
+      bool stringOrPathlibType = PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
       if (stringOrPathlibType){
         void *vptr = 0;
@@ -372,7 +367,7 @@ namespace openstudio {
     %apply path { const path };
 
     // handle const path& separately
-    %typemap(in, fragment="SWIG_openstudio_path") (const path&) {
+    %typemap(in, fragment="SWIG_openstudio_path") const path& {
       $1=NULL;
 
       // check if input is a path already
@@ -387,12 +382,7 @@ namespace openstudio {
           SWIG_exception_fail(SWIG_ValueError, "Invalid null reference openstudio::path const &");
         }
       } else if(PyUnicode_Check($input)) {
-        // Python 3
         std::string s(PyUnicode_AsUTF8($input));
-        $1 = new openstudio::path(openstudio::toPath(s));
-      } else if(PyString_Check($input)) {
-        // Python2, PyString_Check does PyBytes_Check
-        std::string s(PyString_AsString($input));
         $1 = new openstudio::path(openstudio::toPath(s));
       } else if (isPathInstance($input)) {
         PyObject * str_obj = PyObject_Str($input);   // New reference
@@ -404,8 +394,8 @@ namespace openstudio {
       }
     }
 
-    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") (const path&) {
-      bool stringOrPathlibType = PyString_Check($input) || PyUnicode_Check($input) || isPathInstance($input);
+    %typemap(typecheck, precedence=SWIG_TYPECHECK_STRING, fragment="SWIG_openstudio_path") const path& {
+      bool stringOrPathlibType = PyUnicode_Check($input) || isPathInstance($input);
       bool pathType = false;
       if (stringOrPathlibType) {
         void *vptr = 0;
@@ -415,8 +405,8 @@ namespace openstudio {
       $1 = (stringOrPathlibType || pathType) ? 1 : 0;
     }
 
-    %typemap(freearg) (const path&) {
-      if ($1){
+    %typemap(freearg) const path& {
+      if ($1) {
         delete $1;
       }
     }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #5133 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
