### PR TITLE
Swig `T boost::optional<T>::value_or(T default_value)`

### DIFF
--- a/python/test/test_usability.py
+++ b/python/test/test_usability.py
@@ -8,6 +8,10 @@ def test_optional_not_initialized():
     assert not d.is_initialized()
     assert d.empty()
     assert not bool(d)
+    assert isinstance(d.value_or(20.0), float)
+    assert d.value_or(20.0) == 20.0
+    assert isinstance(d.value_or(20), float)
+    assert d.value_or(20) == 20.0
 
 
 def test_optionalinitialized():
@@ -15,6 +19,10 @@ def test_optionalinitialized():
     assert d.is_initialized()
     assert not d.empty()
     assert bool(d)
+    assert isinstance(d.value_or(10.0), float)
+    assert d.value_or(10.0) == 10.0
+    assert isinstance(d.value_or(10), float)
+    assert d.value_or(10) == 10.0
 
 
 def test_path():
@@ -23,6 +31,7 @@ def test_path():
     assert openstudio.model.Model.load(Path("wrong.osm")).empty()
     # And we still support toPath
     assert openstudio.model.Model.load(openstudio.toPath("wrong.osm")).empty()
+
 
 def test_json():
     """We can return jsoncpp objects to a native python dict."""

--- a/ruby/test/Optional_Test.rb
+++ b/ruby/test/Optional_Test.rb
@@ -36,6 +36,10 @@ class Optional_Test < Minitest::Test
     else
       assert(true)
     end
+    assert(optional.value_or(20.0).is_a?(Float))
+    assert_equal(20.0, optional.value_or(20.0))
+    assert(optional.value_or(20).is_a?(Float))
+    assert_equal(20.0, optional.value_or(20))
 
     # would like to use this syntax to test if set
     optional = OpenStudio::OptionalDouble.new
@@ -51,12 +55,10 @@ class Optional_Test < Minitest::Test
     optional.set(10.0)
     assert(optional.is_initialized)
     assert_equal(10.0, optional.get)
-
-
-
+    assert(optional.value_or(20.0).is_a?(Float))
+    assert_equal(10.0, optional.value_or(20.0))
+    assert(optional.value_or(20).is_a?(Float))
+    assert_equal(10.0, optional.value_or(20))
   end
 
-
 end
-
-

--- a/src/utilities/core/CommonImport.i
+++ b/src/utilities/core/CommonImport.i
@@ -106,9 +106,13 @@ namespace boost {
     optional(const boost::optional<T>& t);
     void reset();
     operator bool() const;
-    //bool operator!() const; // SWIG ignores this
-//    T get();
-//    T* operator->();
+
+
+    // bool operator!() const; // SWIG ignores this
+    // T get();
+    // T* operator->();
+    // T value_or(T& default_value);
+
     T operator*();
     bool is_initialized() const;
 
@@ -131,9 +135,19 @@ namespace boost {
           throw std::runtime_error("Optional not initialized");
         }
       }
+
       void set(const T &t) {
         (*self) = t;
       }
+
+      T value_or(const T& default_value) {
+        if (self->is_initialized()) {
+          return self->get();
+        } else {
+          return default_value;
+        }
+      }
+
     }
   };
 


### PR DESCRIPTION
Pull request overview
---------------------

Swig `T boost::optional<T>::value_or(T default_value)`. I think the semantics is nice.


This allows you to write something like

```ruby
def get_optional(is_initialized)
  is_initialized ? OpenStudio::OptionalDouble.new(10.0) : OpenStudio::OptionalDouble.new()
end

val = get_optional(true).value_or(20.0)
raise unless val == 10.0
val = get_optional(false).value_or(20.0)
raise unless val == 20.0
```

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [x] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
