### PR TITLE
Fix #5181 - when using --bundle in the CLI, use Embedded native gems when they are present and version compatible

### DIFF
--- a/src/cli/test/bundle_native_embedded/Gemfile
+++ b/src/cli/test/bundle_native_embedded/Gemfile
@@ -1,0 +1,7 @@
+source 'http://rubygems.org'
+
+# Rubocop requires 'json' '~> 2.3'
+# It also indirectly, via parser, require 'racc'
+gem 'rubocop', '1.63.4'
+# Our CLI has json 2.6.3, which satisfies this version
+# racc is also in our CLI

--- a/src/cli/test/bundle_native_embedded/test.rb
+++ b/src/cli/test/bundle_native_embedded/test.rb
@@ -1,0 +1,14 @@
+require 'rubygems'
+
+def local_gems
+   Gem::Specification.sort_by{ |g| [g.name.downcase, g.version] }.group_by{ |g| g.name }
+end
+
+# list installed gems
+puts local_gems.map{ |name, specs|
+  [name, specs.map{ |spec| spec.version.to_s }.join(',')].join(' ')
+}
+# test a gem that required native extensions
+require 'json'
+puts JSON::VERSION
+raise "json version does not match" unless JSON::VERSION == '2.6.3'

--- a/src/cli/test/test_bundle.rb
+++ b/src/cli/test/test_bundle.rb
@@ -52,7 +52,7 @@ class Bundle_Test < Minitest::Test
     if /mingw/.match(RUBY_PLATFORM) || /mswin/.match(RUBY_PLATFORM)
       skip("Native gems not supported on Windows")
     else
-	  skip("Native gems not supported on Unix or Mac")
+      skip("Native gems not supported on Unix or Mac")
     end
 
     rm_if_exist('Gemfile.lock')
@@ -68,6 +68,25 @@ class Bundle_Test < Minitest::Test
 
   ensure
     Dir.chdir(original_dir)
+  end
+
+
+  # Test for #5181 - This adds a bundle dependency on a native gem we DO have it the CLI
+  def test_bundle_native_embedded
+    Dir.chdir(File.join(File.dirname(__FILE__), 'bundle_native_embedded')) do
+
+      rm_if_exist('Gemfile.lock')
+      rm_if_exist('./test_gems')
+      rm_if_exist('./bundle')
+
+      assert(system('bundle install --path ./test_gems'))
+      #assert(system('bundle lock --add_platform ruby'))
+      if /mingw/.match(RUBY_PLATFORM) || /mswin/.match(RUBY_PLATFORM)
+        assert(system('bundle lock --add_platform mswin64'))
+      end
+      assert(system("'#{OpenStudio::getOpenStudioCLI}' --bundle Gemfile --bundle_path './test_gems' --verbose test.rb"))
+
+    end
   end
 
   def test_bundle_no_install


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5181

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
