### PR TITLE
Fix failing tests on develop

### DIFF
--- a/src/model/test/ZoneHVACEquipmentList_GTest.cpp
+++ b/src/model/test/ZoneHVACEquipmentList_GTest.cpp
@@ -172,6 +172,26 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_ModelObject_Is_First)
 
   bb.setName("Baseboard");
   bb_sch.setName(bb.nameString());
+
+  // Because underneath in Workspace m_workspaceObjectMap is a std::unordered_map we have no guarantee of order, so in case it's not good (it IS on
+  // Unix, but not on Windows), we redo the insertion in a different order
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    if (objects.front().iddObject().type() != IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric)) {
+      bb_sch.remove();
+      bb_sch = ScheduleConstant(m);
+      bb_sch.setName("Baseboard");
+    }
+  }
+
+  // Assert this time the order is good
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), objects.front().iddObject().type());
+  }
+
   EXPECT_TRUE(bb.setAvailabilitySchedule(bb_sch));
   EXPECT_EQ(bb.nameString(), bb_sch.nameString());
 
@@ -189,12 +209,6 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_ModelObject_Is_First)
       ASSERT_TRUE(obj_);
       EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
     }
-  }
-
-  {
-    auto objects = m.getObjectsByName(bb.nameString());
-    EXPECT_EQ(2, objects.size());
-    EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), objects.front().iddObject().type());
   }
 
   EXPECT_NO_THROW(bb_delete.remove());
@@ -225,11 +239,28 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First) {
   ZoneHVACBaseboardConvectiveElectric bb_delete(m);
 
   ZoneHVACBaseboardConvectiveElectric bb(m);
-
   ScheduleConstant bb_sch(m);
-
   bb.setName("Baseboard");
   bb_sch.setName(bb.nameString());
+  // Because underneath in Workspace m_workspaceObjectMap is a std::unordered_map we have no guarantee of order, so in case it's not good (it IS on
+  // Unix, but not on Windows), we redo the insertion in a different order
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    if (objects.front().iddObject().type() != IddObjectType(IddObjectType::OS_Schedule_Constant)) {
+      bb.remove();
+      bb = ZoneHVACBaseboardConvectiveElectric(m);
+      bb.setName("Baseboard");
+    }
+  }
+
+  // Assert this time the order is good
+  {
+    auto objects = m.getObjectsByName(bb.nameString());
+    EXPECT_EQ(2, objects.size());
+    EXPECT_EQ(IddObjectType(IddObjectType::OS_Schedule_Constant), objects.front().iddObject().type());
+  }
+
   EXPECT_TRUE(bb.setAvailabilitySchedule(bb_sch));
   EXPECT_EQ(bb.nameString(), bb_sch.nameString());
 
@@ -247,12 +278,6 @@ TEST_F(ModelFixture, ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First) {
       ASSERT_TRUE(obj_);
       EXPECT_EQ(IddObjectType(IddObjectType::OS_ZoneHVAC_Baseboard_Convective_Electric), obj_->iddObject().type());
     }
-  }
-
-  {
-    auto objects = m.getObjectsByName(bb.nameString());
-    EXPECT_EQ(2, objects.size());
-    EXPECT_EQ(IddObjectType(IddObjectType::OS_Schedule_Constant), objects.front().iddObject().type());
   }
 
   EXPECT_NO_THROW(bb_delete.remove());


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix different order of getObjectsByName on windows

Aims to fix

```
	141 - IdfFixture.WorkspaceObject_eraseExtensibleGroups (Failed)
	2733 - ModelFixture.ZoneHVACEquipmentList_RemoveEquipment_ModelObject_Is_First (Failed)
	2734 - ModelFixture.ZoneHVACEquipmentList_RemoveEquipment_Schedule_Is_First (Failed)
```

https://ci.openstudio.net/blue/organizations/jenkins/openstudio-incremental-windows/detail/PR-5191/2/pipeline#step-65-log-684

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
