### PR TITLE
Fix up uninitialized optional in getPastStepValuesForMeasure

### DIFF
--- a/src/measure/OSRunner.cpp
+++ b/src/measure/OSRunner.cpp
@@ -825,10 +825,11 @@ namespace measure {
       // TODO: should we match on any of these three?
       if (istringEqual(measureName, step.measureDirName())) {  // The directory name, eg `IncreaseWallRValue`
         LOG(Trace, "Step matches on measureDirName");
-      } else if (auto s_ = step.name(); istringEqual(measureName, *s_)) {  // An optional, abritrary one
+      } else if (auto s_ = step.name(); s_.is_initialized() && istringEqual(measureName, *s_)) {  // An optional, abritrary one
         LOG(Trace, "Step matches on name");
       } else if (auto s_ = stepResult_->measureName();
-                 istringEqual(measureName, *s_)) {  // The xml one, eg `increase_insulation_r_value_for_exterior_walls_by_percentage`
+                 s_.is_initialized()
+                 && istringEqual(measureName, *s_)) {  // The xml one, eg `increase_insulation_r_value_for_exterior_walls_by_percentage`
         LOG(Trace, "Step matches on Step Result's measureName");
       } else {
         continue;


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5192 (hopefully, bis repetita)

old code works with std::optional, but not boost::optional 1.79.0

cf https://gcc.godbolt.org/z/7Khs774rd

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
