### PR TITLE
Make pip install run only once instead of everytime CMake reconfigures

### DIFF
--- a/CMake/FindEnergyPlus.cmake
+++ b/CMake/FindEnergyPlus.cmake
@@ -81,7 +81,7 @@ foreach(PATH ${ENERGYPLUS_POSSIBLE_PATHS})
     endif()
 
     # we just need to read the first part of this large file
-    file(READ "${ENERGYPLUS_IDD}" IDD_TEXT LIMIT 1000) 
+    file(READ "${ENERGYPLUS_IDD}" IDD_TEXT LIMIT 1000)
     string(REGEX MATCH "!IDD_BUILD [0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]" BUILD_SHA_LINE "${IDD_TEXT}")
     string(REGEX MATCH "[0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z][0-9a-z]" BUILD_SHA "${BUILD_SHA_LINE}")
     set(ENERGYPLUS_GE_8_2_0 TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,7 +689,7 @@ if(UNIX)
     endif()
 
     execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/${ENERGYPLUS_PATH}")
-
+    file(REMOVE "${PROJECT_BINARY_DIR}/python/engine/pip_install_done.stamp")
   endif()
 
 elseif(WIN32)
@@ -715,7 +715,7 @@ elseif(WIN32)
          EXPECTED_MD5 ${ENERGYPLUS_EXPECTED_HASH})
 
     execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}/${ENERGYPLUS_PATH}")
-
+    file(REMOVE "${PROJECT_BINARY_DIR}/python/engine/pip_install_done.stamp")
   endif()
 
 endif()

--- a/python/SetupPython.cmake
+++ b/python/SetupPython.cmake
@@ -35,12 +35,6 @@ else()
   endif()
 endif()
 
-if(BUILD_CLI)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E env --unset=PIP_REQUIRE_VIRTUALENV ${Python_EXECUTABLE}
-    -m pip install --target=${ENERGYPLUS_DIR}/python_lib --upgrade -r ${PROJECT_SOURCE_DIR}/python/requirements.txt
-  )
-endif()
-
 get_filename_component(Python_PROGRAM_NAME ${Python_EXECUTABLE} NAME)
 
 get_filename_component(RESOLVED_PYTHON_LIBRARY "${Python_LIBRARIES}" REALPATH)

--- a/python/engine/CMakeLists.txt
+++ b/python/engine/CMakeLists.txt
@@ -45,6 +45,27 @@ target_compile_options(pythonengine PRIVATE
 
 target_compile_definitions(pythonengine PRIVATE openstudio_scriptengine_EXPORTS SHARED_OS_LIBS)
 
+# Add a command to pip install the requirements into the E+ folder and generate a stamp file
+# Make it depend on the requirements.txt, so that it reruns when it changes
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pip_install_done.stamp"
+  COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/pip_install_done.stamp"
+  COMMAND ${CMAKE_COMMAND} -E env --unset=PIP_REQUIRE_VIRTUALENV ${Python_EXECUTABLE}
+    -m pip install --target=${ENERGYPLUS_DIR}/python_lib --upgrade -r ${PROJECT_SOURCE_DIR}/python/requirements.txt
+  DEPENDS ${PROJECT_SOURCE_DIR}/python/requirements.txt
+)
+
+# And a target that calls the above command. It is NOT called by default
+add_custom_target(pip_install
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pip_install_done.stamp"
+)
+
+if(BUILD_CLI)
+  # When you build CLI, we want the pip_install to run, so add it as a dependency
+  # which will ensure it's run (beforehand, at **build** not configure time)
+  add_dependencies(pythonengine pip_install)
+endif()
+
 if(BUILD_TESTING)
   set(pythonengine_test_depends
     openstudio_scriptengine


### PR DESCRIPTION
Pull request overview
---------------------

Make pip install run only once. This takes 15s to a minute (depending on pip cache and internet connection) and would run everytime cmake reconfigures, which annoyed the crap out of me.

@kbenne please review.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
