### PR TITLE
Fix #5274 - workflow should not remove contents from zip because of size limit

### DIFF
--- a/src/workflow/Util.cpp
+++ b/src/workflow/Util.cpp
@@ -266,21 +266,11 @@ void zipDirectory(const openstudio::path& dirPath, const openstudio::path& zipFi
           continue;
         }
 
-        auto dirSize = directorySize(dirEntryPath);
-        if (dirSize >= 15'000'000) {
-          LOG_FREE(Info, "openstudio.workflow.Util.zipDirectory", "Skipping too large directory " << dirEntryPath);
-          continue;
-        }
-
         // TODO: do I need a helper like the workflow-gem was doing with add_directory_to_zip?
         zf.addDirectory(dirEntryPath, fs::relative(dirEntryPath, dirPath));
       } else {
         auto ext = dirEntryPath.extension().string();
         if ((ext.find(".zip") != std::string::npos) || (ext.find(".rb") != std::string::npos)) {
-          continue;
-        }
-
-        if ((ext != ".osm") && (ext != ".idf") && (fs::file_size(dirEntryPath) > 100'000'000)) {
           continue;
         }
         zf.addFile(dirEntryPath, fs::relative(dirEntryPath, dirPath));

--- a/src/workflow/Util.cpp
+++ b/src/workflow/Util.cpp
@@ -246,17 +246,6 @@ void zipDirectory(const openstudio::path& dirPath, const openstudio::path& zipFi
 
     static constexpr std::array<std::string_view, 3> filterOutDirNames{"seed", "measures", "weather"};
 
-    auto directorySize = [](const openstudio::path& dirPath) {
-      uintmax_t dirSize = 0;
-      for (const auto& dirEnt : fs::recursive_directory_iterator{dirPath}) {
-        const auto& dirEntryPath = dirEnt.path();
-        if (fs::is_regular_file(dirEntryPath)) {
-          dirSize += fs::file_size(dirEntryPath);
-        }
-      }
-      return dirSize;
-    };
-
     for (const auto& dirEnt : fs::directory_iterator{dirPath}) {
       const auto& dirEntryPath = dirEnt.path();
       if (fs::is_directory(dirEntryPath)) {


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5274 

We no longer want to limit file sizes that go into datapoint zip generated when a workflow is run.

### Pull Request Author

@DavidGoldwasser 

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes

**Labels:**

 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
