### PR TITLE
Relax Alfalfa Point ID Requirements

### DIFF
--- a/src/alfalfa/AlfalfaJSON.cpp
+++ b/src/alfalfa/AlfalfaJSON.cpp
@@ -83,9 +83,10 @@ namespace alfalfa {
 
     Json::Value AlfalfaJSON_Impl::toJSON() const {
       Json::Value root;
-      for (const auto& point : m_points) {
+      int i = 0;
+      for (const auto& point : points()) {
         // No guard here as the toJSON call will throw an exception if the id does not exist.
-        root[point.id().get()] = point.toJSON();
+        root[i++] = point.toJSON();
       }
       return root;
     }

--- a/src/alfalfa/AlfalfaJSON.cpp
+++ b/src/alfalfa/AlfalfaJSON.cpp
@@ -83,8 +83,7 @@ namespace alfalfa {
 
     Json::Value AlfalfaJSON_Impl::toJSON() const {
       Json::Value root;
-      int i = 0;
-      for (const auto& point : points()) {
+      for (Json::ArrayIndex i = 0; const auto& point : points()) {
         // No guard here as the toJSON call will throw an exception if the id does not exist.
         root[i++] = point.toJSON();
       }

--- a/src/alfalfa/AlfalfaPoint.cpp
+++ b/src/alfalfa/AlfalfaPoint.cpp
@@ -92,9 +92,6 @@ namespace alfalfa {
         throw std::runtime_error("Display name must have non-zero length");
       }
       m_display_name = display_name;
-      if (m_id.empty()) {
-        setId(toIdString(display_name));
-      }
     }
 
     std::string AlfalfaPoint_Impl::displayName() const {

--- a/src/alfalfa/AlfalfaPoint.cpp
+++ b/src/alfalfa/AlfalfaPoint.cpp
@@ -11,8 +11,6 @@
 namespace openstudio {
 namespace alfalfa {
 
-  static constexpr std::string_view ID_VALID_CHARS_MSG = "IDs can only contain letters, numbers, and the following special characters _-[]():";
-
   namespace detail {
 
     AlfalfaPoint_Impl::AlfalfaPoint_Impl(const std::string& display_name) {
@@ -22,11 +20,7 @@ namespace alfalfa {
     Json::Value AlfalfaPoint_Impl::toJSON() const {
       Json::Value point;
 
-      if (auto id_ = id()) {
-        point["id"] = *id_;
-      } else {
-        throw std::runtime_error(fmt::format("Point requires a valid ID for export. {}", ID_VALID_CHARS_MSG));
-      }
+      point["id"] = id();
       point["name"] = displayName();
       if (auto input_ = input()) {
         point["input"]["type"] = input_->typeName();
@@ -80,24 +74,17 @@ namespace alfalfa {
     }
 
     void AlfalfaPoint_Impl::setId(const std::string& id) {
-      if (isValidId(id)) {
-        m_id = id;
-      } else {
-        throw std::runtime_error(ID_VALID_CHARS_MSG.data());
+      if (id.empty()) {
+        throw std::runtime_error("Id must have non-zero length");
       }
+      m_id = toIdString(id);
     }
 
-    boost::optional<std::string> AlfalfaPoint_Impl::id() const {
-      boost::optional<std::string> result = m_id;
-      if (!result.is_initialized()) {
-        std::string id = toIdString(displayName());
-        if (isValidId(id)) {
-          result = id;
-        } else {
-          LOG(Warn, fmt::format("Display name '{}' does not produce a valid point ID. Manually set a valid ID or export will fail.", displayName()));
-        }
+    std::string AlfalfaPoint_Impl::id() const {
+      if (m_id.empty()) {
+        return toIdString(displayName());
       }
-      return result;
+      return m_id;
     }
 
     void AlfalfaPoint_Impl::setDisplayName(const std::string& display_name) {
@@ -105,11 +92,8 @@ namespace alfalfa {
         throw std::runtime_error("Display name must have non-zero length");
       }
       m_display_name = display_name;
-      if (!m_id.is_initialized()) {
-        const std::string id = toIdString(display_name);
-        if (!isValidId(id)) {
-          LOG(Warn, fmt::format("Display name '{}' does not produce a valid point ID. Manually set a valid ID or export will fail.", display_name));
-        }
+      if (m_id.empty()) {
+        setId(toIdString(display_name));
       }
     }
 
@@ -125,16 +109,10 @@ namespace alfalfa {
       return m_optional;
     }
 
-    bool AlfalfaPoint_Impl::isValidId(const std::string& id) {
-      return !id.empty() && boost::regex_match(id, boost::regex(R"(^[A-Za-z0-9_\-\[\]:()]*$)"));
-    }
-
     std::string AlfalfaPoint_Impl::toIdString(const std::string& str) {
       return boost::regex_replace(str, boost::regex(" "), "_");
     }
   }  // namespace detail
-
-  // AlfalfaPoint::AlfalfaPoint(const AlfalfaPoint& point) : m_impl(point.m_impl) {}
 
   AlfalfaPoint::AlfalfaPoint(const std::string& display_name) : m_impl(std::make_shared<detail::AlfalfaPoint_Impl>(display_name)) {}
 
@@ -162,7 +140,7 @@ namespace alfalfa {
     return m_impl->units();
   }
 
-  boost::optional<std::string> AlfalfaPoint::id() const {
+  std::string AlfalfaPoint::id() const {
     return m_impl->id();
   }
 

--- a/src/alfalfa/AlfalfaPoint.cpp
+++ b/src/alfalfa/AlfalfaPoint.cpp
@@ -109,7 +109,7 @@ namespace alfalfa {
 
     std::string AlfalfaPoint_Impl::toIdString(const std::string& str) {
       std::string id_string = str;
-      std::replace( id_string.begin(), id_string.end(), ' ', '_');
+      std::replace(id_string.begin(), id_string.end(), ' ', '_');
       return id_string;
     }
   }  // namespace detail

--- a/src/alfalfa/AlfalfaPoint.cpp
+++ b/src/alfalfa/AlfalfaPoint.cpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <string_view>
+#include <algorithm>
 
 namespace openstudio {
 namespace alfalfa {
@@ -107,7 +108,9 @@ namespace alfalfa {
     }
 
     std::string AlfalfaPoint_Impl::toIdString(const std::string& str) {
-      return boost::regex_replace(str, boost::regex(" "), "_");
+      std::string id_string = str;
+      std::replace( id_string.begin(), id_string.end(), ' ', '_');
+      return id_string;
     }
   }  // namespace detail
 

--- a/src/alfalfa/AlfalfaPoint.hpp
+++ b/src/alfalfa/AlfalfaPoint.hpp
@@ -69,7 +69,7 @@ namespace alfalfa {
     /**
      * Get id of point. By default this will be a version of the display name with spaces removed.
      */
-    boost::optional<std::string> id() const;
+    std::string id() const;
 
     /**
      * Set id of point. This is the component which will uniquely identify the point in the API.

--- a/src/alfalfa/AlfalfaPoint_Impl.hpp
+++ b/src/alfalfa/AlfalfaPoint_Impl.hpp
@@ -32,7 +32,7 @@ namespace alfalfa {
 
       boost::optional<std::string> units() const;
 
-      boost::optional<std::string> id() const;
+      std::string id() const;
 
       void setId(const std::string& id);
 
@@ -47,13 +47,11 @@ namespace alfalfa {
      private:
       static std::string toIdString(const std::string& str);
 
-      static bool isValidId(const std::string& id);
-
       boost::optional<AlfalfaComponent> m_input;
       boost::optional<AlfalfaComponent> m_output;
       std::string m_display_name;
       boost::optional<std::string> m_units;
-      boost::optional<std::string> m_id;
+      std::string m_id;
       bool m_optional = true;
 
       // configure logging

--- a/src/alfalfa/test/AlfalfaJSON_GTest.cpp
+++ b/src/alfalfa/test/AlfalfaJSON_GTest.cpp
@@ -195,8 +195,7 @@ TEST(AlfalfaJSON, json_serialization) {
   const bool parsing_success = Json::parseFromStream(r_builder, ifs, &root, &formatted_errors);
   EXPECT_TRUE(parsing_success);
   EXPECT_EQ(alfalfa.toJSON(), root);
-  int i = 0;
-  for (const auto& point : alfalfa.points()) {
+  for (Json::ArrayIndex i = 0; const auto& point : alfalfa.points()) {
     EXPECT_EQ(root[i++], point.toJSON());
   }
 }


### PR DESCRIPTION
Pull request overview
---------------------
After testing the new interface in the real world I found the requirements on id characters to be too onerous. This PR removes all requirements outside of non emptiness.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
