### PR TITLE
Fix Ruby/Python SWIG API when type is AlfalfaComponent

### DIFF
--- a/resources/Examples/compact_osw/measures/AlfalfaEPlusPython/measure.py
+++ b/resources/Examples/compact_osw/measures/AlfalfaEPlusPython/measure.py
@@ -69,6 +69,17 @@ class AlfalfaEPlusPython(openstudio.measure.EnergyPlusMeasure):
         meter_object = openstudio.IdfObject.load("Output:Meter, Electricity:Facility;").get()
         alfalfa.exposeFromObject(meter_object, "Electricity Meter IDF:Eplus:Python")
 
+        # Test Composite Point
+        meter_component = openstudio.alfalfa.AlfalfaMeter("Electricity:Facility")
+        actuator_component = openstudio.alfalfa.AlfalfaActuator("component_name", "component_type", "control_type")
+        composite_point = openstudio.alfalfa.AlfalfaPoint("Compound Point:Ruby")
+        composite_point.setOutput(meter_component)
+        composite_point.setInput(actuator_component)
+        alfalfa.exposePoint(composite_point)
+
+        # Test Expose from Component
+        alfalfa.exposeFromComponent(actuator_component, "From Component Actuator")
+
         # Test Output Variables
         alfalfa.exposeOutputVariable("EMS", "my_var", "Output Variable String:EPlus:Python")
 

--- a/resources/Examples/compact_osw/measures/AlfalfaEPlusRuby/measure.rb
+++ b/resources/Examples/compact_osw/measures/AlfalfaEPlusRuby/measure.rb
@@ -45,6 +45,17 @@ class AlfalfaEPlusRuby < OpenStudio::Measure::EnergyPlusMeasure
     meter_object = OpenStudio::IdfObject.load("Output:Meter, Electricity:Facility;").get()
     alfalfa.exposeFromObject(meter_object, "Electricity Meter IDF:Eplus:Ruby")
 
+    # Test Composite Point
+    meter_component = OpenStudio::Alfalfa::AlfalfaMeter.new("Electricity:Facility")
+    actuator_component = OpenStudio::Alfalfa::AlfalfaActuator.new("component_name", "component_type", "control_type")
+    composite_point = OpenStudio::Alfalfa::AlfalfaPoint.new("Compound Point:Ruby")
+    composite_point.setOutput(meter_component)
+    composite_point.setInput(actuator_component)
+    alfalfa.exposePoint(composite_point)
+
+    # Test Expose from Component
+    alfalfa.exposeFromComponent(actuator_component, "From Component Actuator")
+
     # Test Output Variables
     alfalfa.exposeOutputVariable("EMS", "my_var", "Output Variable String:EPlus:Ruby")
 
@@ -61,7 +72,7 @@ class AlfalfaEPlusRuby < OpenStudio::Measure::EnergyPlusMeasure
     alfalfa.exposeFromObject(global_variable_object, "Global Variable IDF:EPlus:Ruby")
 
     # Test Actuators
-    alfalfa.exposeActuator("component_name", "componen_type", "control_type", "Actuator String:EPlus:Ruby")
+    alfalfa.exposeActuator("component_name", "component_type", "control_type", "Actuator String:EPlus:Ruby")
 
     actuator_object = OpenStudio::IdfObject.load("EnergyManagementSystem:Actuator,MyActuator,component_name,component_type,control_type;").get()
     alfalfa.exposeFromObject(actuator_object, "Actuator IDF:EPlus:Ruby")

--- a/src/alfalfa/Alfalfa.i
+++ b/src/alfalfa/Alfalfa.i
@@ -57,4 +57,26 @@
 %template(OptionalAlfalfaPoint) boost::optional<openstudio::alfalfa::AlfalfaPoint>;
 %template(OptionalAlfalfaComponent) boost::optional<openstudio::alfalfa::AlfalfaComponent>;
 
+namespace openstudio::alfalfa {
+  %extend AlfalfaPoint {
+    void setOutput(const AlfalfaComponentBase& component) {
+      AlfalfaComponent alfalfa_component(component);
+      $self->setOutput(alfalfa_component);
+    }
+
+    void setInput(const AlfalfaComponentBase& component) {
+      AlfalfaComponent alfalfa_component(component);
+      $self->setInput(alfalfa_component);
+    }
+  }
+
+  %extend AlfalfaJSON {
+    boost::optional<AlfalfaPoint> AlfalfaJSON::exposeFromComponent(const AlfalfaComponentBase& component, const std::string& display_name = std::string()) {
+      AlfalfaComponent alfalfa_component(component);
+      return $self->exposeFromComponent(alfalfa_component, display_name);
+    }
+  }
+}
+
+
 #endif

--- a/src/alfalfa/AlfalfaComponent.hpp
+++ b/src/alfalfa/AlfalfaComponent.hpp
@@ -12,8 +12,7 @@ namespace alfalfa {
   class ALFALFA_API AlfalfaComponent
   {
    public:
-    template <typename T, std::enable_if_t<std::is_base_of<AlfalfaComponentBase, T>::value, bool> = true>
-    AlfalfaComponent(T component) : m_component(std::make_unique<T>(std::move(component))) {}
+    AlfalfaComponent(const AlfalfaComponentBase& component) : m_component(component.clone()) {}
 
     AlfalfaComponent(const AlfalfaComponent& other) : m_component(other.m_component->clone()) {}
 

--- a/src/alfalfa/test/AlfalfaJSON_GTest.cpp
+++ b/src/alfalfa/test/AlfalfaJSON_GTest.cpp
@@ -391,6 +391,15 @@ TEST(AlfalfaJSON, expose_meter) {
   EXPECT_FALSE(str_point.input().is_initialized());
   EXPECT_TRUE(str_point.output().is_initialized());
   EXPECT_EQ(str_point.displayName(), display_name);
+
+  // Test Other Point Construction Methods
+  const AlfalfaPoint component_point = alfalfa.exposeFromComponent(str_component, display_name).get();
+  AlfalfaPoint custom_point(display_name);
+  EXPECT_THROW({ custom_point.setInput(str_component); }, std::runtime_error);
+  custom_point.setOutput(str_component);
+
+  EXPECT_EQ(str_point, custom_point);
+  EXPECT_EQ(str_point, component_point);
 }
 
 TEST(AlfalfaJSON, expose_output_variable) {
@@ -461,6 +470,15 @@ TEST(AlfalfaJSON, expose_output_variable) {
   EXPECT_TRUE(str_point.output().is_initialized());
   EXPECT_FALSE(str_point.input().is_initialized());
   EXPECT_EQ(str_point.displayName(), display_name);
+
+  // Test Other Point Construction Methods
+  const AlfalfaPoint component_point = alfalfa.exposeFromComponent(str_component, display_name).get();
+  AlfalfaPoint custom_point(display_name);
+  EXPECT_THROW({ custom_point.setInput(str_component); }, std::runtime_error);
+  custom_point.setOutput(str_component);
+
+  EXPECT_EQ(str_point, custom_point);
+  EXPECT_EQ(str_point, component_point);
 }
 
 TEST(AlfalfaJSON, expose_global_variable) {
@@ -501,6 +519,15 @@ TEST(AlfalfaJSON, expose_global_variable) {
   EXPECT_TRUE(str_point.input().is_initialized());
   EXPECT_TRUE(str_point.output().is_initialized());
   EXPECT_EQ(str_point.displayName(), display_name);
+
+  // Test Other Point Construction Methods
+  const AlfalfaPoint component_point = alfalfa.exposeFromComponent(str_component, display_name).get();
+  AlfalfaPoint custom_point(display_name);
+  custom_point.setInput(str_component);
+  custom_point.setOutput(str_component);
+
+  EXPECT_EQ(str_point, custom_point);
+  EXPECT_EQ(str_point, component_point);
 }
 
 TEST(AlfalfaJSON, expose_actuator) {
@@ -550,4 +577,13 @@ TEST(AlfalfaJSON, expose_actuator) {
   EXPECT_TRUE(str_point.input().is_initialized());
   EXPECT_TRUE(str_point.output().is_initialized());
   EXPECT_EQ(str_point.displayName(), display_name);
+
+  // Test Other Point Construction Methods
+  const AlfalfaPoint component_point = alfalfa.exposeFromComponent(str_component, display_name).get();
+  AlfalfaPoint custom_point(display_name);
+  custom_point.setInput(str_component);
+  custom_point.setOutput(str_component);
+
+  EXPECT_EQ(str_point, custom_point);
+  EXPECT_EQ(str_point, component_point);
 }


### PR DESCRIPTION
Pull request overview
---------------------

Add additional function in SWIG for `AlfalfaJSON::exposeFromComponent`, `AlfalfaPoint::setInput` and `AlfalfaPoint::setOutput` which provides a method which takes `const AlfalfaComponentBase&` instead of `AlfalfaComponent`. This is required because it seems like SWIG cannot understand the converting constructor.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
