### PR TITLE
Fix #5315 - OpenStudio CLI unable to require uuid in OpenStudio 3.9 (thereby breaking dependencies like openstudio-extension)

### DIFF
--- a/python/module/openstudio.py
+++ b/python/module/openstudio.py
@@ -50,7 +50,10 @@ else:
         # When we're using system python to load the **installed** C:\openstudio-X.Y-Z\Python stuff (not PyPi package)
         # This allows finding openstudiolib.dll and the msvc ones in the bin/ folder while we're in the Python/ folder
         # Otherwise you'd have to manually copy these DLLs from bin/ to Python/
-        os.add_dll_directory(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'bin')))
+        bin_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'bin'))
+        if os.path.isdir(bin_dir):
+            os.add_dll_directory(bin_dir)
+
     import openstudioairflow as airflow
     import openstudioenergyplus as energyplus
     import openstudioepjson as epjson

--- a/ruby/engine/embedded_help.rb
+++ b/ruby/engine/embedded_help.rb
@@ -3,6 +3,8 @@
 #  See also https://openstudio.net/license
 ########################################################################################################################
 
+require 'stringio'
+
 module EmbeddedScripting
   @@fileNames = EmbeddedScripting::allFileNamesAsString.split(';')
 
@@ -55,6 +57,17 @@ BINDING = Kernel::binding()
 
 # DLM: ignore for now
 #Encoding.default_external = Encoding::ASCII
+
+# We patch Kernel.open, and IO.open
+# to read embedded files as a StringIO, not as a FileIO
+# But Gem.open_file for eg expects it to be a File, not a StringIO, and on
+# Windows it will call File::flock (file lock) to protect access, but StringIO
+# does not have this method
+class FakeFileAsStringIO < StringIO
+  def flock
+    return 0
+  end
+end
 
 module Kernel
   # ":" is our root path to the embedded file system
@@ -329,7 +342,7 @@ module Kernel
         #puts "string = #{string}"
         if block_given?
           # if a block is given, then a new IO is created and closed
-          io = StringIO.open(string)
+          io = FakeFileAsStringIO.open(string)
           begin
             result = yield(io)
           ensure
@@ -337,13 +350,13 @@ module Kernel
           end
           return result
         else
-          return StringIO.open(string)
+          return FakeFileAsStringIO.open(string)
         end
       else
         #puts "IO.open cannot find embedded file '#{absolute_path}' for '#{name}'"
         if block_given?
           # if a block is given, then a new IO is created and closed
-          io = StringIO.open("")
+          io = FakeFileAsStringIO.open("")
           begin
             result = yield(io)
           ensure
@@ -459,7 +472,7 @@ class IO
         #puts "string = #{string}"
         if block_given?
           # if a block is given, then a new IO is created and closed
-          io = StringIO.open(string)
+          io = FakeFileAsStringIO.open(string)
           begin
             result = yield(io)
           ensure
@@ -467,13 +480,13 @@ class IO
           end
           return result
         else
-          return StringIO.open(string)
+          return FakeFileAsStringIO.open(string)
         end
       else
         puts "IO.open cannot find embedded file '#{absolute_path}' for '#{name}'"
         if block_given?
           # if a block is given, then a new IO is created and closed
-          io = StringIO.open("")
+          io = FakeFileAsStringIO.open("")
           begin
             result = yield(io)
           ensure

--- a/ruby/engine/embedded_help.rb
+++ b/ruby/engine/embedded_help.rb
@@ -64,7 +64,7 @@ BINDING = Kernel::binding()
 # Windows it will call File::flock (file lock) to protect access, but StringIO
 # does not have this method
 class FakeFileAsStringIO < StringIO
-  def flock
+  def flock(operation)
     return 0
   end
 end

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -203,6 +203,11 @@ if(BUILD_TESTING)
     PASS_REGULAR_EXPRESSION "Hello from -x, at National Renewable Energy Laboratory"
   )
 
+  # Test for 5315
+  add_test(NAME OpenStudioCLI.EmbeddedScripting.uuid
+    COMMAND $<TARGET_FILE:openstudio> ${CMAKE_CURRENT_SOURCE_DIR}/test/ensure_uuid_can_be_loaded.rb
+  )
+
   add_test(NAME OpenStudioCLI.Classic.Run_RubyOnly
     COMMAND $<TARGET_FILE:openstudio> classic run -w compact_ruby_only.osw
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/Examples/compact_osw/"

--- a/src/cli/test/ensure_uuid_can_be_loaded.rb
+++ b/src/cli/test/ensure_uuid_can_be_loaded.rb
@@ -1,0 +1,5 @@
+require 'uuid'
+
+u = UUID.new
+
+puts u.inspect


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5315
 - Windows only

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
