### PR TITLE
#5319 - gbXML Reverse Translator - Scan for the gbxml Schema version: skip schema validation with a warning when not 7.03

### DIFF
--- a/src/gbxml/ReverseTranslator.cpp
+++ b/src/gbxml/ReverseTranslator.cpp
@@ -100,12 +100,17 @@ namespace gbxml {
           if (version.empty()) {
             LOG(Warn, "gbXML has no `version` attribute for the schema version, assuming 7.03.");
             version = "7.03";
-          } else if (version != "7.03") {
-            LOG(Error, "Version of schema specified: " << version << ", expected 7.03. Validation will still assume 7.03, expect errors.");
           }
-          // validate the gbxml prior to reverse translation
-          auto gbxmlValidator = XMLValidator::gbxmlValidator();
-          gbxmlValidator.validate(path);
+          if (version == "7.03") {
+            // validate the gbxml prior to reverse translation
+            auto gbxmlValidator = XMLValidator::gbxmlValidator();
+            gbxmlValidator.validate(path);
+          } else {
+            LOG(Error,
+                "Version of schema specified: " << version
+                                                << ", expected 7.03. gbXML Schema Validation skipped. Note that ReverseTranslator rules are built "
+                                                   "for 7.03 and older versions are not officially supported, check resulting model with care.");
+          };
 
           result = this->convert(root);
         }

--- a/src/gbxml/ReverseTranslator.cpp
+++ b/src/gbxml/ReverseTranslator.cpp
@@ -110,7 +110,7 @@ namespace gbxml {
           }
           if (schemaVersion == VersionString(7, 3)) {
             // validate the gbxml prior to reverse translation
-            auto gbxmlValidator = XMLValidator::gbxmlValidator(VersionString(7, 3));
+            auto gbxmlValidator = XMLValidator::gbxmlValidator(schemaVersion);
             gbxmlValidator.validate(path);
           } else {
             LOG(Error,

--- a/src/gbxml/ReverseTranslator.cpp
+++ b/src/gbxml/ReverseTranslator.cpp
@@ -37,6 +37,7 @@
 #include "../model/AdditionalProperties.hpp"
 
 #include "../utilities/core/Assert.hpp"
+#include "../utilities/core/Compare.hpp"
 #include "../utilities/core/FilesystemHelpers.hpp"
 #include "../utilities/units/Quantity.hpp"
 #include "../utilities/units/UnitFactory.hpp"
@@ -97,13 +98,19 @@ namespace gbxml {
           }
           // Scan version of gbxml schema
           std::string version = root.attribute("version").value();
+          VersionString schemaVersion(7, 3);
           if (version.empty()) {
             LOG(Warn, "gbXML has no `version` attribute for the schema version, assuming 7.03.");
-            version = "7.03";
+          } else {
+            try {
+              schemaVersion = VersionString(version);
+            } catch (...) {
+              LOG(Warn, "gbXML has `version` '" << version << "' which was not understood, assuming 7.03.");
+            }
           }
-          if (version == "7.03") {
+          if (schemaVersion == VersionString(7, 3)) {
             // validate the gbxml prior to reverse translation
-            auto gbxmlValidator = XMLValidator::gbxmlValidator();
+            auto gbxmlValidator = XMLValidator::gbxmlValidator(VersionString(7, 3));
             gbxmlValidator.validate(path);
           } else {
             LOG(Error,

--- a/src/utilities/xml/XMLValidator.cpp
+++ b/src/utilities/xml/XMLValidator.cpp
@@ -472,14 +472,18 @@ std::vector<LogMessage> XMLValidator::logMessages() const {
   return m_logMessages;
 }
 
-XMLValidator XMLValidator::gbxmlValidator() {
+XMLValidator XMLValidator::gbxmlValidator(const VersionString& schemaVersion) {
   const auto tmpDir = openstudio::filesystem::create_temporary_directory("xmlvalidation");
   if (tmpDir.empty()) {
     LOG_AND_THROW("Failed to create a temporary directory for extracting the embedded path");
   }
+  if (schemaVersion != VersionString(7, 3)) {
+    LOG_AND_THROW("Unexpected gbXML Schema Version: accepted = [7.03]");
+  }
   const bool quiet = true;
-  ::openstudio::embedded_files::extractFile(":/xml/resources/GreenBuildingXML_Ver7.03.xsd", openstudio::toString(tmpDir), quiet);
-  auto validator = XMLValidator(tmpDir / "GreenBuildingXML_Ver7.03.xsd");
+  std::string schemaName = fmt::format("GreenBuildingXML_Ver{}.{:02}.xsd", schemaVersion.major(), schemaVersion.minor());
+  ::openstudio::embedded_files::extractFile(fmt::format(":/xml/resources/{}", schemaName), openstudio::toString(tmpDir), quiet);
+  auto validator = XMLValidator(tmpDir / schemaName);
   validator.m_tempDir = tmpDir;
   return validator;
 }

--- a/src/utilities/xml/XMLValidator.hpp
+++ b/src/utilities/xml/XMLValidator.hpp
@@ -52,7 +52,7 @@ class UTILITIES_API XMLValidator
   XMLValidator& operator=(const XMLValidator& other) = default;
   XMLValidator& operator=(XMLValidator&& other) noexcept = default;
 
-  static XMLValidator gbxmlValidator();
+  static XMLValidator gbxmlValidator(const VersionString& schemaVersion = VersionString(7, 3));
 
   static XMLValidator bclXMLValidator(openstudio::BCLXMLType bclXMLType = openstudio::BCLXMLType::MeasureXML,
                                       const VersionString& schemaVersion = VersionString(3, 1));


### PR DESCRIPTION
Pull request overview
---------------------

 - #5319 
 - gbXML Reverse Translator - Scan for the gbxml Schema version: skip schema validation with a warning when not 7.03

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
