### PR TITLE
Fix floorplanjs issue

### DIFF
--- a/src/utilities/geometry/FloorplanJS.cpp
+++ b/src/utilities/geometry/FloorplanJS.cpp
@@ -1077,13 +1077,11 @@ ThreeScene FloorplanJS::toThreeScene(bool openstudioFormat) const {
   Json::ArrayIndex storyN = stories.size();
   for (Json::ArrayIndex storyIdx = 0; storyIdx < storyN; ++storyIdx) {
 
-    std::string storyName = "";
     if (checkKeyAndType(stories[storyIdx], "name", Json::stringValue)) {
-      storyName = stories[storyIdx].get("name", "").asString();
-      buildingStoryNames.push_back(storyName);
+      buildingStoryNames.push_back(stories[storyIdx].get("name", "").asString());
     }
 
-    std::string storyColor;
+    std::string storyColor = "";
     if (checkKeyAndType(stories[storyIdx], "color", Json::stringValue)) {
       storyColor = stories[storyIdx].get("color", storyColor).asString();
     }

--- a/src/utilities/geometry/FloorplanJS.cpp
+++ b/src/utilities/geometry/FloorplanJS.cpp
@@ -1081,7 +1081,7 @@ ThreeScene FloorplanJS::toThreeScene(bool openstudioFormat) const {
       buildingStoryNames.push_back(stories[storyIdx].get("name", "").asString());
     }
 
-    std::string storyColor = "";
+    std::string storyColor;
     if (checkKeyAndType(stories[storyIdx], "color", Json::stringValue)) {
       storyColor = stories[storyIdx].get("color", storyColor).asString();
     }

--- a/src/utilities/geometry/FloorplanJS.cpp
+++ b/src/utilities/geometry/FloorplanJS.cpp
@@ -1077,8 +1077,9 @@ ThreeScene FloorplanJS::toThreeScene(bool openstudioFormat) const {
   Json::ArrayIndex storyN = stories.size();
   for (Json::ArrayIndex storyIdx = 0; storyIdx < storyN; ++storyIdx) {
 
+    std::string storyName = "";
     if (checkKeyAndType(stories[storyIdx], "name", Json::stringValue)) {
-      std::string storyName = stories[storyIdx].get("name", storyName).asString();
+      storyName = stories[storyIdx].get("name", "").asString();
       buildingStoryNames.push_back(storyName);
     }
 


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5327 (IF THIS IS A DEFECT)

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->
Fix the test about floorPlanJS.

The line:

```
std::string storyName = stories[storyIdx].get("name", storyName).asString();
```
contains bad initilization which is using the storyName before it initilizaed properly.

The bad initiliazation trigger some kind of undefined behavior and the undefined behavior is ....undefined.

Therefore, somehow it works, somehow it broken.

<!--- Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol. -->

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [x] CI status: all green or justified


A run of tests from the remote CI box:

```
[----------] 173 tests from GeometryFixture
[ RUN      ] GeometryFixture.BoundingBox
[       OK ] GeometryFixture.BoundingBox (0 ms)
[ RUN      ] GeometryFixture.BoundingBox_Empty
[       OK ] GeometryFixture.BoundingBox_Empty (0 ms)
[ RUN      ] GeometryFixture.BoundingBox_Touching
[       OK ] GeometryFixture.BoundingBox_Touching (0 ms)
[ RUN      ] GeometryFixture.BoundingBox_NoIntersection
[       OK ] GeometryFixture.BoundingBox_NoIntersection (0 ms)
[ RUN      ] GeometryFixture.FloorplanJS
[       OK ] GeometryFixture.FloorplanJS (9 ms)
```


```
./Products/openstudio_model_tests --gtest_filter="*ThreeJSReverseTranslator_FloorplanJS*"
Running main() from gmock_main.cc
Note: Google Test filter = *ThreeJSReverseTranslator_FloorplanJS*
[==========] Running 15 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 15 tests from ModelFixture
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS
Starting toThreeScene in source
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS (37 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SurfaceMatch
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SurfaceMatch (20 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Doors
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Doors (16 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Windows
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Windows (60 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SimAUD_Paper
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SimAUD_Paper (231 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Shading
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Shading (11 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SplitLevel
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_SplitLevel (17 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StorySpaceHeights
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StorySpaceHeights (24 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Colors
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Colors (8 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_DifferingNumVertices
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_DifferingNumVertices (10 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_School
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_School (295 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StoryMultipliers
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StoryMultipliers (28 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StoryMultipliers2
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_StoryMultipliers2 (22 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_OpenToBelow
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_OpenToBelow (18 ms)
[ RUN      ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Site_ClimateZones_4166
Starting toThreeScene in source
[       OK ] ModelFixture.ThreeJSReverseTranslator_FloorplanJS_Site_ClimateZones_4166 (28 ms)
[----------] 15 tests from ModelFixture (831 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 1 test suite ran. (832 ms total)
[  PASSED  ] 15 tests.
```
TODO:
- Make the CI passed since some update probably needed to add in the machine.