### PR TITLE
fixed all the unittests from #5327 

### DIFF
--- a/src/utilities/bcl/BCL.hpp
+++ b/src/utilities/bcl/BCL.hpp
@@ -196,7 +196,7 @@ class UTILITIES_API BCLSearchResult
   std::string m_modelerDescription;
   std::string m_fidelityLevel;
   std::string m_componentType;
-  bool m_provenanceRequired;
+  bool m_provenanceRequired = false;
   std::vector<BCLProvenance> m_provenances;
   std::vector<std::string> m_tags;
   std::vector<Attribute> m_attributes;


### PR DESCRIPTION
* Fix #5327

The only one test left from 5327 is `BCLFixture.RemoteBCL_BCLSearchResult` and fixed by set the 

`m_provenanceRequired` to `false` explictly. The  `m_provenanceRequired` to be true and then `BCLSearchResult::provenanceRequired` returns true even though should not be. 


The old logic make the unittest broken b/c:

1. initialize the m_provenanceRequired == true
2. Didn't run the logic in constructor [here](https://github.com/NREL/OpenStudio/blob/9db49090f352e270c1c827374e9e70597ae7c0f0/src/utilities/bcl/BCL.cpp#L370-L373) and still be true.
3. Find the comflict in unittest [here](https://github.com/NREL/OpenStudio/blob/9db49090f352e270c1c827374e9e70597ae7c0f0/src/utilities/bcl/test/BCL_GTest.cpp#L444)

The new logic solved the issue by:

Forcely set the value of m_provenanceRequired as `false` from start in BCL.hpp.
```
ctest -R "BCLFixture.RemoteBCL_BCLSearchResult" -V
UpdateCTestConfiguration  from :/Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/DartConfiguration.tcl
Parse Config file:/Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/DartConfiguration.tcl
UpdateCTestConfiguration  from :/Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/DartConfiguration.tcl
Parse Config file:/Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/DartConfiguration.tcl
Test project /Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 665
    Start 665: BCLFixture.RemoteBCL_BCLSearchResult

665: Test command: /Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/Products/openstudio_utilities_tests "--gtest_filter=BCLFixture.RemoteBCL_BCLSearchResult" "--gtest_also_run_disabled_tests"
665: Working Directory: /Users/jenkins/git/OpenStudioIncremental/OS-build-release-v2/src/utilities
665: Test timeout computed to be: 660
665: Running main() from gmock_main.cc
665: Note: Google Test filter = BCLFixture.RemoteBCL_BCLSearchResult
665: [==========] Running 1 test from 1 test suite.
665: [----------] Global test environment set-up.
665: [----------] 1 test from BCLFixture
665: [ RUN      ] BCLFixture.RemoteBCL_BCLSearchResult
665: Calling the metaSearch[       OK ] BCLFixture.RemoteBCL_BCLSearchResult (3091 ms)
665: [----------] 1 test from BCLFixture (3091 ms total)
665: 
665: [----------] Global test environment tear-down
665: [==========] 1 test from 1 test suite ran. (3091 ms total)
665: [  PASSED  ] 1 test.
1/1 Test #665: BCLFixture.RemoteBCL_BCLSearchResult ...   Passed    3.15 sec

The following tests passed:
	BCLFixture.RemoteBCL_BCLSearchResult

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   3.40 sec
```


Pull request overview
---------------------

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

To fix the only one unittest failed from #5327 .

<!--- Please read [OpenStudio Pull Requests](https://github.com/NREL/OpenStudio/wiki/OpenStudio-Pull-Requests) to better understand the OpenStudio Pull Request protocol. -->

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [x] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
