### PR TITLE
Fix typo in StandardsInformationConstruction

### DIFF
--- a/src/model/StandardsInformationConstruction.cpp
+++ b/src/model/StandardsInformationConstruction.cpp
@@ -92,7 +92,7 @@ namespace model {
         }
       }
       if (intendedSurfaceType) {
-        if (istringEqual(*intendedSurfaceType, "InterorWall")) {
+        if (istringEqual(*intendedSurfaceType, "InteriorWall")) {
           result.push_back("Mass");
           result.push_back("Metal");
           result.push_back("SteelFramed");


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes small typo in the StandardsConstructionType options for the StandardsInformationConstruction object.

### Pull Request Author
 - [x] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**
 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
