### PR TITLE
#4830 - Add a new ReportingMeasure::modelOutputRequests(model, runner, argument_map) that runs before E+ FT

### DIFF
--- a/python/engine/PythonEngine.cpp
+++ b/python/engine/PythonEngine.cpp
@@ -413,6 +413,21 @@ int PythonEngine::numberOfArguments(ScriptObject& methodObject, std::string_view
   return numberOfArguments;
 }
 
+bool PythonEngine::hasMethod(ScriptObject& methodObject, std::string_view methodName) {
+  auto val = std::any_cast<PythonObject>(methodObject.object);
+  if (PyObject_HasAttrString(val.obj_, methodName.data()) == 0) {
+    return false;
+  }
+  PyObject* method = PyObject_GetAttrString(val.obj_, methodName.data());  // New reference
+  bool result = false;
+  if (PyMethod_Check(method)) {
+    result = true;
+  }
+
+  Py_DECREF(method);
+  return result;
+}
+
 }  // namespace openstudio
 
 extern "C"

--- a/python/engine/PythonEngine.hpp
+++ b/python/engine/PythonEngine.hpp
@@ -38,7 +38,7 @@ class PythonEngine final : public ScriptEngine
 
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) override;
 
-  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) override;
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName, bool overriden_only) override;
 
  protected:
   void* getAs_impl(ScriptObject& obj, const std::type_info&) override;

--- a/python/engine/PythonEngine.hpp
+++ b/python/engine/PythonEngine.hpp
@@ -38,6 +38,8 @@ class PythonEngine final : public ScriptEngine
 
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) override;
 
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) override;
+
  protected:
   void* getAs_impl(ScriptObject& obj, const std::type_info&) override;
 

--- a/python/engine/test/PythonEngine_GTest.cpp
+++ b/python/engine/test/PythonEngine_GTest.cpp
@@ -181,7 +181,7 @@ TEST_F(PythonEngineFixture, hasMethod) {
     const auto scriptPath = getScriptPath(classAndDirName);
     auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
-    // TODO: this will fail, because the BASE class has it.
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests", false));  // overriden_only = false
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
   }
   {
@@ -189,6 +189,7 @@ TEST_F(PythonEngineFixture, hasMethod) {
     const auto scriptPath = getScriptPath(classAndDirName);
     auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests", false));  // overriden_only = false
     EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
   }
 }

--- a/python/engine/test/PythonEngine_GTest.cpp
+++ b/python/engine/test/PythonEngine_GTest.cpp
@@ -174,3 +174,21 @@ TEST_F(PythonEngineFixture, AlfalfaMeasure) {
   measurePtr->run(model, runner, arguments);
   EXPECT_EQ(5, runner.alfalfa().points().size());
 }
+
+TEST_F(PythonEngineFixture, hasMethod) {
+  {
+    const std::string classAndDirName = "ReportingMeasureWithoutModelOutputs";
+    const auto scriptPath = getScriptPath(classAndDirName);
+    auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    // TODO: this will fail, because the BASE class has it.
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
+  }
+  {
+    const std::string classAndDirName = "ReportingMeasureWithModelOutputs";
+    const auto scriptPath = getScriptPath(classAndDirName);
+    auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
+  }
+}

--- a/python/engine/test/ReportingMeasureWithModelOutputs/measure.py
+++ b/python/engine/test/ReportingMeasureWithModelOutputs/measure.py
@@ -1,0 +1,52 @@
+"""insert your copyright here.
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+"""
+
+from pathlib import Path
+
+import openstudio
+
+
+class ReportingMeasureWithModelOutputs(openstudio.measure.ReportingMeasure):
+    """An ReportingMeasure."""
+
+    def name(self):
+        return "ReportingMeasureWithModelOutputs"
+
+    def description(self):
+        return "DESCRIPTION_TEXT"
+
+    def modeler_description(self):
+        return "MODELER_DESCRIPTION_TEXT"
+
+    def arguments(self, model: openstudio.model.Model):
+        args = openstudio.measure.OSArgumentVector()
+        return args
+
+    def outputs(self):
+        outs = openstudio.measure.OSOutputVector()
+        return outs
+
+    def modelOutputRequests(
+        self,
+        model: openstudio.model.Model,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ) -> bool:
+        return True
+
+    def energyPlusOutputRequests(
+        self, runner: openstudio.measure.OSRunner, user_arguments: openstudio.measure.OSArgumentMap
+    ):
+        result = openstudio.IdfObjectVector()
+        return result
+
+    def run(
+        self,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ):
+        super().run(runner, user_arguments)
+        return True

--- a/python/engine/test/ReportingMeasureWithModelOutputs/measure.xml
+++ b/python/engine/test/ReportingMeasureWithModelOutputs/measure.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>reporting_measure_with_model_outputs</name>
+  <uid>9971eb7b-3225-4795-9690-9941a7471ce0</uid>
+  <version_id>be88754a-3d7f-433e-9912-94a2993c9463</version_id>
+  <version_modified>2025-03-14T13:15:30Z</version_modified>
+  <xml_checksum>1DA817AF</xml_checksum>
+  <class_name>ReportingMeasureWithModelOutputs</class_name>
+  <display_name>ReportingMeasureWithModelOutputs</display_name>
+  <description>DESCRIPTION_TEXT</description>
+  <modeler_description>MODELER_DESCRIPTION_TEXT</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>CFB17771</checksum>
+    </file>
+  </files>
+</measure>

--- a/python/engine/test/ReportingMeasureWithoutModelOutputs/measure.py
+++ b/python/engine/test/ReportingMeasureWithoutModelOutputs/measure.py
@@ -1,0 +1,44 @@
+"""insert your copyright here.
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+"""
+
+from pathlib import Path
+
+import openstudio
+
+
+class ReportingMeasureWithoutModelOutputs(openstudio.measure.ReportingMeasure):
+    """An ReportingMeasure."""
+
+    def name(self):
+        return "ReportingMeasureWithoutModelOutputs"
+
+    def description(self):
+        return "DESCRIPTION_TEXT"
+
+    def modeler_description(self):
+        return "MODELER_DESCRIPTION_TEXT"
+
+    def arguments(self, model: openstudio.model.Model):
+        args = openstudio.measure.OSArgumentVector()
+        return args
+
+    def outputs(self):
+        outs = openstudio.measure.OSOutputVector()
+        return outs
+
+    def energyPlusOutputRequests(
+        self, runner: openstudio.measure.OSRunner, user_arguments: openstudio.measure.OSArgumentMap
+    ):
+        result = openstudio.IdfObjectVector()
+        return result
+
+    def run(
+        self,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ):
+        super().run(runner, user_arguments)
+        return True

--- a/python/engine/test/ReportingMeasureWithoutModelOutputs/measure.xml
+++ b/python/engine/test/ReportingMeasureWithoutModelOutputs/measure.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>reporting_measure_without_model_outputs</name>
+  <uid>a0876945-a15b-469d-bc22-90f133720e7c</uid>
+  <version_id>49740c2c-1804-4a4e-ace5-c30b6d350c5f</version_id>
+  <version_modified>2025-03-14T13:15:17Z</version_modified>
+  <xml_checksum>1DA817AF</xml_checksum>
+  <class_name>ReportingMeasureWithoutModelOutputs</class_name>
+  <display_name>ReportingMeasureWithoutModelOutputs</display_name>
+  <description>DESCRIPTION_TEXT</description>
+  <modeler_description>MODELER_DESCRIPTION_TEXT</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>816BF07D</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
@@ -1,0 +1,168 @@
+"""insert your copyright here.
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+"""
+
+from pathlib import Path
+
+import openstudio
+
+
+class PythonReportingMeasureWithModelOutputRequests(openstudio.measure.ReportingMeasure):
+    """An ReportingMeasure."""
+
+    def name(self) -> str:
+        """Returns the human readable name.
+
+        Measure name should be the title case of the class name.
+        The measure name is the first contact a user has with the measure;
+        it is also shared throughout the measure workflow, visible in the OpenStudio Application,
+        PAT, Server Management Consoles, and in output reports.
+        As such, measure names should clearly describe the measure's function,
+        while remaining general in nature
+        """
+        return "Reporting Measure with Model Output Requests"
+
+    def description(self) -> str:
+        """Human readable description.
+
+        The measure description is intended for a general audience and should not assume
+        that the reader is familiar with the design and construction practices suggested by the measure.
+        """
+        return "A new reporting measure that has a modelOutputRequests"
+
+    def modeler_description(self) -> str:
+        """Human readable description of modeling approach.
+
+        The modeler description is intended for the energy modeler using the measure.
+        It should explain the measure's intent, and include any requirements about
+        how the baseline model must be set up, major assumptions made by the measure,
+        and relevant citations or references to applicable modeling resources
+        """
+        return "This was added at 3.10.0"
+
+    def arguments(self, model: openstudio.model.Model) -> openstudio.measure.OSArgumentVector:
+        """Prepares user arguments for the measure.
+
+        Measure arguments define which -- if any -- input parameters the user may set before running the measure.
+        """
+        args = openstudio.measure.OSArgumentVector()
+
+        report_drybulb_temp = openstudio.measure.OSArgument.makeBoolArgument("report_drybulb_temp", True)
+        report_drybulb_temp.setDisplayName("Add output variables for Drybulb Temperature")
+        report_drybulb_temp.setDescription("Will add drybulb temp and report min/max values in html.")
+        report_drybulb_temp.setDefaultValue(True)
+        args.append(report_drybulb_temp)
+
+        add_output_json = openstudio.measure.OSArgument.makeBoolArgument("add_output_json", True)
+        add_output_json.setDisplayName("Request JSON output")
+        add_output_json.setDescription("Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true")
+        add_output_json.setDefaultValue(True)
+        args.append(add_output_json)
+
+        return args
+
+    def outputs(self) -> openstudio.measure.OSOutputVector:
+        """Define the outputs that the measure will create."""
+        outs = openstudio.measure.OSOutputVector()
+
+        # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+        return outs
+
+    def modelOutputRequests(
+        self,
+        model: openstudio.model.Model,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ) -> bool:
+        """This method is called on all reporting measures immediately before the translation to E+ IDF.
+
+        There is an implicit contract that this method should NOT be modifying your model in a way that would produce
+        different results, meaning it should only add or modify reporting-related elements
+        (eg: OutputTableSummaryReports, OutputControlFiles, etc)
+
+        If you mean to modify the model in a significant way, use a `ModelMeasure`
+        NOTE: this method will ONLY be called if you use the C++ CLI,  not the `classic` (Ruby) one
+        """
+        if runner.getBoolArgumentValue("add_output_json", user_arguments):
+            output_json = model.getOutputJSON()
+            output_json.setOptionType("TimeSeriesAndTabular")
+            output_json.setOutputJSON(True)
+            output_json.setOutputCBOR(False)
+            output_json.setOutputMessagePack(False)
+
+        return True
+
+    def energyPlusOutputRequests(
+        self, runner: openstudio.measure.OSRunner, user_arguments: openstudio.measure.OSArgumentMap
+    ) -> openstudio.IdfObjectVector:
+        """Returns a vector of IdfObject's to request EnergyPlus objects needed by the run method.
+
+        This is done after ForwardTranslation to IDF, and there is a list of accepted objects.
+        """
+        super().energyPlusOutputRequests(runner, user_arguments)  # Do **NOT** remove this line
+
+        result = openstudio.IdfObjectVector()
+
+        # To use the built-in error checking we need the model...
+        # get the last model and sql file
+        model = runner.lastOpenStudioModel()
+        if not model.is_initialized():
+            runner.registerError("Cannot find last model.")
+            return False
+
+        model = model.get()
+
+        # use the built-in error checking
+        if not runner.validateUserArguments(self.arguments(model), user_arguments):
+            return False
+
+        if runner.getBoolArgumentValue("report_drybulb_temp", user_arguments):
+            request = openstudio.IdfObject.load(
+                "Output:Variable, , Site Outdoor Air Drybulb Temperature, Hourly;"
+            ).get()
+            result.append(request)
+
+        return result
+
+    def run(
+        self,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ) -> bool:
+        """Defines what happens when the measure is run."""
+        super().run(runner, user_arguments)
+
+        # get the last model and sql file
+        model = runner.lastOpenStudioModel()
+        if not model.is_initialized():
+            runner.registerError("Cannot find last model.")
+            return False
+        model = model.get()
+
+        # use the built-in error checking (need model)
+        if not runner.validateUserArguments(self.arguments(model), user_arguments):
+            return False
+
+        # load sql file
+        sql_file = runner.lastEnergyPlusSqlFile()
+        if not sql_file.is_initialized():
+            runner.registerError("Cannot find last sql file.")
+            return False
+
+        sql_file = sql_file.get()
+        model.setSqlFile(sql_file)
+        # write html file: any file named 'report*.*' in the current working directory
+        # will be copied to the ./reports/ folder as 'reports/<measure_class_name>_<filename>.html'
+        Path("report_python_with.txt").write_text("OK")
+
+        # Close the sql file
+        sql_file.close()
+
+        return True
+
+
+# register the measure to be used by the application
+PythonReportingMeasureWithModelOutputRequests().registerWithApplication()

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
@@ -154,7 +154,7 @@ class PythonReportingMeasureWithModelOutputRequests(openstudio.measure.Reporting
 
         sql_file = sql_file.get()
         model.setSqlFile(sql_file)
-        # write html file: any file named 'report*.*' in the current working directory
+        # write file: any file named 'report*.*' in the current working directory
         # will be copied to the ./reports/ folder as 'reports/<measure_class_name>_<filename>.html'
         Path("report_python_with.txt").write_text("OK")
 

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.py
@@ -111,13 +111,13 @@ class PythonReportingMeasureWithModelOutputRequests(openstudio.measure.Reporting
         model = runner.lastOpenStudioModel()
         if not model.is_initialized():
             runner.registerError("Cannot find last model.")
-            return False
+            return result
 
         model = model.get()
 
         # use the built-in error checking
         if not runner.validateUserArguments(self.arguments(model), user_arguments):
-            return False
+            return result
 
         if runner.getBoolArgumentValue("report_drybulb_temp", user_arguments):
             request = openstudio.IdfObject.load(

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>python_reporting_measure_with_model_output_requests</name>
+  <uid>90b5aa6c-a23d-4be3-b24a-a695d27e3848</uid>
+  <version_id>5ddc1769-f3f2-466f-9272-617a0cd080d9</version_id>
+  <version_modified>2025-03-14T16:35:06Z</version_modified>
+  <xml_checksum>1DA817AF</xml_checksum>
+  <class_name>PythonReportingMeasureWithModelOutputRequests</class_name>
+  <display_name>Reporting Measure with Model Output Requests</display_name>
+  <description>A new reporting measure that has a modelOutputRequests</description>
+  <modeler_description>This was added at 3.10.0</modeler_description>
+  <arguments>
+    <argument>
+      <name>report_drybulb_temp</name>
+      <display_name>Add output variables for Drybulb Temperature</display_name>
+      <description>Will add drybulb temp and report min/max values in html.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>add_output_json</name>
+      <display_name>Request JSON output</display_name>
+      <description>Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.10.0</identifier>
+        <min_compatible>3.10.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>C198FABF</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>python_reporting_measure_with_model_output_requests</name>
   <uid>90b5aa6c-a23d-4be3-b24a-a695d27e3848</uid>
-  <version_id>5ddc1769-f3f2-466f-9272-617a0cd080d9</version_id>
-  <version_modified>2025-03-14T16:35:06Z</version_modified>
+  <version_id>735c4950-ce2a-49da-bec9-d08a55e06496</version_id>
+  <version_modified>2025-03-14T16:42:28Z</version_modified>
   <xml_checksum>1DA817AF</xml_checksum>
   <class_name>PythonReportingMeasureWithModelOutputRequests</class_name>
   <display_name>Reporting Measure with Model Output Requests</display_name>
@@ -77,7 +77,7 @@
       <filename>measure.py</filename>
       <filetype>py</filetype>
       <usage_type>script</usage_type>
-      <checksum>C198FABF</checksum>
+      <checksum>70ECC2B3</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>python_reporting_measure_with_model_output_requests</name>
   <uid>90b5aa6c-a23d-4be3-b24a-a695d27e3848</uid>
-  <version_id>735c4950-ce2a-49da-bec9-d08a55e06496</version_id>
-  <version_modified>2025-03-14T16:42:28Z</version_modified>
+  <version_id>398d6d2e-3240-4390-83b4-2477193285eb</version_id>
+  <version_modified>2025-03-14T16:51:11Z</version_modified>
   <xml_checksum>1DA817AF</xml_checksum>
   <class_name>PythonReportingMeasureWithModelOutputRequests</class_name>
   <display_name>Reporting Measure with Model Output Requests</display_name>
@@ -77,7 +77,7 @@
       <filename>measure.py</filename>
       <filetype>py</filetype>
       <usage_type>script</usage_type>
-      <checksum>70ECC2B3</checksum>
+      <checksum>0B936742</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.py
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.py
@@ -1,0 +1,135 @@
+"""insert your copyright here.
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+"""
+
+from pathlib import Path
+
+import openstudio
+
+
+class PythonReportingMeasureWithoutModelOutputRequests(openstudio.measure.ReportingMeasure):
+    """An ReportingMeasure."""
+
+    def name(self):
+        """Returns the human readable name.
+
+        Measure name should be the title case of the class name.
+        The measure name is the first contact a user has with the measure;
+        it is also shared throughout the measure workflow, visible in the OpenStudio Application,
+        PAT, Server Management Consoles, and in output reports.
+        As such, measure names should clearly describe the measure's function,
+        while remaining general in nature
+        """
+        return "Reporting Measure without Model Output Requests"
+
+    def description(self):
+        """Human readable description.
+
+        The measure description is intended for a general audience and should not assume
+        that the reader is familiar with the design and construction practices suggested by the measure.
+        """
+        return "An older reporting measure that does not have modelOutputRequests"
+
+    def modeler_description(self):
+        """Human readable description of modeling approach.
+
+        The modeler description is intended for the energy modeler using the measure.
+        It should explain the measure's intent, and include any requirements about
+        how the baseline model must be set up, major assumptions made by the measure,
+        and relevant citations or references to applicable modeling resources
+        """
+        return "This is a measure that was added before 3.10.0"
+
+    def arguments(self, model: openstudio.model.Model):
+        """Prepares user arguments for the measure.
+
+        Measure arguments define which -- if any -- input parameters the user may set before running the measure.
+        """
+        args = openstudio.measure.OSArgumentVector()
+
+        report_drybulb_temp = openstudio.measure.OSArgument.makeBoolArgument("report_drybulb_temp", True)
+        report_drybulb_temp.setDisplayName("Add output variables for Drybulb Temperature")
+        report_drybulb_temp.setDescription("Will add drybulb temp and report min/max values in html.")
+        report_drybulb_temp.setValue(True)
+        args.append(report_drybulb_temp)
+
+        return args
+
+    def outputs(self):
+        """Define the outputs that the measure will create."""
+        outs = openstudio.measure.OSOutputVector()
+
+        # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+        return outs
+
+    def energyPlusOutputRequests(
+        self, runner: openstudio.measure.OSRunner, user_arguments: openstudio.measure.OSArgumentMap
+    ):
+        """Returns a vector of IdfObject's to request EnergyPlus objects needed by the run method."""
+        super().energyPlusOutputRequests(runner, user_arguments)  # Do **NOT** remove this line
+
+        result = openstudio.IdfObjectVector()
+
+        # To use the built-in error checking we need the model...
+        # get the last model and sql file
+        model = runner.lastOpenStudioModel()
+        if not model.is_initialized():
+            runner.registerError("Cannot find last model.")
+            return False
+
+        model = model.get()
+
+        # use the built-in error checking
+        if not runner.validateUserArguments(self.arguments(model), user_arguments):
+            return False
+
+        if runner.getBoolArgumentValue("report_drybulb_temp", user_arguments):
+            request = openstudio.IdfObject.load(
+                "Output:Variable, , Site Outdoor Air Drybulb Temperature, Hourly;"
+            ).get()
+            result.append(request)
+
+        return result
+
+    def run(
+        self,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ):
+        """Defines what happens when the measure is run."""
+        super().run(runner, user_arguments)
+
+        # get the last model and sql file
+        model = runner.lastOpenStudioModel()
+        if not model.is_initialized():
+            runner.registerError("Cannot find last model.")
+            return False
+        model = model.get()
+
+        # use the built-in error checking (need model)
+        if not runner.validateUserArguments(self.arguments(model), user_arguments):
+            return False
+
+        # load sql file
+        sql_file = runner.lastEnergyPlusSqlFile()
+        if not sql_file.is_initialized():
+            runner.registerError("Cannot find last sql file.")
+            return False
+
+        sql_file = sql_file.get()
+        model.setSqlFile(sql_file)
+        # write file: any file named 'report*.*' in the current working directory
+        # will be copied to the ./reports/ folder as 'reports/<measure_class_name>_<filename>.html'
+        Path("report_python_without.txt").write_text("OK")
+
+        # Close the sql file
+        sql_file.close()
+
+        return True
+
+
+# register the measure to be used by the application
+PythonReportingMeasureWithoutModelOutputRequests().registerWithApplication()

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.py
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.py
@@ -78,13 +78,13 @@ class PythonReportingMeasureWithoutModelOutputRequests(openstudio.measure.Report
         model = runner.lastOpenStudioModel()
         if not model.is_initialized():
             runner.registerError("Cannot find last model.")
-            return False
+            return result
 
         model = model.get()
 
         # use the built-in error checking
         if not runner.validateUserArguments(self.arguments(model), user_arguments):
-            return False
+            return result
 
         if runner.getBoolArgumentValue("report_drybulb_temp", user_arguments):
             request = openstudio.IdfObject.load(

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>python_reporting_measure_without_model_output_requests</name>
   <uid>f1cbb7b8-e068-417e-8b2f-505f8441ab14</uid>
-  <version_id>06e75776-b04e-4eef-9f53-33a5c5d54eb5</version_id>
-  <version_modified>2025-03-14T16:33:26Z</version_modified>
+  <version_id>26cc30f8-03b9-4f32-a48c-6106c078e625</version_id>
+  <version_modified>2025-03-14T16:42:43Z</version_modified>
   <xml_checksum>1DA817AF</xml_checksum>
   <class_name>PythonReportingMeasureWithoutModelOutputRequests</class_name>
   <display_name>Reporting Measure without Model Output Requests</display_name>
@@ -57,7 +57,7 @@
       <filename>measure.py</filename>
       <filetype>py</filetype>
       <usage_type>script</usage_type>
-      <checksum>B01FB240</checksum>
+      <checksum>9AA7CFE7</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/PythonReportingMeasureWithoutModelOutputRequests/measure.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>python_reporting_measure_without_model_output_requests</name>
+  <uid>f1cbb7b8-e068-417e-8b2f-505f8441ab14</uid>
+  <version_id>06e75776-b04e-4eef-9f53-33a5c5d54eb5</version_id>
+  <version_modified>2025-03-14T16:33:26Z</version_modified>
+  <xml_checksum>1DA817AF</xml_checksum>
+  <class_name>PythonReportingMeasureWithoutModelOutputRequests</class_name>
+  <display_name>Reporting Measure without Model Output Requests</display_name>
+  <description>An older reporting measure that does not have modelOutputRequests</description>
+  <modeler_description>This is a measure that was added before 3.10.0</modeler_description>
+  <arguments>
+    <argument>
+      <name>report_drybulb_temp</name>
+      <display_name>Add output variables for Drybulb Temperature</display_name>
+      <description>Will add drybulb temp and report min/max values in html.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.py</filename>
+      <filetype>py</filetype>
+      <usage_type>script</usage_type>
+      <checksum>B01FB240</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
@@ -84,13 +84,13 @@ class RubyReportingMeasureWithModelOutputRequests < OpenStudio::Measure::Reporti
     model = runner.lastOpenStudioModel
     if model.empty?
       runner.registerError('Cannot find last model.')
-      return false
+      return result
     end
     model = model.get
 
     # use the built-in error checking
     if !runner.validateUserArguments(arguments(model), user_arguments)
-      return false
+      return result
     end
 
     # NOTE: this should rather be done in modelOutputRequests

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
@@ -1,0 +1,145 @@
+# insert your copyright here
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+require 'erb'
+
+# start the measure
+class RubyReportingMeasureWithModelOutputRequests < OpenStudio::Measure::ReportingMeasure
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'Reporting Measure with Model Output Requests'
+  end
+
+  # human readable description
+  def description
+    return 'A new reporting measure that has a modelOutputRequests'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'This was added at 3.10.0'
+  end
+
+  # define the arguments that the user will input
+  def arguments(model = nil)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+    # bool argument to report report_drybulb_temp
+    report_drybulb_temp = OpenStudio::Measure::OSArgument.makeBoolArgument('report_drybulb_temp', true)
+    report_drybulb_temp.setDisplayName('Add output variables for Drybulb Temperature')
+    report_drybulb_temp.setDescription('Will add drybulb temp and report min/mix value in html.')
+    report_drybulb_temp.setDefaultValue(true)
+    args << report_drybulb_temp
+
+    add_output_json = OpenStudio::Measure::OSArgument.makeBoolArgument('add_output_json', true)
+    add_output_json.setDisplayName('Request JSON output')
+    add_output_json.setDescription('Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true')
+    add_output_json.setDefaultValue(true)
+    args << add_output_json
+
+    return args
+  end
+
+  # define the outputs that the measure will create
+  def outputs
+    outs = OpenStudio::Measure::OSOutputVector.new
+
+    # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+    return outs
+  end
+
+  # This method is called on all reporting measures immediately before the translation to E+ IDF
+  # There is an implicit contract that this method should NOT be modifying your model in a way that would produce
+  # different results, meaning it should only add or modify reporting-related elements
+  # (eg: OutputTableSummaryReports, OutputControlFiles, etc)
+  # If you mean to modify the model in a significant way, use a `ModelMeasure`
+  # NOTE: this method will ONLY be called if you use the C++ CLI, not the `classic` (Ruby) one
+  def modelOutputRequests(model, runner, user_arguments)
+    if runner.getBoolArgumentValue('add_output_json', user_arguments)
+      output_json = model.getOutputJSON
+      output_json.setOptionType('TimeSeriesAndTabular')
+      output_json.setOutputJSON(true)
+      output_json.setOutputCBOR(false)
+      output_json.setOutputMessagePack(false)
+    end
+
+    return true
+  end
+
+  # return a vector of IdfObject's to request EnergyPlus objects needed by the run method
+  # Warning: Do not change the name of this method to be snake_case. The method must be lowerCamelCase.
+  # This is done after ForwardTranslation to IDF, and there is a list of
+  # accepted objects
+  def energyPlusOutputRequests(runner, user_arguments)
+    super(runner, user_arguments)  # Do **NOT** remove this line
+
+    result = OpenStudio::IdfObjectVector.new
+
+    # To use the built-in error checking we need the model...
+    # get the last model and sql file
+    model = runner.lastOpenStudioModel
+    if model.empty?
+      runner.registerError('Cannot find last model.')
+      return false
+    end
+    model = model.get
+
+    # use the built-in error checking
+    if !runner.validateUserArguments(arguments(model), user_arguments)
+      return false
+    end
+
+    # NOTE: this should rather be done in modelOutputRequests
+    if runner.getBoolArgumentValue('report_drybulb_temp', user_arguments)
+      request = OpenStudio::IdfObject.load('Output:Variable,,Site Outdoor Air Drybulb Temperature,Hourly;').get
+      result << request
+    end
+
+    return result
+  end
+
+  # define what happens when the measure is run
+  def run(runner, user_arguments)
+    super(runner, user_arguments)
+
+    # get the last model and sql file
+    model = runner.lastOpenStudioModel
+    if model.empty?
+      runner.registerError('Cannot find last model.')
+      return false
+    end
+    model = model.get
+
+    # use the built-in error checking (need model)
+    if !runner.validateUserArguments(arguments(model), user_arguments)
+      return false
+    end
+
+    # get measure arguments
+    report_drybulb_temp = runner.getBoolArgumentValue('report_drybulb_temp', user_arguments)
+
+    # load sql file
+    sql_file = runner.lastEnergyPlusSqlFile
+    if sql_file.empty?
+      runner.registerError('Cannot find last sql file.')
+      return false
+    end
+    sql_file = sql_file.get
+    model.setSqlFile(sql_file)
+    # write file: any file named 'report*.*' in the current working directory
+    # will be copied to the ./reports/ folder as 'reports/<measure_class_name>_<filename>.html'
+    File.write("./report_ruby_with.txt", "OK")
+
+    # close the sql file
+    sql_file.close
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+RubyReportingMeasureWithModelOutputRequests.new.registerWithApplication

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.rb
@@ -110,13 +110,13 @@ class RubyReportingMeasureWithModelOutputRequests < OpenStudio::Measure::Reporti
     model = runner.lastOpenStudioModel
     if model.empty?
       runner.registerError('Cannot find last model.')
-      return false
+      return result
     end
     model = model.get
 
     # use the built-in error checking (need model)
     if !runner.validateUserArguments(arguments(model), user_arguments)
-      return false
+      return result
     end
 
     # get measure arguments
@@ -126,7 +126,7 @@ class RubyReportingMeasureWithModelOutputRequests < OpenStudio::Measure::Reporti
     sql_file = runner.lastEnergyPlusSqlFile
     if sql_file.empty?
       runner.registerError('Cannot find last sql file.')
-      return false
+      return result
     end
     sql_file = sql_file.get
     model.setSqlFile(sql_file)

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>ruby_reporting_measure_with_model_output_requests</name>
   <uid>6663879f-2582-42e8-967d-b209507f1721</uid>
-  <version_id>e19b1fb5-bb69-4e22-aeba-e805359bb686</version_id>
-  <version_modified>2025-03-14T16:42:34Z</version_modified>
+  <version_id>70a45976-2ac0-43a6-9853-b6fae76f5908</version_id>
+  <version_modified>2025-03-14T16:51:16Z</version_modified>
   <xml_checksum>58F01CAA</xml_checksum>
   <class_name>RubyReportingMeasureWithModelOutputRequests</class_name>
   <display_name>Reporting Measure with Model Output Requests</display_name>
@@ -77,7 +77,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>09DAD053</checksum>
+      <checksum>1E726765</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>ruby_reporting_measure_with_model_output_requests</name>
+  <uid>6663879f-2582-42e8-967d-b209507f1721</uid>
+  <version_id>dd1da652-30c6-4364-b2ff-f0495084c519</version_id>
+  <version_modified>2025-03-14T16:33:47Z</version_modified>
+  <xml_checksum>58F01CAA</xml_checksum>
+  <class_name>RubyReportingMeasureWithModelOutputRequests</class_name>
+  <display_name>Reporting Measure with Model Output Requests</display_name>
+  <description>A new reporting measure that has a modelOutputRequests</description>
+  <modeler_description>This was added at 3.10.0</modeler_description>
+  <arguments>
+    <argument>
+      <name>report_drybulb_temp</name>
+      <display_name>Add output variables for Drybulb Temperature</display_name>
+      <description>Will add drybulb temp and report min/mix value in html.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>add_output_json</name>
+      <display_name>Request JSON output</display_name>
+      <description>Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Ruby</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.10.0</identifier>
+        <min_compatible>3.10.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>1D5BDDE8</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>ruby_reporting_measure_with_model_output_requests</name>
   <uid>6663879f-2582-42e8-967d-b209507f1721</uid>
-  <version_id>dd1da652-30c6-4364-b2ff-f0495084c519</version_id>
-  <version_modified>2025-03-14T16:33:47Z</version_modified>
+  <version_id>e19b1fb5-bb69-4e22-aeba-e805359bb686</version_id>
+  <version_modified>2025-03-14T16:42:34Z</version_modified>
   <xml_checksum>58F01CAA</xml_checksum>
   <class_name>RubyReportingMeasureWithModelOutputRequests</class_name>
   <display_name>Reporting Measure with Model Output Requests</display_name>
@@ -77,7 +77,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>1D5BDDE8</checksum>
+      <checksum>09DAD053</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.rb
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.rb
@@ -1,0 +1,93 @@
+# insert your copyright here
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+require 'erb'
+
+# start the measure
+class RubyReportingMeasureWithoutModelOutputRequests < OpenStudio::Measure::ReportingMeasure
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'Reporting Measure without Model Output Requests'
+  end
+
+  # human readable description
+  def description
+    return 'An older reporting measure that does not have modelOutputRequests'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'This is a measure that was added before 3.10.0'
+  end
+
+  # define the arguments that the user will input
+  def arguments(model = nil)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+    # bool argument to report report_drybulb_temp
+    report_drybulb_temp = OpenStudio::Measure::OSArgument.makeBoolArgument('report_drybulb_temp', true)
+    report_drybulb_temp.setDisplayName('Add output variables for Drybulb Temperature')
+    report_drybulb_temp.setDescription('Will add drybulb temp and report min/mix value in html.')
+    report_drybulb_temp.setValue(true)
+    args << report_drybulb_temp
+
+    return args
+  end
+
+  # define the outputs that the measure will create
+  def outputs
+    outs = OpenStudio::Measure::OSOutputVector.new
+
+    # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+    return outs
+  end
+
+  # return a vector of IdfObject's to request EnergyPlus objects needed by the run method
+  # Warning: Do not change the name of this method to be snake_case. The method must be lowerCamelCase.
+  def energyPlusOutputRequests(runner, user_arguments)
+    super(runner, user_arguments)  # Do **NOT** remove this line
+
+    result = OpenStudio::IdfObjectVector.new
+
+    # To use the built-in error checking we need the model...
+    # get the last model and sql file
+    model = runner.lastOpenStudioModel
+    if model.empty?
+      runner.registerError('Cannot find last model.')
+      return false
+    end
+    model = model.get
+
+    # use the built-in error checking (need model)
+    if !runner.validateUserArguments(arguments(model), user_arguments)
+      return false
+    end
+
+    # get measure arguments
+    report_drybulb_temp = runner.getBoolArgumentValue('report_drybulb_temp', user_arguments)
+
+    # load sql file
+    sql_file = runner.lastEnergyPlusSqlFile
+    if sql_file.empty?
+      runner.registerError('Cannot find last sql file.')
+      return false
+    end
+    sql_file = sql_file.get
+    model.setSqlFile(sql_file)
+    # write file: any file named 'report*.*' in the current working directory
+    # will be copied to the ./reports/ folder as 'reports/<measure_class_name>_<filename>.html'
+    File.write("./report_ruby_without.txt", "OK")
+
+    # close the sql file
+    sql_file.close
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+RubyReportingMeasureWithoutModelOutputRequests.new.registerWithApplication

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.rb
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.rb
@@ -58,13 +58,13 @@ class RubyReportingMeasureWithoutModelOutputRequests < OpenStudio::Measure::Repo
     model = runner.lastOpenStudioModel
     if model.empty?
       runner.registerError('Cannot find last model.')
-      return false
+      return result
     end
     model = model.get
 
     # use the built-in error checking (need model)
     if !runner.validateUserArguments(arguments(model), user_arguments)
-      return false
+      return result
     end
 
     # get measure arguments

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>ruby_reporting_measure_without_model_output_requests</name>
   <uid>7fe3d1eb-2118-4cac-91e3-94fd489b97af</uid>
-  <version_id>0339fec9-7f58-4e81-8239-d8423927bcdb</version_id>
-  <version_modified>2025-03-14T16:33:21Z</version_modified>
+  <version_id>e1ce6548-a004-4697-9c10-090eee9f413b</version_id>
+  <version_modified>2025-03-14T16:42:49Z</version_modified>
   <xml_checksum>58F01CAA</xml_checksum>
   <class_name>RubyReportingMeasureWithoutModelOutputRequests</class_name>
   <display_name>Reporting Measure without Model Output Requests</display_name>
@@ -57,7 +57,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>B60F2759</checksum>
+      <checksum>3605AEE1</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>ruby_reporting_measure_without_model_output_requests</name>
+  <uid>7fe3d1eb-2118-4cac-91e3-94fd489b97af</uid>
+  <version_id>0339fec9-7f58-4e81-8239-d8423927bcdb</version_id>
+  <version_modified>2025-03-14T16:33:21Z</version_modified>
+  <xml_checksum>58F01CAA</xml_checksum>
+  <class_name>RubyReportingMeasureWithoutModelOutputRequests</class_name>
+  <display_name>Reporting Measure without Model Output Requests</display_name>
+  <description>An older reporting measure that does not have modelOutputRequests</description>
+  <modeler_description>This is a measure that was added before 3.10.0</modeler_description>
+  <arguments>
+    <argument>
+      <name>report_drybulb_temp</name>
+      <display_name>Add output variables for Drybulb Temperature</display_name>
+      <description>Will add drybulb temp and report min/mix value in html.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+  </arguments>
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Ruby</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>B60F2759</checksum>
+    </file>
+  </files>
+</measure>

--- a/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
+++ b/resources/workflow/reporting_modeloutputrequests/measures/RubyReportingMeasureWithoutModelOutputRequests/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>ruby_reporting_measure_without_model_output_requests</name>
   <uid>7fe3d1eb-2118-4cac-91e3-94fd489b97af</uid>
-  <version_id>e1ce6548-a004-4697-9c10-090eee9f413b</version_id>
-  <version_modified>2025-03-14T16:42:49Z</version_modified>
+  <version_id>d07158b5-8a23-44ea-85d0-dd234c9f9cb9</version_id>
+  <version_modified>2025-03-14T16:51:24Z</version_modified>
   <xml_checksum>58F01CAA</xml_checksum>
   <class_name>RubyReportingMeasureWithoutModelOutputRequests</class_name>
   <display_name>Reporting Measure without Model Output Requests</display_name>
@@ -57,7 +57,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>3605AEE1</checksum>
+      <checksum>B3C25E43</checksum>
     </file>
   </files>
 </measure>

--- a/resources/workflow/reporting_modeloutputrequests/python.osw
+++ b/resources/workflow/reporting_modeloutputrequests/python.osw
@@ -1,0 +1,12 @@
+{
+    "weather_file": "../../Examples/compact_osw/files/srrl_2013_amy.epw",
+    "seed_file": "../example_model.osm",
+    "steps": [
+        {
+            "measure_dir_name": "PythonReportingMeasureWithModelOutputRequests"
+        },
+        {
+            "measure_dir_name": "PythonReportingMeasureWithoutModelOutputRequests"
+        }
+    ]
+}

--- a/resources/workflow/reporting_modeloutputrequests/ruby.osw
+++ b/resources/workflow/reporting_modeloutputrequests/ruby.osw
@@ -1,0 +1,12 @@
+{
+    "weather_file": "../../Examples/compact_osw/files/srrl_2013_amy.epw",
+    "seed_file": "../example_model.osm",
+    "steps": [
+        {
+            "measure_dir_name": "RubyReportingMeasureWithModelOutputRequests"
+        },
+        {
+            "measure_dir_name": "RubyReportingMeasureWithoutModelOutputRequests"
+        }
+    ]
+}

--- a/ruby/engine/RubyEngine.cpp
+++ b/ruby/engine/RubyEngine.cpp
@@ -237,6 +237,12 @@ int RubyEngine::numberOfArguments(ScriptObject& methodObject, std::string_view m
   return rb_obj_method_arity(val, method_id);
 }
 
+bool RubyEngine::hasMethod(ScriptObject& methodObject, std::string_view methodName) {
+  auto val = std::any_cast<VALUE>(methodObject.object);
+  ID method_id = rb_intern(methodName.data());
+  return rb_respond_to(val, method_id) == 1;
+}
+
 }  // namespace openstudio
 
 extern "C"

--- a/ruby/engine/RubyEngine.cpp
+++ b/ruby/engine/RubyEngine.cpp
@@ -237,10 +237,23 @@ int RubyEngine::numberOfArguments(ScriptObject& methodObject, std::string_view m
   return rb_obj_method_arity(val, method_id);
 }
 
-bool RubyEngine::hasMethod(ScriptObject& methodObject, std::string_view methodName) {
+bool RubyEngine::hasMethod(ScriptObject& methodObject, std::string_view methodName, bool overriden_only) {
   auto val = std::any_cast<VALUE>(methodObject.object);
   ID method_id = rb_intern(methodName.data());
-  return rb_respond_to(val, method_id) == 1;
+  if (rb_respond_to(val, method_id) == 0) {
+    return false;
+  }
+  if (!overriden_only) {
+    return true;
+  }
+
+  // I'd have prefered to do the equivalent of `instance_obj.method(:methodName).owner == instance_obj.class` but that is borderline impossible
+  // Instead, this is equivalent to `instance_obj.class.instance_methods(false).include?(:methodName)`
+  VALUE klass = rb_obj_class(val);
+  // include_methods_from_ancestors: false;
+  VALUE argv[1] = {Qfalse};
+  VALUE methods_without_ancestors = rb_class_instance_methods(1, argv, klass);
+  return rb_ary_includes(methods_without_ancestors, ID2SYM(method_id)) == Qtrue;
 }
 
 }  // namespace openstudio

--- a/ruby/engine/RubyEngine.hpp
+++ b/ruby/engine/RubyEngine.hpp
@@ -39,6 +39,8 @@ class RubyEngine final : public ScriptEngine
 
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) override;
 
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) override;
+
  protected:
   // convert the underlying object to the correct type, then return it as a void *
   // so the above template function can provide it back to the caller.

--- a/ruby/engine/RubyEngine.hpp
+++ b/ruby/engine/RubyEngine.hpp
@@ -39,7 +39,7 @@ class RubyEngine final : public ScriptEngine
 
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) override;
 
-  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) override;
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName, bool overriden_only) override;
 
  protected:
   // convert the underlying object to the correct type, then return it as a void *

--- a/ruby/engine/test/ReportingMeasureWithModelOutputs/measure.rb
+++ b/ruby/engine/test/ReportingMeasureWithModelOutputs/measure.rb
@@ -1,0 +1,63 @@
+# insert your copyright here
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+require 'erb'
+
+# start the measure
+class ReportingMeasureWithModelOutputs < OpenStudio::Measure::ReportingMeasure
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'ReportingMeasureWithModelOutputs'
+  end
+
+  # human readable description
+  def description
+    return 'DESCRIPTION_TEXT'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'MODELER_DESCRIPTION_TEXT'
+  end
+
+  # define the arguments that the user will input
+  def arguments(model = nil)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+    return args
+  end
+
+  # define the outputs that the measure will create
+  def outputs
+    outs = OpenStudio::Measure::OSOutputVector.new
+
+    # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+    return outs
+  end
+
+  def modelOutputRequests(model, runner, user_arguments)
+    return true
+  end
+
+  # return a vector of IdfObject's to request EnergyPlus objects needed by the run method
+  # Warning: Do not change the name of this method to be snake_case. The method must be lowerCamelCase.
+  def energyPlusOutputRequests(runner, user_arguments)
+    result = OpenStudio::IdfObjectVector.new
+
+    return result
+  end
+
+  # define what happens when the measure is run
+  def run(runner, user_arguments)
+    super(runner, user_arguments)
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+ReportingMeasureWithModelOutputs.new.registerWithApplication

--- a/ruby/engine/test/ReportingMeasureWithModelOutputs/measure.xml
+++ b/ruby/engine/test/ReportingMeasureWithModelOutputs/measure.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>reporting_measure_with_model_outputs</name>
+  <uid>3bfd478b-0575-4a4e-b347-ea3d82f66c21</uid>
+  <version_id>95038fac-6565-4c3a-be46-fd14ac12bcee</version_id>
+  <version_modified>2025-03-14T13:14:52Z</version_modified>
+  <xml_checksum>58F01CAA</xml_checksum>
+  <class_name>ReportingMeasureWithModelOutputs</class_name>
+  <display_name>ReportingMeasureWithModelOutputs</display_name>
+  <description>DESCRIPTION_TEXT</description>
+  <modeler_description>MODELER_DESCRIPTION_TEXT</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Ruby</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>811D6B05</checksum>
+    </file>
+  </files>
+</measure>

--- a/ruby/engine/test/ReportingMeasureWithoutModelOutputs/measure.rb
+++ b/ruby/engine/test/ReportingMeasureWithoutModelOutputs/measure.rb
@@ -1,0 +1,59 @@
+# insert your copyright here
+
+# see the URL below for information on how to write OpenStudio measures
+# http://nrel.github.io/OpenStudio-user-documentation/reference/measure_writing_guide/
+
+require 'erb'
+
+# start the measure
+class ReportingMeasureWithoutModelOutputs < OpenStudio::Measure::ReportingMeasure
+  # human readable name
+  def name
+    # Measure name should be the title case of the class name.
+    return 'ReportingMeasureWithoutModelOutputs'
+  end
+
+  # human readable description
+  def description
+    return 'DESCRIPTION_TEXT'
+  end
+
+  # human readable description of modeling approach
+  def modeler_description
+    return 'MODELER_DESCRIPTION_TEXT'
+  end
+
+  # define the arguments that the user will input
+  def arguments(model = nil)
+    args = OpenStudio::Measure::OSArgumentVector.new
+
+    return args
+  end
+
+  # define the outputs that the measure will create
+  def outputs
+    outs = OpenStudio::Measure::OSOutputVector.new
+
+    # this measure does not produce machine readable outputs with registerValue, return an empty list
+
+    return outs
+  end
+
+  # return a vector of IdfObject's to request EnergyPlus objects needed by the run method
+  # Warning: Do not change the name of this method to be snake_case. The method must be lowerCamelCase.
+  def energyPlusOutputRequests(runner, user_arguments)
+    result = OpenStudio::IdfObjectVector.new
+
+    return result
+  end
+
+  # define what happens when the measure is run
+  def run(runner, user_arguments)
+    super(runner, user_arguments)
+
+    return true
+  end
+end
+
+# register the measure to be used by the application
+ReportingMeasureWithoutModelOutputs.new.registerWithApplication

--- a/ruby/engine/test/ReportingMeasureWithoutModelOutputs/measure.xml
+++ b/ruby/engine/test/ReportingMeasureWithoutModelOutputs/measure.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<measure>
+  <schema_version>3.1</schema_version>
+  <name>reporting_measure_without_model_outputs</name>
+  <uid>0a873e3c-1dba-49c2-8c22-1f4e8661e74b</uid>
+  <version_id>b7c5702f-b0bd-4b6c-9ff5-53f977e68f3e</version_id>
+  <version_modified>2025-03-14T13:15:10Z</version_modified>
+  <xml_checksum>58F01CAA</xml_checksum>
+  <class_name>ReportingMeasureWithoutModelOutputs</class_name>
+  <display_name>ReportingMeasureWithoutModelOutputs</display_name>
+  <description>DESCRIPTION_TEXT</description>
+  <modeler_description>MODELER_DESCRIPTION_TEXT</modeler_description>
+  <arguments />
+  <outputs />
+  <provenances />
+  <tags>
+    <tag>Reporting.QAQC</tag>
+  </tags>
+  <attributes>
+    <attribute>
+      <name>Measure Type</name>
+      <value>ReportingMeasure</value>
+      <datatype>string</datatype>
+    </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Ruby</value>
+      <datatype>string</datatype>
+    </attribute>
+  </attributes>
+  <files>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.9.0</identifier>
+        <min_compatible>3.9.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>171A0196</checksum>
+    </file>
+  </files>
+</measure>

--- a/ruby/engine/test/RubyEngine_GTest.cpp
+++ b/ruby/engine/test/RubyEngine_GTest.cpp
@@ -183,7 +183,7 @@ TEST_F(RubyEngineFixture, hasMethod) {
     const auto scriptPath = getScriptPath(classAndDirName);
     auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
-    // TODO: this will fail, because the BASE class has it.
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests", false));  // overriden_only = false
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
   }
   {
@@ -191,6 +191,7 @@ TEST_F(RubyEngineFixture, hasMethod) {
     const auto scriptPath = getScriptPath(classAndDirName);
     auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
     EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests", false));  // overriden_only = false
     EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
   }
 }

--- a/ruby/engine/test/RubyEngine_GTest.cpp
+++ b/ruby/engine/test/RubyEngine_GTest.cpp
@@ -176,3 +176,21 @@ Traceback (most recent call last):
     },
     "stack level too deep");
 }
+
+TEST_F(RubyEngineFixture, hasMethod) {
+  {
+    const std::string classAndDirName = "ReportingMeasureWithoutModelOutputs";
+    const auto scriptPath = getScriptPath(classAndDirName);
+    auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    // TODO: this will fail, because the BASE class has it.
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
+  }
+  {
+    const std::string classAndDirName = "ReportingMeasureWithModelOutputs";
+    const auto scriptPath = getScriptPath(classAndDirName);
+    auto measureScriptObject = (*thisEngine)->loadMeasure(scriptPath, classAndDirName);
+    EXPECT_FALSE((*thisEngine)->hasMethod(measureScriptObject, "doesNotExists"));
+    EXPECT_TRUE((*thisEngine)->hasMethod(measureScriptObject, "modelOutputRequests"));
+  }
+}

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -358,6 +358,11 @@ if(BUILD_TESTING)
       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/workflow/output_test/"
     )
 
+    add_test(NAME OpenStudioCLI.test_reporting_modeloutputrequests
+      COMMAND ${Python_EXECUTABLE} -m pytest --verbose --os-cli-path $<TARGET_FILE:openstudio> "${CMAKE_CURRENT_SOURCE_DIR}/test/test_reporting_modeloutputrequests.py"
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/resources/workflow/reporting_modeloutputrequests/"
+    )
+
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/Testing/")
     add_test(NAME OpenStudioCLI.test_bcl_measure_templates
       COMMAND ${Python_EXECUTABLE} -m pytest --verbose --os-cli-path $<TARGET_FILE:openstudio> "${CMAKE_CURRENT_SOURCE_DIR}/test/test_bcl_measure_templates.py"

--- a/src/cli/test/test_reporting_modeloutputrequests.py
+++ b/src/cli/test/test_reporting_modeloutputrequests.py
@@ -1,0 +1,29 @@
+import pytest
+
+from workflow_helpers import run_workflow
+
+@pytest.mark.parametrize(
+    "language, is_labs",
+    [
+        ["ruby", False],
+        ["ruby", True],
+        # ["python", False], // Not possible
+        ["python", True],
+    ],
+)
+
+def test_reportingmeasure_model_output_requests(osclipath, language: str, is_labs: bool):
+    suffix = "labs" if is_labs else "classic"
+    base_osw_name = f"{language}.osw"
+
+    runDir, r = run_workflow(
+        osclipath=osclipath,
+        base_osw_name=base_osw_name,
+        suffix=suffix,
+        is_labs=is_labs,
+        verbose=False,
+        debug=True,
+        post_process_only=False,
+    )
+    r.check_returncode()
+    assert r.returncode == 0

--- a/src/measure/ReportingMeasure.cpp
+++ b/src/measure/ReportingMeasure.cpp
@@ -14,7 +14,7 @@
 namespace openstudio {
 namespace measure {
 
-  ReportingMeasure::ReportingMeasure() : OSMeasure(MeasureType::ReportingMeasure){};
+  ReportingMeasure::ReportingMeasure() : OSMeasure(MeasureType::ReportingMeasure) {};
 
   std::vector<OSArgument> ReportingMeasure::arguments(const openstudio::model::Model& /*model*/) const {
     return {};
@@ -26,6 +26,11 @@ namespace measure {
 
   bool ReportingMeasure::run(OSRunner& runner, const std::map<std::string, OSArgument>& /*user_arguments*/) const {
     runner.prepareForMeasureRun(*this);
+    return true;
+  }
+
+  bool ReportingMeasure::modelOutputRequests(openstudio::model::Model& /*model*/, OSRunner& /*runner*/,
+                                             const std::map<std::string, OSArgument>& /*user_arguments*/) const {
     return true;
   }
 

--- a/src/measure/ReportingMeasure.hpp
+++ b/src/measure/ReportingMeasure.hpp
@@ -55,6 +55,15 @@ namespace measure {
    *  super(runner, user_arguments). */
     virtual bool run(OSRunner& runner, const std::map<std::string, OSArgument>& user_arguments) const;
 
+    /** This method is called on all reporting measures immediately before the translation to E+ IDF.
+     *  There is an implicit contract that this method should NOT be modifying your model in a way that would produce
+     *  different results, meaning it should only add or modify reporting-related elements (eg: OutputTableSummaryReports, OutputControlFiles, etc)
+     *  but that is not going to be enforced.
+     *  If you mean to modify the model in a significant way, use a ModelMeasure.
+     */
+    virtual bool modelOutputRequests(openstudio::model::Model& model, OSRunner& runner,
+                                     const std::map<std::string, OSArgument>& user_arguments) const;
+
     /** This method is called on all reporting measures immediately before the E+
    *  simulation. The code that injects these objects into the IDF checks that
    *  only objects of allowed types are added to prevent changes that impact

--- a/src/scriptengine/ScriptEngine.hpp
+++ b/src/scriptengine/ScriptEngine.hpp
@@ -77,7 +77,11 @@ class ScriptEngine
   // issue for the underlying ScriptObject (and VALUE or PyObject), so just return the ScriptObject
   virtual ScriptObject loadMeasure(const openstudio::path& measureScriptPath, std::string_view className) = 0;
 
+  // Returns number of arguments for methodName of the object methodObject
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) = 0;
+
+  // Check if methodObject has a method called methodName
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) = 0;
 
   template <typename T>
   T getAs(ScriptObject& obj) {

--- a/src/scriptengine/ScriptEngine.hpp
+++ b/src/scriptengine/ScriptEngine.hpp
@@ -80,8 +80,8 @@ class ScriptEngine
   // Returns number of arguments for methodName of the object methodObject
   virtual int numberOfArguments(ScriptObject& methodObject, std::string_view methodName) = 0;
 
-  // Check if methodObject has a method called methodName
-  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName) = 0;
+  // Check if methodObject has a method called methodName. If overriden_only, will only look into the current subclass, not the parent ones
+  virtual bool hasMethod(ScriptObject& methodObject, std::string_view methodName, bool overriden_only = true) = 0;
 
   template <typename T>
   T getAs(ScriptObject& obj) {

--- a/src/utilities/bcl/templates/ReportingMeasure/measure.py
+++ b/src/utilities/bcl/templates/ReportingMeasure/measure.py
@@ -12,7 +12,7 @@ import openstudio
 class ReportingMeasureName(openstudio.measure.ReportingMeasure):
     """An ReportingMeasure."""
 
-    def name(self):
+    def name(self) -> str:
         """Returns the human readable name.
 
         Measure name should be the title case of the class name.
@@ -24,7 +24,7 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         """
         return "NAME_TEXT"
 
-    def description(self):
+    def description(self) -> str:
         """Human readable description.
 
         The measure description is intended for a general audience and should not assume
@@ -32,7 +32,7 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         """
         return "DESCRIPTION_TEXT"
 
-    def modeler_description(self):
+    def modeler_description(self) -> str:
         """Human readable description of modeling approach.
 
         The modeler description is intended for the energy modeler using the measure.
@@ -42,7 +42,7 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         """
         return "MODELER_DESCRIPTION_TEXT"
 
-    def arguments(self, model: openstudio.model.Model):
+    def arguments(self, model: openstudio.model.Model) -> openstudio.measure.OSArgumentVector:
         """Prepares user arguments for the measure.
 
         Measure arguments define which -- if any -- input parameters the user may set before running the measure.
@@ -52,12 +52,18 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         report_drybulb_temp = openstudio.measure.OSArgument.makeBoolArgument("report_drybulb_temp", True)
         report_drybulb_temp.setDisplayName("Add output variables for Drybulb Temperature")
         report_drybulb_temp.setDescription("Will add drybulb temp and report min/max values in html.")
-        report_drybulb_temp.setValue(True)
+        report_drybulb_temp.setDefaultValue(True)
         args.append(report_drybulb_temp)
+
+        add_output_json = openstudio.measure.OSArgument.makeBoolArgument("add_output_json", True)
+        add_output_json.setDisplayName("Request JSON output")
+        add_output_json.setDescription("Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true")
+        add_output_json.setDefaultValue(True)
+        args.append(add_output_json)
 
         return args
 
-    def outputs(self):
+    def outputs(self) -> openstudio.measure.OSOutputVector:
         """Define the outputs that the measure will create."""
         outs = openstudio.measure.OSOutputVector()
 
@@ -65,10 +71,37 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
 
         return outs
 
+    def modelOutputRequests(
+        self,
+        model: openstudio.model.Model,
+        runner: openstudio.measure.OSRunner,
+        user_arguments: openstudio.measure.OSArgumentMap,
+    ) -> bool:
+        """This method is called on all reporting measures immediately before the translation to E+ IDF.
+
+        There is an implicit contract that this method should NOT be modifying your model in a way that would produce
+        different results, meaning it should only add or modify reporting-related elements
+        (eg: OutputTableSummaryReports, OutputControlFiles, etc)
+
+        If you mean to modify the model in a significant way, use a `ModelMeasure`
+        NOTE: this method will ONLY be called if you use the C++ CLI,  not the `classic` (Ruby) one
+        """
+        if runner.getBoolArgumentValue("add_output_json", user_arguments):
+            output_json = model.getOutputJSON()
+            output_json.setOptionType("TimeSeriesAndTabular")
+            output_json.setOutputJSON(True)
+            output_json.setOutputCBOR(False)
+            output_json.setOutputMessagePack(False)
+
+        return True
+
     def energyPlusOutputRequests(
         self, runner: openstudio.measure.OSRunner, user_arguments: openstudio.measure.OSArgumentMap
-    ):
-        """Returns a vector of IdfObject's to request EnergyPlus objects needed by the run method."""
+    ) -> openstudio.IdfObjectVector:
+        """Returns a vector of IdfObject's to request EnergyPlus objects needed by the run method.
+
+        This is done after ForwardTranslation to IDF, and there is a list of accepted objects.
+        """
         super().energyPlusOutputRequests(runner, user_arguments)  # Do **NOT** remove this line
 
         result = openstudio.IdfObjectVector()
@@ -98,7 +131,7 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         self,
         runner: openstudio.measure.OSRunner,
         user_arguments: openstudio.measure.OSArgumentMap,
-    ):
+    ) -> bool:
         """Defines what happens when the measure is run."""
         super().run(runner, user_arguments)
 

--- a/src/utilities/bcl/templates/ReportingMeasure/measure.py
+++ b/src/utilities/bcl/templates/ReportingMeasure/measure.py
@@ -111,13 +111,13 @@ class ReportingMeasureName(openstudio.measure.ReportingMeasure):
         model = runner.lastOpenStudioModel()
         if not model.is_initialized():
             runner.registerError("Cannot find last model.")
-            return False
+            return result
 
         model = model.get()
 
         # use the built-in error checking
         if not runner.validateUserArguments(self.arguments(model), user_arguments):
-            return False
+            return result
 
         if runner.getBoolArgumentValue("report_drybulb_temp", user_arguments):
             request = openstudio.IdfObject.load(

--- a/src/utilities/bcl/templates/ReportingMeasure/measure.rb
+++ b/src/utilities/bcl/templates/ReportingMeasure/measure.rb
@@ -84,13 +84,13 @@ class ReportingMeasureName < OpenStudio::Measure::ReportingMeasure
     model = runner.lastOpenStudioModel
     if model.empty?
       runner.registerError('Cannot find last model.')
-      return false
+      return result
     end
     model = model.get
 
     # use the built-in error checking
     if !runner.validateUserArguments(arguments(model), user_arguments)
-      return false
+      return result
     end
 
     # NOTE: this should rather be done in modelOutputRequests

--- a/src/utilities/bcl/templates/ReportingMeasure/measure.rb
+++ b/src/utilities/bcl/templates/ReportingMeasure/measure.rb
@@ -31,8 +31,14 @@ class ReportingMeasureName < OpenStudio::Measure::ReportingMeasure
     report_drybulb_temp = OpenStudio::Measure::OSArgument.makeBoolArgument('report_drybulb_temp', true)
     report_drybulb_temp.setDisplayName('Add output variables for Drybulb Temperature')
     report_drybulb_temp.setDescription('Will add drybulb temp and report min/mix value in html.')
-    report_drybulb_temp.setValue(true)
+    report_drybulb_temp.setDefaultValue(true)
     args << report_drybulb_temp
+
+    add_output_json = OpenStudio::Measure::OSArgument.makeBoolArgument('add_output_json', true)
+    add_output_json.setDisplayName('Request JSON output')
+    add_output_json.setDescription('Will add Output:JSON with TimeSeriesAndTabular and set Output JSON to true')
+    add_output_json.setDefaultValue(true)
+    args << add_output_json
 
     return args
   end
@@ -46,8 +52,28 @@ class ReportingMeasureName < OpenStudio::Measure::ReportingMeasure
     return outs
   end
 
+  # This method is called on all reporting measures immediately before the translation to E+ IDF
+  # There is an implicit contract that this method should NOT be modifying your model in a way that would produce
+  # different results, meaning it should only add or modify reporting-related elements
+  # (eg: OutputTableSummaryReports, OutputControlFiles, etc)
+  # If you mean to modify the model in a significant way, use a `ModelMeasure`
+  # NOTE: this method will ONLY be called if you use the C++ CLI, not the `classic` (Ruby) one
+  def modelOutputRequests(model, runner, user_arguments)
+    if runner.getBoolArgumentValue('add_output_json', user_arguments)
+      output_json = model.getOutputJSON
+      output_json.setOptionType('TimeSeriesAndTabular')
+      output_json.setOutputJSON(true)
+      output_json.setOutputCBOR(false)
+      output_json.setOutputMessagePack(false)
+    end
+
+    return true
+  end
+
   # return a vector of IdfObject's to request EnergyPlus objects needed by the run method
   # Warning: Do not change the name of this method to be snake_case. The method must be lowerCamelCase.
+  # This is done after ForwardTranslation to IDF, and there is a list of
+  # accepted objects
   def energyPlusOutputRequests(runner, user_arguments)
     super(runner, user_arguments)  # Do **NOT** remove this line
 
@@ -67,6 +93,7 @@ class ReportingMeasureName < OpenStudio::Measure::ReportingMeasure
       return false
     end
 
+    # NOTE: this should rather be done in modelOutputRequests
     if runner.getBoolArgumentValue('report_drybulb_temp', user_arguments)
       request = OpenStudio::IdfObject.load('Output:Variable,,Site Outdoor Air Drybulb Temperature,Hourly;').get
       result << request

--- a/src/workflow/OSWorkflow.hpp
+++ b/src/workflow/OSWorkflow.hpp
@@ -124,7 +124,15 @@ class OSWorkflow
 
   void initializeWeatherFileFromOSW();
   void updateLastWeatherFileFromModel();
-  void applyMeasures(MeasureType measureType, bool energyplus_output_requests = false);
+
+  enum class ApplyMeasureType
+  {
+    Regular = 0,
+    ModelOutputRequests,
+    EnergyPlusOutputRequest
+  };
+
+  void applyMeasures(MeasureType measureType, ApplyMeasureType = ApplyMeasureType::Regular);
   static void applyArguments(measure::OSArgumentMap& argumentMap, const std::string& argumentName, const openstudio::Variant& argumentValue);
   void saveOSMToRootDirIfDebug();
   void saveIDFToRootDirIfDebug();

--- a/src/workflow/RunEnergyPlusMeasures.cpp
+++ b/src/workflow/RunEnergyPlusMeasures.cpp
@@ -19,7 +19,7 @@ void OSWorkflow::runEnergyPlusMeasures() {
   // Weather file is handled in runInitialization
 
   LOG(Info, "Beginning to execute EnergyPlus Measures.");
-  applyMeasures(MeasureType::EnergyPlusMeasure, false);
+  applyMeasures(MeasureType::EnergyPlusMeasure, ApplyMeasureType::Regular);
   LOG(Info, "Finished applying EnergyPlus Measures.");
 
   communicateMeasureAttributes();

--- a/src/workflow/RunOpenStudioMeasures.cpp
+++ b/src/workflow/RunOpenStudioMeasures.cpp
@@ -19,8 +19,12 @@ void OSWorkflow::runOpenStudioMeasures() {
   // Weather file is handled in runInitialization
 
   LOG(Info, "Beginning to execute OpenStudio Measures");
-  applyMeasures(MeasureType::ModelMeasure, false);
+  applyMeasures(MeasureType::ModelMeasure, ApplyMeasureType::Regular);
   LOG(Info, "Finished applying OpenStudio Measures.");
+
+  LOG(Info, "Beginning to execute Reporting Measures's Model Output Requests");
+  applyMeasures(MeasureType::ReportingMeasure, ApplyMeasureType::ModelOutputRequests);
+  LOG(Info, "Finished applying Reporting Measures's Model Output Requests.")
 
   // Save final OSM
   if (!workflowJSON.runOptions()->fast()) {

--- a/src/workflow/RunPreProcess.cpp
+++ b/src/workflow/RunPreProcess.cpp
@@ -43,10 +43,9 @@ void OSWorkflow::runPreProcess() {
   }
 
   // Add any EnergyPlus Output Requests from Reporting Measures
-  LOG(Info, "Beginning to collect output requests from Reporting measures.");
-  const bool energyplus_output_requests = true;
-  applyMeasures(MeasureType::ReportingMeasure, energyplus_output_requests);
-  LOG(Info, "Finished collecting output requests from Reporting measures.");
+  LOG(Info, "Beginning to collect EnergyPlus output requests from Reporting measures.");
+  applyMeasures(MeasureType::ReportingMeasure, ApplyMeasureType::EnergyPlusOutputRequest);
+  LOG(Info, "Finished collecting EnergyPlus output requests from Reporting measures.");
 
   // Skip the pre-processor if halted
   if (runner.halted()) {

--- a/src/workflow/RunReportingMeasures.cpp
+++ b/src/workflow/RunReportingMeasures.cpp
@@ -54,7 +54,7 @@ void OSWorkflow::runReportingMeasures() {
   }
 
   LOG(Info, "Beginning to execute Reporting Measures.");
-  applyMeasures(MeasureType::ReportingMeasure, false);
+  applyMeasures(MeasureType::ReportingMeasure, ApplyMeasureType::Regular);
   LOG(Info, "Finished applying Reporting Measures.");
 
   communicateMeasureAttributes();


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4830

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
