### PR TITLE
Fix #5307 - DefrostEnergyInputRatioModifierFunctionofTemperatureCurve is orphaned when AirConditionerVariableRefrigerantFlow is removed

### DIFF
--- a/src/model/AirConditionerVariableRefrigerantFlow.cpp
+++ b/src/model/AirConditionerVariableRefrigerantFlow.cpp
@@ -1593,6 +1593,11 @@ namespace model {
         result.push_back(curve.get());
       }
 
+      curve = defrostEnergyInputRatioModifierFunctionofTemperatureCurve();
+      if (curve) {
+        result.push_back(curve.get());
+      }
+
       curve = heatRecoveryCoolingCapacityModifierCurve();
       if (curve) {
         result.push_back(curve.get());

--- a/src/model/test/AirConditionerVariableRefrigerantFlow_GTest.cpp
+++ b/src/model/test/AirConditionerVariableRefrigerantFlow_GTest.cpp
@@ -25,6 +25,7 @@
 #include "../CurveQuadratic_Impl.hpp"
 #include "../CurveExponent.hpp"
 #include "../CurveExponent_Impl.hpp"
+#include "../TableLookup.hpp"
 #include "../ModelObjectList.hpp"
 #include "../ModelObjectList_Impl.hpp"
 #include "../FanOnOff.hpp"
@@ -383,5 +384,31 @@ TEST_F(ModelFixture, AirConditionerVariableRefrigerantFlow_MatchingCoilTypes) {
     EXPECT_EQ(1, vrf.terminals().size());
     EXPECT_FALSE(vrf.addTerminal(vrfTerminal));
     EXPECT_EQ(1, vrf.terminals().size());
+  }
+}
+
+TEST_F(ModelFixture, AirConditionerVariableRefrigerantFlow_RemoveCurves) {
+  // Test for #5307
+  {
+    Model model;
+    AirConditionerVariableRefrigerantFlow vrf(model);
+    const size_t expected_size = model.getModelObjects<Curve>().size();
+    EXPECT_FALSE(vrf.defrostEnergyInputRatioModifierFunctionofTemperatureCurve());
+    CurveBiquadratic defrostCurve(model);
+    EXPECT_TRUE(vrf.setDefrostEnergyInputRatioModifierFunctionofTemperatureCurve(defrostCurve));
+    EXPECT_EQ(expected_size + 1, model.getModelObjects<Curve>().size());
+    vrf.remove();
+    EXPECT_EQ(0, model.getModelObjects<Curve>().size());
+  }
+  {
+    Model model;
+    AirConditionerVariableRefrigerantFlow vrf(model);
+    const size_t expected_size = model.getModelObjects<Curve>().size();
+    EXPECT_FALSE(vrf.defrostEnergyInputRatioModifierFunctionofTemperatureCurve());
+    TableLookup defrostCurve(model);
+    EXPECT_TRUE(vrf.setDefrostEnergyInputRatioModifierFunctionofTemperatureCurve(defrostCurve));
+    EXPECT_EQ(expected_size + 1, model.getModelObjects<Curve>().size());
+    vrf.remove();
+    EXPECT_EQ(0, model.getModelObjects<Curve>().size());
   }
 }


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5307 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Model API Changes / Additions
 - [x] Model API methods are tested (in `src/model/test`)

**Labels:**

 - [x] If change to an IDD file, add the label `IDDChange`
 - [x] If breaking existing API, add the label `APIChange`
 - [x] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
