### PR TITLE
Fix #4994 - Old materials OSC (< 0.7.4) cannot be loaded anymore

### DIFF
--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -480,6 +480,8 @@ namespace osversion {
     auto start = m_map.find(startVersion);
     if (start != m_map.end()) {
 
+      bool is_component_update_needed = false;  // To avoid constantly comparing VersionString
+
       std::string translatedIdf;
       VersionString lastVersion("0.0.0");
       boost::optional<IddFileAndFactoryWrapper> oIddFile;
@@ -514,7 +516,8 @@ namespace osversion {
         return;
       }
       IdfFile idfFile = *oIdfFile;
-      if (m_isComponent && lastVersion > VersionString(0, 7, 4)) {
+      if (m_isComponent && (is_component_update_needed || (lastVersion > VersionString(0, 7, 4)))) {
+        is_component_update_needed = true;
         updateComponentData(idfFile);
       }
       m_map[oIdfFile->version()] = idfFile;

--- a/src/osversion/VersionTranslator.cpp
+++ b/src/osversion/VersionTranslator.cpp
@@ -514,7 +514,7 @@ namespace osversion {
         return;
       }
       IdfFile idfFile = *oIdfFile;
-      if (m_isComponent) {
+      if (m_isComponent && lastVersion > VersionString(0, 7, 4)) {
         updateComponentData(idfFile);
       }
       m_map[oIdfFile->version()] = idfFile;

--- a/src/osversion/test/0_7_0/Brick_Fired_Clay_4_in_130_lb_ft3.osc
+++ b/src/osversion/test/0_7_0/Brick_Fired_Clay_4_in_130_lb_ft3.osc
@@ -1,0 +1,25 @@
+
+
+OS:Material,
+  Brick - Fired Clay - 4 in. - 130 lb/ft3,  ! Name
+  MediumRough,              ! Roughness
+  0.1016,                   ! Thickness {m}
+  1.02,                     ! Conductivity {W/m-K}
+  2082.40023861482,         ! Density {kg/m3}
+  790;                      ! Specific Heat {J/kg-K}
+
+OS:ComponentData:Tags,
+  OS:ComponentData 1;       ! ComponentData Name
+
+OS:ComponentData,
+  OS:ComponentData 1,       ! Name
+  {294a1c0c-f7a1-4ee9-88cc-1c117e4f5a64},  ! UUID
+  {8184c6c0-7b09-4329-8934-b2c966ee1338},  ! Version UUID
+  ,                         ! Description
+  ,                         ! Fidelity Level
+  OS_Material,              ! Type of Object 1
+  Brick - Fired Clay - 4 in. - 130 lb/ft3;  ! Name of Object 1
+
+OS:ComponentData:Attributes,
+  OS:ComponentData 1;       ! ComponentData Name
+


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #4994

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
