### PR TITLE
Fix #5385 - add WorkflowJSON::setRootDir(path&) and setRunDir(path&)

### DIFF
--- a/src/utilities/filetypes/WorkflowJSON.cpp
+++ b/src/utilities/filetypes/WorkflowJSON.cpp
@@ -29,6 +29,8 @@ namespace detail {
 
     if (exists(result)) {
       result = boost::filesystem::canonical(result);
+    } else {
+      result = boost::filesystem::weakly_canonical(result);
     }
 
     return result;
@@ -353,6 +355,19 @@ namespace detail {
     return result;
   }
 
+  bool WorkflowJSON_Impl::setRootDir(const openstudio::path& path) {
+    if (path.is_relative()) {
+      auto canonical_path = canonicalOrAbsolute(path);
+      if (!pathBeginsWith(m_oswDir, canonical_path)) {
+        LOG(Warn, "Resulting rootDir '" << canonical_path << "' is not a descendant of oswDir: '" << m_oswDir << "'");
+      }
+    }
+
+    m_value["root"] = toString(path);
+    onUpdate();
+    return true;
+  }
+
   openstudio::path WorkflowJSON_Impl::runDir() const {
     Json::Value defaultValue("./run");
     Json::Value runDirectory = m_value.get("run_directory", defaultValue);
@@ -365,6 +380,19 @@ namespace detail {
       return canonicalOrAbsolute(result, absoluteRootDir());
     }
     return result;
+  }
+
+  bool WorkflowJSON_Impl::setRunDir(const openstudio::path& path) {
+    if (path.is_relative()) {
+      auto canonical_path = canonicalOrAbsolute(path);
+      if (!pathBeginsWith(m_oswDir, canonical_path)) {
+        LOG(Warn, "Resulting runDir '" << canonical_path << "' is not a descendant of oswDir: '" << m_oswDir << "'");
+      }
+    }
+
+    m_value["run_directory"] = toString(path);
+    onUpdate();
+    return true;
   }
 
   openstudio::path WorkflowJSON_Impl::outPath() const {
@@ -1051,12 +1079,20 @@ openstudio::path WorkflowJSON::absoluteRootDir() const {
   return getImpl<detail::WorkflowJSON_Impl>()->absoluteRootDir();
 }
 
+bool WorkflowJSON::setRootDir(const openstudio::path& path) {
+  return getImpl<detail::WorkflowJSON_Impl>()->setRootDir(path);
+}
+
 openstudio::path WorkflowJSON::runDir() const {
   return getImpl<detail::WorkflowJSON_Impl>()->runDir();
 }
 
 openstudio::path WorkflowJSON::absoluteRunDir() const {
   return getImpl<detail::WorkflowJSON_Impl>()->absoluteRunDir();
+}
+
+bool WorkflowJSON::setRunDir(const openstudio::path& path) {
+  return getImpl<detail::WorkflowJSON_Impl>()->setRunDir(path);
 }
 
 openstudio::path WorkflowJSON::outPath() const {

--- a/src/utilities/filetypes/WorkflowJSON.hpp
+++ b/src/utilities/filetypes/WorkflowJSON.hpp
@@ -138,9 +138,15 @@ class UTILITIES_API WorkflowJSON
   openstudio::path rootDir() const;
   openstudio::path absoluteRootDir() const;
 
+  /** Sets the rootDir */
+  bool setRootDir(const openstudio::path& path);
+
   /** Returns the run directory, default value is './run'. Evaluated relative to rootDir if not absolute. */
   openstudio::path runDir() const;
   openstudio::path absoluteRunDir() const;
+
+  /** Sets the runDir */
+  bool setRunDir(const openstudio::path& path);
 
   /** Returns the path to write output OSW, default value is 'out.osw'. Evaluated relative to oswDir to ensure relative paths remain valid. */
   openstudio::path outPath() const;

--- a/src/utilities/filetypes/WorkflowJSON_Impl.hpp
+++ b/src/utilities/filetypes/WorkflowJSON_Impl.hpp
@@ -89,9 +89,12 @@ namespace detail {
 
     openstudio::path rootDir() const;
     openstudio::path absoluteRootDir() const;
+    bool setRootDir(const openstudio::path& path);
 
     openstudio::path runDir() const;
     openstudio::path absoluteRunDir() const;
+
+    bool setRunDir(const openstudio::path& path);
 
     openstudio::path outPath() const;
     openstudio::path absoluteOutPath() const;

--- a/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
+++ b/src/utilities/filetypes/test/WorkflowJSON_GTest.cpp
@@ -1483,3 +1483,26 @@ TEST(Filetypes, WorkflowJSON_ValidateMeasures_WrongOrder) {
 
   EXPECT_EQ("OpenStudio measure 'FakeModelMeasure' called after Energyplus simulation.", sink.logMessages()[0].logMessage());
 }
+
+TEST(Filetypes, WorkflowJSON_rootDir) {
+  auto p = resourcesPath() / toPath("utilities/Filetypes/full.osw");
+  WorkflowJSON w(p);
+  EXPECT_EQ(p, w.oswPath().get());
+  EXPECT_EQ(p.parent_path(), w.oswDir());
+  EXPECT_EQ(toPath("../.."), w.rootDir());
+  EXPECT_EQ(w.oswDir().parent_path().parent_path(), w.absoluteRootDir());
+  EXPECT_EQ(toPath("./run"), w.runDir());
+  EXPECT_EQ(w.oswDir().parent_path().parent_path() / "run", w.absoluteRunDir());
+
+  EXPECT_TRUE(w.setRootDir("../"));
+  EXPECT_EQ(toPath(".."), w.rootDir());
+  EXPECT_EQ(w.oswDir().parent_path(), w.absoluteRootDir());
+  EXPECT_EQ(toPath("./run"), w.runDir());
+  EXPECT_EQ(w.oswDir().parent_path() / "run", w.absoluteRunDir());
+
+  EXPECT_TRUE(w.setRunDir("../run"));
+  EXPECT_EQ(toPath(".."), w.rootDir());
+  EXPECT_EQ(w.oswDir().parent_path(), w.absoluteRootDir());
+  EXPECT_EQ(toPath("../run"), w.runDir());
+  EXPECT_EQ(w.oswDir().parent_path().parent_path() / "run", w.absoluteRunDir());
+}

--- a/src/workflow/OSWorkflow.cpp
+++ b/src/workflow/OSWorkflow.cpp
@@ -273,7 +273,7 @@ bool OSWorkflow::run() {
     }
   }
   if (!openstudio::filesystem::is_directory(runDirPath)) {
-    openstudio::filesystem::create_directory(runDirPath);
+    openstudio::filesystem::create_directories(runDirPath);
   }
 
   FileLogSink logFile(runDirPath / "run.log");

--- a/src/workflow/RunInitialization.cpp
+++ b/src/workflow/RunInitialization.cpp
@@ -36,7 +36,7 @@ void OSWorkflow::runInitialization() {
         openstudio::filesystem::remove_all(generatedFilesDir);
       }
       LOG(Debug, "Creating generated files directory: " << generatedFilesDir);
-      openstudio::filesystem::create_directory(generatedFilesDir);
+      openstudio::filesystem::create_directories(generatedFilesDir);
 
       // insert the generated files directory in the first spot so all generated ExternalFiles go here
       auto fps = workflowJSON.filePaths();


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #5385
 -  add WorkflowJSON::setRootDir(path&) and setRunDir(path&)

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
