### PR TITLE
Fix #5388 - --bundle options not working for CLI in docker-openstudio, possibly OS itself + Fix #5190 - Don't pick up system gem in CLI

### DIFF
--- a/ruby/bindings/InitRubyBindings.cpp
+++ b/ruby/bindings/InitRubyBindings.cpp
@@ -662,6 +662,10 @@ end)ruby";
     // in hash.c there's lot of env-related functions, but all private, aside from rb_env_clear();
     const std::string clearEnvs = R"ruby(
 ENV.reject! { |k, _| ['GEM', 'BUNDLE'].any? { |x| k.start_with?(x) } }
+# No env variable isn't the same as empty. Gem::PathSupport does stuff like @home = env["GEM_HOME"] || Gem.default_dir
+ENV['GEM_HOME'] = ''
+ENV['GEM_PATH'] = ''
+ENV['GEM_SPEC_CACHE'] = ''
   )ruby";
 
     openstudio::evalString(clearEnvs);
@@ -749,6 +753,21 @@ ENV.reject! { |k, _| ['GEM', 'BUNDLE'].any? { |x| k.start_with?(x) } }
     end
   end
 
+#  module Gem
+#    def self.default_dir
+#      @default_dir = ""
+#    end
+#
+#    def self.find_home
+#      ""
+#    end
+#
+#    def self.default_specifications_dir
+#      @default_specifications_dir = ""
+#    end
+#  end
+#
+  Gem.clear_paths
   Gem::Deprecate.skip = true
 
   # find all the embedded gems

--- a/ruby/bindings/InitRubyBindings.cpp
+++ b/ruby/bindings/InitRubyBindings.cpp
@@ -630,7 +630,7 @@ module IRB # :nodoc:
 
     @CONF[:IRB_RC].call(irb.context) if @CONF[:IRB_RC]
     # puts @CONF[:PROMPT_MODE]
-    os_version = "3.8.0" # OpenStudio::openStudioVersion
+    os_version = "3.10.0" # OpenStudio::openStudioVersion
     @CONF[:PROMPT][:OPENSTUDIO] = {
       :PROMPT_I=>"(os #{os_version}) :%03n > ",
       :PROMPT_S=>"(os #{os_version}) :%03n%l> ",
@@ -884,53 +884,53 @@ ENV.reject! { |k, _| ['GEM', 'BUNDLE'].any? { |x| k.start_with?(x) } }
     RbConfig::CONFIG['arch'] = 'x64-mingw32'
   end
 
-    # require bundler
-    # have to do some forward declaration and pre-require to get around autoload cycles
-    require 'bundler/errors'
-    #require 'bundler/environment_preserver'
-    require 'bundler/plugin'
-    #require 'bundler/rubygems_ext'
-    require 'bundler/rubygems_integration'
+  # require bundler
+  # have to do some forward declaration and pre-require to get around autoload cycles
+  require 'bundler/errors'
+  #require 'bundler/environment_preserver'
+  require 'bundler/plugin'
+  #require 'bundler/rubygems_ext'
+  require 'bundler/rubygems_integration'
 
-    # Global list, to be populated below
-    $ignore_native_gem_names = []
+  # Global list, to be populated below
+  $ignore_native_gem_names = []
 
-    module Bundler
-      class RubygemsIntegration
+  module Bundler
+    class RubygemsIntegration
 
-        alias :ori_spec_missing_extensions? :spec_missing_extensions?
+      alias :ori_spec_missing_extensions? :spec_missing_extensions?
 
-        def spec_missing_extensions?(spec, default = true)
+      def spec_missing_extensions?(spec, default = true)
 
-          # This avoids getting an annoying message for no reason
-          if $ignore_native_gem_names.any? {|name| name == spec.name }
-            return false
-          end
-
-          return ori_spec_missing_extensions?(spec, default)
+        # This avoids getting an annoying message for no reason
+        if $ignore_native_gem_names.any? {|name| name == spec.name }
+          return false
         end
+
+        return ori_spec_missing_extensions?(spec, default)
       end
     end
+  end
 
-    require 'bundler/version'
-    require 'bundler/ruby_version'
-    #require 'bundler/constants'
-    #require 'bundler/current_ruby'
-    require 'bundler/gem_helpers'
-    #require 'bundler/plugin'
-    require 'bundler/source'
-    require 'bundler/definition'
-    require 'bundler/dsl'
-    require 'bundler/uri_credentials_filter'
-    require 'bundler/uri_normalizer'
-    require 'bundler/index'
-    require 'bundler/digest'
-    require 'bundler/source/git'
-    require 'bundler/source/git/git_proxy'
-    require 'bundler/match_remote_metadata'
-    require 'bundler/remote_specification'
-    require 'bundler/stub_specification'
-    require 'bundler'
+  require 'bundler/version'
+  require 'bundler/ruby_version'
+  #require 'bundler/constants'
+  #require 'bundler/current_ruby'
+  require 'bundler/gem_helpers'
+  #require 'bundler/plugin'
+  require 'bundler/source'
+  require 'bundler/definition'
+  require 'bundler/dsl'
+  require 'bundler/uri_credentials_filter'
+  require 'bundler/uri_normalizer'
+  require 'bundler/index'
+  require 'bundler/digest'
+  require 'bundler/source/git'
+  require 'bundler/source/git/git_proxy'
+  require 'bundler/match_remote_metadata'
+  require 'bundler/remote_specification'
+  require 'bundler/stub_specification'
+  require 'bundler'
 
   begin
     # activate bundled gems

--- a/ruby/bindings/InitRubyBindings.cpp
+++ b/ruby/bindings/InitRubyBindings.cpp
@@ -965,16 +965,17 @@ ENV.reject! { |k, _| ['GEM', 'BUNDLE'].any? { |x| k.start_with?(x) } }
     locked_specs = Bundler.definition.instance_variable_get(:@locked_specs)
 
     embedded_gems_to_activate.each do |spec|
-      $logger.trace "embedded_gems_to_activate.each: spec: #{spec.name}"
       if spec.extensions.empty?
-        $logger.trace "Spec #{spec.name} has no extensions"
+        # $logger.trace "Spec #{spec.name} has no extensions"
         next
       end
 
       unless locked_specs.any? {|locked_spec| locked_spec.name == spec.name}
-        $logger.trace "#{spec.name} not in locked_specs"
+        # $logger.trace "#{spec.name} not in locked_specs"
         next
       end
+
+      $logger.trace "embedded_gems_to_activate.each: spec: #{spec.name}"
 
       dep_to_requirements = {}
       locked_specs.each do |locked_spec|

--- a/ruby/engine/embedded_help.rb
+++ b/ruby/engine/embedded_help.rb
@@ -721,7 +721,11 @@ def require_rb_config_with_patch
   s = EmbeddedScripting::getFileAsString(path_with_extension)
   s = OpenStudio::preprocess_ruby_script(s)
 
-  s = s.gsub(/CONFIG\["prefix"\] = .*/, 'CONFIG["prefix"] = ":"').gsub(/CONFIG\["libdir"\] = .*/, 'CONFIG["libdir"] = "$(prefix)"')
+  s = (
+    s.gsub(/CONFIG\["prefix"\] = .*/, 'CONFIG["prefix"] = ":"')
+     .gsub(/CONFIG\["libdir"\] = .*/, 'CONFIG["libdir"] = "$(prefix)"')
+     .gsub(/CONFIG\["rubylibprefix"\] = .*/, 'CONFIG["rubylibprefix"] = "$(libdir)/$(RUBY_BASE_NAME)"') # win32 only
+  )
 
   result = Kernel::eval(s, BINDING, path_with_extension)
 

--- a/ruby/engine/embedded_help.rb
+++ b/ruby/engine/embedded_help.rb
@@ -94,6 +94,7 @@ module Kernel
   # puts $LOAD_PATH
 
   # TODO: double check and update platform-specific includes
+  $LOAD_PATH.clear
   $LOAD_PATH << ':'
   $LOAD_PATH << ":/ruby/site_ruby/#{RUBY_V}"
   $LOAD_PATH << ":/ruby/site_ruby/#{RUBY_V}/#{RUBY_PLATFORM}"

--- a/src/cli/test/bundle_native_embedded/Gemfile
+++ b/src/cli/test/bundle_native_embedded/Gemfile
@@ -6,3 +6,5 @@ gem 'rubocop', '1.63.4'
 # Our CLI has json 2.6.3, which satisfies this version
 # racc is also in our CLI
 gem 'rexml', '3.2.5' # Avoid strscan native dep
+
+gem 'rubocop-ast', '1.42.0' # rubocop-ast added the prism (native) dependency recently (1.43.0)


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #5388
 - Fixes #5190 

I am extremely unhappy with what I came up with, but that's the result of a day of hitting the same wall.

I'm not even 100% sure this fixes all corner cases yet.

We ought to remove the embedded filesystem.


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
