### PR TITLE
#5398 - Workarounds to let OpenStudio build with recent clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,7 @@ if(UNIX)
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     # TODO: workaround for #5398, remove when updating boost
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion") 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion -Wno-deprecated-declarations")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,8 @@ if(UNIX)
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     # TODO: workaround for #5398, remove when updating boost
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion -Wno-deprecated-declarations")
+    AddCXXFlagIfSupported(-Wno-enum-constexpr-conversion COMPILER_SUPPORTS_enum_constexpr_conversion) # Clang 16.0+ and Apple Clang 15+ only
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,8 @@ if(UNIX)
   # Note: CMAKE_CXX_STANDARD (with no extensions) already sets -std=c++17 (or std=c++1z).
   if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    # TODO: workaround for #5398, remove when updating boost
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion") 
   endif()
 endif()
 

--- a/dependencies/cpprestsdk_char_traits_workaround.hpp
+++ b/dependencies/cpprestsdk_char_traits_workaround.hpp
@@ -1,0 +1,88 @@
+#ifndef CPPRESTSDK_CHAR_TRAITS_WORKAROUND
+#define CPPRESTSDK_CHAR_TRAITS_WORKAROUND
+
+// https://github.com/microsoft/cpprestsdk/issues/1812
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace std {
+template <>
+struct char_traits<uint8_t>
+{
+  using char_type = uint8_t;
+  using int_type = unsigned int;
+  using off_type = std::streamoff;
+  using pos_type = std::streampos;
+  using state_type = std::mbstate_t;
+
+  static void assign(char_type& c1, const char_type& c2) noexcept {
+    c1 = c2;
+  }
+
+  static bool eq(char_type c1, char_type c2) noexcept {
+    return c1 == c2;
+  }
+
+  static bool lt(char_type c1, char_type c2) noexcept {
+    return c1 < c2;
+  }
+
+  static int compare(const char_type* s1, const char_type* s2, std::size_t n) noexcept {
+    return std::memcmp(s1, s2, n);
+  }
+
+  static std::size_t length(const char_type* s) noexcept {
+    const char_type* p = s;
+    while (*p != 0)
+      ++p;
+    return p - s;
+  }
+
+  static const char_type* find(const char_type* s, std::size_t n, const char_type& a) noexcept {
+    for (std::size_t i = 0; i < n; ++i) {
+      if (eq(s[i], a)) {
+        return s + i;
+      }
+    }
+
+    return nullptr;
+  }
+
+  static char_type* move(char_type* s1, const char_type* s2, std::size_t n) noexcept {
+    return static_cast<char_type*>(std::memmove(s1, s2, n));
+  }
+
+  static char_type* copy(char_type* s1, const char_type* s2, std::size_t n) noexcept {
+    return static_cast<char_type*>(std::memcpy(s1, s2, n));
+  }
+
+  static char_type* assign(char_type* s, std::size_t n, char_type a) noexcept {
+    std::fill_n(s, n, a);
+    return s;
+  }
+
+  static int_type not_eof(int_type c) noexcept {
+    return c == eof() ? ~eof() : c;
+  }
+
+  static char_type to_char_type(int_type c) noexcept {
+    return static_cast<char_type>(c);
+  }
+
+  static int_type to_int_type(char_type c) noexcept {
+    return static_cast<int_type>(c);
+  }
+
+  static bool eq_int_type(int_type c1, int_type c2) noexcept {
+    return c1 == c2;
+  }
+
+  static int_type eof() noexcept {
+    return static_cast<int_type>(-1);
+  }
+};
+}  // namespace std
+
+#endif  // ifndef CPPRESTSDK_CHAR_TRAITS_WORKAROUND

--- a/src/cli/MeasureManager.hpp
+++ b/src/cli/MeasureManager.hpp
@@ -21,6 +21,9 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #endif
+#if __APPLE__
+#  include "../../dependencies/cpprestsdk_char_traits_workaround.hpp"
+#endif
 #define _TURN_OFF_PLATFORM_STRING  // cpprestsdk has an ugly macro U() that makes fmt break...
 #include <cpprest/http_listener.h>
 #if (defined(__GNUC__))

--- a/src/nano/nano_signal_slot.hpp
+++ b/src/nano/nano_signal_slot.hpp
@@ -37,7 +37,7 @@ class Signal<RT(Args...)> : private Observer
 
   template <typename L>
   void connect(L* instance) {
-    Observer::insert(Delegate::template bind<L>(instance), this);
+    Observer::insert(Delegate::bind(instance), this);
   }
   template <typename L>
   void connect(L& instance) {
@@ -71,7 +71,7 @@ class Signal<RT(Args...)> : private Observer
 
   template <typename L>
   void disconnect(L* instance) {
-    Observer::remove(Delegate::template bind<L>(instance), this);
+    Observer::remove(Delegate::bind(instance), this);
   }
   template <typename L>
   void disconnect(L& instance) {

--- a/src/nano/nano_signal_slot.hpp
+++ b/src/nano/nano_signal_slot.hpp
@@ -37,7 +37,7 @@ class Signal<RT(Args...)> : private Observer
 
   template <typename L>
   void connect(L* instance) {
-    Observer::insert(Delegate::template bind(instance), this);
+    Observer::insert(Delegate::template bind<L>(instance), this);
   }
   template <typename L>
   void connect(L& instance) {
@@ -71,7 +71,7 @@ class Signal<RT(Args...)> : private Observer
 
   template <typename L>
   void disconnect(L* instance) {
-    Observer::remove(Delegate::template bind(instance), this);
+    Observer::remove(Delegate::template bind<L>(instance), this);
   }
   template <typename L>
   void disconnect(L& instance) {

--- a/src/utilities/bcl/RemoteBCL.hpp
+++ b/src/utilities/bcl/RemoteBCL.hpp
@@ -14,6 +14,9 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #endif
+#if __APPLE__
+#  include "../../../dependencies/cpprestsdk_char_traits_workaround.hpp"
+#endif
 // Macro U from cpprestsdk is clashing with (cf boost https://github.com/microsoft/cpprestsdk/issues/1214)
 #define _TURN_OFF_PLATFORM_STRING
 #include <cpprest/http_client.h>


### PR DESCRIPTION
Pull request overview
---------------------

- These are **WORKAROUNDS** for #5398.
- I think a proper fix would be to bump the dependencies (and eliminate cpprestsdk while at it)

### Pull Request Author


 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
