### PR TITLE
Fixup Python Bindings workflow + add an ubuntu-22.04-arm runner

### DIFF
--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -287,16 +287,24 @@ jobs:
           if [ "${{ matrix.name }}" == "macOS_arm64" ]; then
             PYTHON_ARCH=arm64
             # Avoid "builtin __has_nothrow_assign is deprecated; use __is_nothrow_assignable instead" in boost/1.79 with recent clang
-            conan install . --output-folder=./build --build=missing -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release -o with_testing=False -o with_benchmark=False -c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION -Wno-enum-constexpr-conversion']"
+            conan install . --output-folder=./build --build=missing \
+              -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release \
+              -o with_testing=False -o with_benchmark=False -o with_ruby=False \
+              -c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION -Wno-enum-constexpr-conversion']"
           else
-            conan install . --output-folder=./build --build=missing -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release -o with_testing=False -o with_benchmark=False -c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']"
+            conan install . --output-folder=./build --build=missing \
+              -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release \
+              -o with_testing=False -o with_benchmark=False -o with_ruby=False \
+              -c tools.build:cxxflags="['-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']"
           fi
         else
           if [ "${{ matrix.name }}" == "Ubuntu_arm64" ]; then
             PYTHON_ARCH=arm64
           fi
           PYTHON_VERSION=${{ steps.setup-python.outputs.python-version }}
-          conan install . --output-folder=./build --build=missing -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release -o with_testing=False -o with_benchmark=False
+          conan install . --output-folder=./build --build=missing \
+            -c tools.cmake.cmaketoolchain:generator=Ninja -s compiler.cppstd=20 -s build_type=Release \
+            -o with_testing=False -o with_benchmark=False -o with_ruby=False
         fi
         echo -e "::endgroup::"
 
@@ -309,7 +317,15 @@ jobs:
         echo -e "::endgroup::"
 
         begin_group "Build"
-        cmake --build --preset conan-release
+        if [ "${{ matrix.name }}" == "Ubuntu_arm64" ]; then
+          echo "Ubuntu_arm64 is apparently running out of memory/CPU during the build as of 2025-06-18, so work around it"
+          N=$(nproc)
+          cmake --build --preset conan-release --target openstudiolib -j $N
+          cmake --build --preset conan-release --target python_sdk -j $(($N - 2))
+          cmake --build --preset conan-release -j $(($N - 2))
+        else
+          cmake --build --preset conan-release
+        fi
         echo -e "::endgroup::"
 
 


### PR DESCRIPTION
Pull request overview
---------------------

The python bindings were failing due to:
* macos-12 is fully removed
* Python 3.13 on windows was failing because it was using 3.13.4 which has an issue that tries to link to Python3.13t.lib even in non-threaded python
     * Explictly use 3.13.5 
     * cf https://github.com/python/cpython/issues/135151 

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
