### PR TITLE
Fix ChillerElectricEIR air cooled curves

### DIFF
--- a/src/model/ChillerElectricEIR.cpp
+++ b/src/model/ChillerElectricEIR.cpp
@@ -999,6 +999,16 @@ namespace model {
   ChillerElectricEIR::ChillerElectricEIR(const Model& model) : WaterToWaterComponent(ChillerElectricEIR::iddObjectType(), model) {
     OS_ASSERT(getImpl<detail::ChillerElectricEIR_Impl>());
 
+    // Both of the following test files have capft and eirft curves with the ctor values below:
+    // - DOAS_wNeutralSupplyAir_wFanCoilUnits.idf
+    // - WaterCooledChillerWithVSCondenserControl.idf
+    // But the curves are unused in the test files.
+
+    // The following test files have curve values shown in the E+ documentation:
+    // - ElectricEIRChiller.idf (WaterCooled)
+    // - ElectricEIRChillerHeatRecoveryAuto.idf (WaterCooled)
+    // - ElectricEIRChiller_EvapCooledCondenser.idf (EvaporativelyCooled)
+
     CurveBiquadratic ccFofT(model);
     ccFofT.setCoefficient1Constant(1.0215158);
     ccFofT.setCoefficient2x(0.037035864);

--- a/src/model/test/ChillerElectricEIR_GTest.cpp
+++ b/src/model/test/ChillerElectricEIR_GTest.cpp
@@ -1117,3 +1117,23 @@ TEST_F(ModelFixture, ChillerElectricEIR_HeatRecoverySetpointNode) {
   ASSERT_TRUE(chiller.heatRecoveryLeavingTemperatureSetpointNode());
   EXPECT_EQ(hrOutletNode, chiller.heatRecoveryLeavingTemperatureSetpointNode().get());
 }
+
+TEST_F(ModelFixture, ChillerElectricEIR_referenceConditionsCurveOutput) {
+
+  // Test for #2093, #2957
+  Model model;
+  ChillerElectricEIR chiller(model);
+
+  double ref_lchwt = chiller.referenceLeavingChilledWaterTemperature();
+  double ref_ecnwt = chiller.referenceEnteringCondenserFluidTemperature();
+
+  CurveBiquadratic capft = chiller.coolingCapacityFunctionOfTemperature();
+  CurveBiquadratic eirft = chiller.electricInputToCoolingOutputRatioFunctionOfTemperature();
+  CurveQuadratic eirfplr = chiller.electricInputToCoolingOutputRatioFunctionOfPLR();
+
+  EXPECT_DOUBLE_EQ(1.0, capft.evaluate(ref_lchwt, ref_ecnwt));  // 85F (water cooled)
+  EXPECT_DOUBLE_EQ(1.0, eirft.evaluate(ref_lchwt, ref_ecnwt));  // 85F (water cooled)
+  EXPECT_DOUBLE_EQ(1.0, capft.evaluate(ref_lchwt, 35.0));  // 95F (air cooled)
+  EXPECT_DOUBLE_EQ(1.0, eirft.evaluate(ref_lchwt, 35.0));  // 95F (air cooled)
+  EXPECT_DOUBLE_EQ(1.0, eirfplr.evaluate(1.0));
+}

--- a/src/model/test/ChillerElectricReformulatedEIR_GTest.cpp
+++ b/src/model/test/ChillerElectricReformulatedEIR_GTest.cpp
@@ -914,3 +914,21 @@ TEST_F(ModelFixture, ChillerElectricReformulatedEIR_PlantLoopConnections_addToNo
   ASSERT_TRUE(chiller.heatRecoveryLoop());
   EXPECT_EQ(hrLoop, chiller.heatRecoveryLoop().get());
 }
+
+TEST_F(ModelFixture, ChillerElectricReformulatedEIR_referenceConditionsCurveOutput) {
+
+  // Test for #2093, #2957
+  Model model;
+  ChillerElectricReformulatedEIR chiller(model);
+
+  double ref_lchwt = chiller.referenceLeavingChilledWaterTemperature();
+  double ref_lcnwt = chiller.referenceLeavingCondenserWaterTemperature();
+
+  CurveBiquadratic capft = chiller.coolingCapacityFunctionOfTemperature();
+  CurveBiquadratic eirft = chiller.electricInputToCoolingOutputRatioFunctionOfTemperature();
+  CurveBicubic eirfplr = chiller.electricInputToCoolingOutputRatioFunctionOfPLR();
+
+  EXPECT_DOUBLE_EQ(1.0, capft.evaluate(ref_lchwt, ref_lcnwt));
+  EXPECT_DOUBLE_EQ(1.0, eirft.evaluate(ref_lchwt, ref_lcnwt));
+  EXPECT_DOUBLE_EQ(1.0, eirfplr.evaluate(1.0));
+}


### PR DESCRIPTION
Pull request overview
---------------------

 - Fixes #2093 
 - Fixes #2957

See https://github.com/NREL/OpenStudio/issues/2093#issuecomment-3111032463.
Perhaps the default value for "Reference Entering Condenser Fluid Temperature" needs to be changed to 35C?

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
