### PR TITLE
Adjust autosized methods based on OS-resources autosize_hvac

### DIFF
--- a/src/model/CoilHeatingElectricMultiStageStageData.cpp
+++ b/src/model/CoilHeatingElectricMultiStageStageData.cpp
@@ -122,8 +122,7 @@ namespace model {
       auto [index, parentCoil] = indexAndNameOpt.get();
       const std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
 
-      // EPLUS-SQL-INCONSISTENCY
-      return parentCoil.getImpl<CoilHeatingElectricMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:ElectricMultiStage");
+      return parentCoil.getImpl<CoilHeatingElectricMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:Electric:MultiStage");
     }
 
     void CoilHeatingElectricMultiStageStageData_Impl::autosize() {

--- a/src/model/CoilHeatingGasMultiStageStageData.cpp
+++ b/src/model/CoilHeatingGasMultiStageStageData.cpp
@@ -132,8 +132,7 @@ namespace model {
       auto [index, parentCoil] = indexAndNameOpt.get();
       const std::string sqlField = "Design Size Stage " + std::to_string(index) + " Nominal Capacity";
 
-      // EPLUS-SQL-INCONSISTENCY
-      return parentCoil.getImpl<CoilHeatingGasMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:GasMultiStage");
+      return parentCoil.getImpl<CoilHeatingGasMultiStage_Impl>()->getAutosizedValue(sqlField, "W", "Coil:Heating:Gas:MultiStage");
     }
 
     void CoilHeatingGasMultiStageStageData_Impl::autosize() {

--- a/src/model/ThermalStorageChilledWaterStratified.cpp
+++ b/src/model/ThermalStorageChilledWaterStratified.cpp
@@ -734,7 +734,7 @@ namespace model {
     }
 
     boost::optional<double> ThermalStorageChilledWaterStratified_Impl::autosizedNominalCoolingCapacity() const {
-      return getAutosizedValue("Nominal Cooling Capacity", "W");
+      return getAutosizedValue("Maximum Heater Capacity", "W");
     }
 
     boost::optional<double> ThermalStorageChilledWaterStratified_Impl::autosizedUseSideDesignFlowRate() const {


### PR DESCRIPTION
Pull request overview
---------------------

Companion PR:
* https://github.com/NREL/OpenStudio-resources/pull/226

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
