### PR TITLE
Revised the label used in Windows Incremental Jenkins Builds

### DIFF
--- a/Jenkinsfile_develop_windows
+++ b/Jenkinsfile_develop_windows
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs') _
+@Library('cbci_shared_libs@windows-server-label') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {


### PR DESCRIPTION
The new label is simply 'windows-server'