### PR TITLE
Fix segfault in ruby bindings

### DIFF
--- a/ruby/bindings/CMakeLists.txt
+++ b/ruby/bindings/CMakeLists.txt
@@ -1,11 +1,16 @@
+find_package(antlr4-runtime REQUIRED CONFIG)
+
 add_library( rubybindings OBJECT
   InitRubyBindings.hpp
   InitRubyBindings.cpp
+  ModelicaAntlrCleanup.hpp
+  ModelicaAntlrCleanup.cpp
 )
 
 target_include_directories(rubybindings PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
+
 target_link_libraries(rubybindings PRIVATE ${ALL_RUBY_BINDING_TARGETS} rubyinterpreter-declarations)
 
 # wd4996=no deprecated warnings ; wd5033=register

--- a/ruby/bindings/InitRubyBindings.cpp
+++ b/ruby/bindings/InitRubyBindings.cpp
@@ -4,6 +4,7 @@
 ***********************************************************************************************************************/
 
 #include "InitRubyBindings.hpp"
+#include "ModelicaAntlrCleanup.hpp"
 #include "../interpreter/RubyEval.hpp"
 
 // #define HAVE_ISFINITE 1
@@ -130,6 +131,9 @@ namespace ruby {
     rb_provide("openstudiomodel");
     rb_provide("openstudiomodel.so");
     Init_openstudiomodelica();
+    // Ensure the ANTLR cleanup hook is armed as soon as the Modelica bindings are loaded so Ruby
+    // can unwind cleanly at interpreter shutdown without dlclose() crashes.
+    openstudio::ruby::registerModelicaAntlrCleanup();
     rb_provide("openstudiomodelica");
     rb_provide("openstudiomodelica.so");
     Init_openstudiomodelcore();

--- a/ruby/bindings/ModelicaAntlrCleanup.cpp
+++ b/ruby/bindings/ModelicaAntlrCleanup.cpp
@@ -1,0 +1,42 @@
+#include "ModelicaAntlrCleanup.hpp"
+
+#include <antlr4-runtime.h>
+#include <ruby.h>
+
+#include <memory>
+#include <mutex>
+
+namespace {
+
+using FactoryPtr = std::unique_ptr<antlr4::TokenFactory<antlr4::CommonToken>>;
+
+extern "C" void modelica_antlr_cleanup(VALUE) {
+  // This runs as part of Ruby's end_proc chain before the VM dlcloses openstudio.so. We explicitly
+  // release the singleton so ANTLR's own static destructor becomes a no-op; otherwise Ruby would
+  // run the destructor after parts of the interpreter are gone and we'd segfault while unloading.
+  auto* defaultFactory = const_cast<FactoryPtr*>(&antlr4::CommonTokenFactory::DEFAULT);
+  if (!defaultFactory) {
+    return;
+  }
+  auto* raw = defaultFactory->release();
+  if (raw != nullptr) {
+    delete raw;
+  }
+}
+
+}  // namespace
+
+namespace openstudio::ruby {
+
+void registerModelicaAntlrCleanup() {
+  // Ruby's Init_* entry points are called once per interpreter, so guard the end_proc registration
+  // with std::call_once to avoid stacking duplicate callbacks when Init_openstudiomodelica is
+  // invoked multiple times (eg. when tests reload the bindings). This static also satisfies the
+  // "just use a registrar" idea without running Ruby APIs during global constructors; rb_set_end_proc
+  // must execute while the VM is alive, so the call_once guard lives inside the Init path instead of
+  // at the translation-unit scope.
+  static std::once_flag registeredFlag;
+  std::call_once(registeredFlag, []() { rb_set_end_proc(modelica_antlr_cleanup, Qnil); });
+}
+
+}  // namespace openstudio::ruby

--- a/ruby/bindings/ModelicaAntlrCleanup.hpp
+++ b/ruby/bindings/ModelicaAntlrCleanup.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace openstudio::ruby {
+
+/**
+ * Register a Ruby end_proc hook that tears down ANTLR singletons safely when the interpreter exits.
+ *
+ * Why does this exist? Linking the Modelica parser into openstudio.so drags in ANTLR's global
+ * singletons (notably CommonTokenFactory::DEFAULT). Ruby unloads extensions with dlclose() and runs
+ * them through its GC at exit, so ANTLR's destructors fire while the interpreter is already winding
+ * down, which consistently segfaults. We cannot delete the singleton from a global static
+ * destructor either because every executable that links
+ * openstudio_modelica (gtests, CLI, etc.) would explode during __cxa_finalize() before Ruby was
+ * ever involved, and we cannot register Ruby callbacks from such a static because rb_set_end_proc
+ * must run after the VM boots.
+ *
+ * Instead, we register a Ruby end_proc callback once per interpreter that releases the singleton
+ * *only* when the Ruby VM shuts down. That keeps the workaround scoped to Ruby, preserves the
+ * default teardown order for other binaries, and mirrors Ruby's own extension lifecycle.
+ */
+void registerModelicaAntlrCleanup();
+
+}  // namespace openstudio::ruby


### PR DESCRIPTION
```
/**
 * Register a Ruby end_proc hook that tears down ANTLR singletons safely when the interpreter exits.
 *
 * Why does this exist? Linking the Modelica parser into openstudio.so drags in ANTLR's global
 * singletons (notably CommonTokenFactory::DEFAULT). Ruby unloads extensions with dlclose() and runs
 * them through its GC at exit, so ANTLR's destructors fire while the interpreter is already winding
 * down, which consistently segfaults. We cannot delete the singleton from a global static
 * destructor either because every executable that links
 * openstudio_modelica (gtests, CLI, etc.) would explode during __cxa_finalize() before Ruby was
 * ever involved, and we cannot register Ruby callbacks from such a static because rb_set_end_proc
 * must run after the VM boots.
 *
 * Instead, we register a Ruby end_proc callback once per interpreter that releases the singleton
 * *only* when the Ruby VM shuts down. That keeps the workaround scoped to Ruby, preserves the
 * default teardown order for other binaries, and mirrors Ruby's own extension lifecycle.
 */
```