### PR TITLE
Remove specific version reference for shared libraries in Jenkinsfile

### DIFF
--- a/Jenkinsfile_develop_osx
+++ b/Jenkinsfile_develop_osx
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs
 
-@Library('cbci_shared_libs@boost_compatibility') _
+@Library('cbci_shared_libs') _
 
 // Build for PR to develop branch only.
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) {


### PR DESCRIPTION
Eliminate the specific version reference for shared libraries in the Jenkinsfile to allow for more flexibility in library usage. This change simplifies the library declaration and avoids potential issues with version compatibility.

