### PR TITLE
Fix #5614: Handle UTF-8 BOM in EPW files

### DIFF
--- a/src/utilities/filetypes/EpwFile.cpp
+++ b/src/utilities/filetypes/EpwFile.cpp
@@ -15,8 +15,11 @@
 #include <fmt/format.h>
 #include <array>
 #include <cmath>
+#include <string_view>
 
 namespace openstudio {
+
+constexpr std::string_view UTF8_BOM{"\xEF\xBB\xBF", 3};
 
 static double psat(double T) {
   // Compute water vapor saturation pressure, eqns 5 and 6 from ASHRAE Fundamentals 2009 Ch. 1
@@ -4892,6 +4895,10 @@ bool EpwFile::parse(std::istream& ifs, bool storeData) {
     if (!std::getline(ifs, line)) {
       LOG(Error, "Could not read line " << i + 1 << " of EPW file '" << m_path << "'");
       return false;
+    }
+
+    if ((i == 0) && line.starts_with(UTF8_BOM)) {
+      line.erase(0, UTF8_BOM.size());
     }
 
     switch (i) {

--- a/src/utilities/filetypes/test/EpwFile_GTest.cpp
+++ b/src/utilities/filetypes/test/EpwFile_GTest.cpp
@@ -8,12 +8,18 @@
 #include "../../time/Time.hpp"
 #include "../../time/Date.hpp"
 #include "../../core/Checksum.hpp"
+#include "../../core/FilesystemHelpers.hpp"
 
 #include <resources.hxx>
 
 #include <array>
+#include <string_view>
 
 using namespace openstudio;
+
+namespace {
+constexpr std::string_view UTF8_BOM{"\xEF\xBB\xBF", 3};
+}
 
 TEST(Filetypes, EpwFile) {
   // LOCATION,Climate Zone 1,CA,USA,CTZRV2,725945,40.80,-124.20,-8.0,13.0
@@ -43,6 +49,16 @@ TEST(Filetypes, EpwFile) {
   EXPECT_EQ(Date(MonthOfYear::Jan, 1), epwFile.startDate());
   EXPECT_EQ(Date(MonthOfYear::Dec, 31), epwFile.endDate());
   EXPECT_FALSE(epwFile.isActual());
+}
+
+TEST(Filetypes, EpwFile_UTF8BOM) {
+  const path p = resourcesPath() / toPath("utilities/Filetypes/USA_CO_Golden-NREL.724666_TMY3.epw");
+  const std::string epwContent = std::string(UTF8_BOM) + openstudio::filesystem::read_as_string(p);
+
+  const boost::optional<EpwFile> epwFile = EpwFile::loadFromString(epwContent);
+
+  ASSERT_TRUE(epwFile);
+  EXPECT_EQ("Denver Centennial  Golden   Nr", epwFile->city());
 }
 
 TEST(Filetypes, EpwFile_Data) {


### PR DESCRIPTION
## Summary

- Fix #5614
- Strip a leading UTF-8 byte order mark before parsing an EPW `LOCATION` header.
- Add a regression test proving BOM-prefixed EPW content remains loadable.

## Root cause

`EpwFile::parse` passed the first line through unchanged, while `parseLocation` requires the first comma-delimited field to equal `LOCATION`. For UTF-8-with-BOM files, that field begins with the bytes `EF BB BF`, so a valid header was reported as missing its `LOCATION` specifier.

The fix only removes a UTF-8 BOM at the beginning of the first line. Existing validation remains unchanged, and this does not attempt to decode UTF-16 or UTF-32 files.

## User impact

EPW files saved as UTF-8 with BOM, including the file attached to #5614, can now be processed normally.

## Validation

- Added `Filetypes.EpwFile_UTF8BOM` and observed it fail before the implementation change and pass afterward.
- Ran all 25 `Filetypes.EpwFile*` tests successfully.
- Re-ran the original 2.5 MB EPW attachment from #5614 and confirmed the parsing failure no longer occurs.
- Ran `git diff --check` successfully.

Fixes #5614.
