### PR TITLE
Hotfix #5629 - read_as_string should open as binary

### DIFF
--- a/src/utilities/core/FilesystemHelpers.cpp
+++ b/src/utilities/core/FilesystemHelpers.cpp
@@ -35,7 +35,7 @@ namespace filesystem {
   }
 
   std::string read_as_string(const openstudio::path& t_path) {
-    openstudio::filesystem::ifstream f(t_path);
+    openstudio::filesystem::ifstream f(t_path, std::ios_base::binary);
     return read_as_string(f);
   }
 


### PR DESCRIPTION
Pull request overview
---------------------

- Hotfix #5629

Root cause: read_as_string(const openstudio::path& t_path) in src/utilities/core/FilesystemHelpers.cpp opened the file with openstudio::filesystem::ifstream f(t_path); — no std::ios_base::binary flag. On Windows this defaults to text mode, which translates \r\n → \n while reading.

The underlying read() helper computes file_len from tellg()/seekg() (the raw on-disk byte count) and then does a single t_file.read(&buf.front(), file_len). In text mode, the CRLF translation means fewer characters actually get read than the buffer was sized for, so the string gets truncated/corrupted with trailing garbage — silently, no error. This only manifests on Windows since POSIX has no text/binary distinction, which matches the "Windows and only Windows" symptom, and explains why parsing barreled all the way to line 8769 before choking on garbage.

The sibling function read(const path&) already correctly used std::ios_base::binary — the string-returning overload just missed it.

Fix: src/utilities/core/FilesystemHelpers.cpp:38 — added std::ios_base::binary to match.


### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
