### PR TITLE
[WIP] Follow-up to #5633: trim filesystem::read buffer to gcount() for text-mode streams

### DIFF
--- a/src/utilities/core/FilesystemHelpers.cpp
+++ b/src/utilities/core/FilesystemHelpers.cpp
@@ -20,7 +20,10 @@ namespace filesystem {
     const auto file_len = end_pos - cur_pos;
     t_file.seekg(cur_pos);
     std::vector<char> buf(file_len);
-    t_file.read(&buf.front(), file_len);
+    t_file.read(buf.data(), file_len);
+    // In text mode on Windows, CRLF->LF translation can make the number of characters read
+    // less than the on-disk length computed above; trim the unwritten zero-filled tail
+    buf.resize(static_cast<std::size_t>(t_file.gcount()));
     return buf;
   }
 


### PR DESCRIPTION
Pull request overview
---------------------

Follow-up hardening for #5629 / #5633 — this closes the remaining gap from the same root cause fixed in those PRs.

#5633 fixed `read_as_string(const path&)` by opening the file in binary mode. However, the underlying `read(openstudio::filesystem::ifstream&)` helper is still vulnerable when a **caller-supplied** stream was opened in text mode: it sizes the buffer from the on-disk byte count (`seekg`/`tellg`), but on Windows the text-mode CRLF→LF translation makes `istream::read()` deliver fewer characters than that, leaving a tail of zero-initialized (NUL) bytes in the returned buffer — silently.

There is at least one live path hitting this today: `PrjModelImpl.cpp:78` opens `ifstream file(path)` (text mode) and hands it to `contam::Reader` → `read_as_string(ifstream&)` → `read(ifstream&)`. On Windows, a CONTAM `.prj` file with CRLF line endings gets the same NUL-padded corruption that broke `Filetypes.EpwFile_UTF8BOM`.

Fix: after `read()`, trim the buffer to `gcount()` — the number of characters actually delivered. Binary-mode reads are unaffected (character count always equals the byte length), so this is a no-op on POSIX and for all existing binary callers.

Verified on Linux by rebuilding `openstudio_utilities_tests`: the full-suite failure list is byte-identical before/after the change (only pre-existing local environment failures), and all `Filetypes.EpwFile*` tests pass.

**Note:** I will follow up on this PR with the related documentation updates required for this project before it is ready for full review.

### Pull Request Author

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [x] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR
